### PR TITLE
FIX: cjs loader pattern in package.json require

### DIFF
--- a/.changeset/empty-wombats-swim.md
+++ b/.changeset/empty-wombats-swim.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-core": patch
+---
+
+Package requires for cjs loader are broken in @adobe/aio-commerce-lib-core, this release fixes it

--- a/packages/aio-commerce-lib-core/package.json
+++ b/packages/aio-commerce-lib-core/package.json
@@ -38,8 +38,8 @@
           "default": "./dist/es/*/index.js"
         },
         "require": {
-          "types": "./dist/cjs/lib/*/index.d.cts",
-          "default": "./dist/cjs/lib/*/index.cjs"
+          "types": "./dist/cjs/*/index.d.cts",
+          "default": "./dist/cjs/*/index.cjs"
         }
       },
       "./package.json": "./package.json"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Package requires for cjs loader are broken in @adobe/aio-commerce-lib-core

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
