### PR TITLE
INTERNAL: renovate preserve semver ranges and remove rate limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,9 +13,9 @@
 
     ":automergeDisabled",
     ":ignoreUnstable",
-    ":prConcurrentLimitNone",
-    ":prHourlyLimit4",
     ":maintainLockFilesWeekly",
+    ":prConcurrentLimitNone",
+    ":preserveSemverRanges",
     ":rebaseStalePrs",
     ":renovatePrefix",
     ":updateNotScheduled",
@@ -25,6 +25,7 @@
   "automerge": false,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "RENOVATE: ",
+
   "labels": ["dependencies"],
   "postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## Description

Reconfigures Renovate to not pin dependencies, as it's not something you would want for distributed packages. It's too restrictive for library consumers and it may cause way too much bloating and duplication in `node_modules` folder.

It also removes the hourly limit.