### PR TITLE
INTERNAL: fix labeler and announce to TS

### DIFF
--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -41,5 +41,7 @@
   - any-glob-to-any-file: '.changeset/**'
 
 "without-changeset":
-- changed-files:
-  - any-glob-to-any-file: '!.changeset/**'
+- all:
+  - changed-files:
+    - any-glob-to-any-file: '**/*'
+    - all-globs-to-all-files: '!.changeset/**'

--- a/.github/scripts/tsconfig.json
+++ b/.github/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["../../configs/typescript/tsconfig.base.json"],
+  "compilerOptions": {
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+
+  "include": ["**/*.ts"]
+}

--- a/.github/workflows/labeler-workflow.yml
+++ b/.github/workflows/labeler-workflow.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Label PR
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
-          configuration-path: .github/labeler.yml
+          configuration-path: .github/labeler-config.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,13 +53,15 @@ jobs:
         id: announcement
         if: steps.changesets.outputs.published == 'true'
         run: |
-          SLACK_WEBHOOK_PAYLOAD="$(node .github/scripts/announce.js '${{ steps.changesets.outputs.publishedPackages }}')"
+          # From Node v22.18.0, the node command is able to run .ts files directly (if it only needs type stripping).
+          # As of August 2025, Node v22.18.0 is already LTS (the version used by this workflow).
+          SLACK_WEBHOOK_PAYLOAD="$(node .github/scripts/announce.ts '${{ steps.changesets.outputs.publishedPackages }}')"
           echo "SLACK_WEBHOOK_PAYLOAD=$SLACK_WEBHOOK_PAYLOAD" >> "$GITHUB_OUTPUT"
 
       - name: Notify on Slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         if: steps.changesets.outputs.published == 'true'
         with:
-          webhook: ${{ secrets.TEST_SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: ${{ steps.announcement.outputs.SLACK_WEBHOOK_PAYLOAD }}


### PR DESCRIPTION
## Description

This PR addresses the following:

- Use TypeScript on the `announce` script as latest Node LTS supports it. The `tsconfig.json` added in the `.github/scripts` folder contains a configuration tailored to type-check script files in a way that Node supports it (with erasable syntax only, which is what it supports for now).

- Change the `TEST_SLACK_WEBHOOK_URL` to point to `SLACK_WEBHOOK_URL` which targets the appropriate Slack channel for release announcements.

- Fixes a bug with the labeler workflow where a PR ended up with both `with-changeset` and `without-changeset` labels at the same time, when these two are actually mutually exclusive.   