### PR TITLE
[1/3] CEXT-4993: create api utilities

### DIFF
--- a/packages-private/aio-commerce-lib-api/biome.jsonc
+++ b/packages-private/aio-commerce-lib-api/biome.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+
+  "root": false,
+  "extends": "//"
+}

--- a/packages-private/aio-commerce-lib-api/package.json
+++ b/packages-private/aio-commerce-lib-api/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@aio-commerce-sdk/aio-commerce-lib-api",
+  "type": "module",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=20 <=24"
+  },
+  "license": "Apache-2.0",
+  "description": "A set of utilities to build HTTP/API clients for I/O Events and Adobe Commerce",
+  "scripts": {
+    "build": "tsdown",
+    "docs": "typedoc && prettier --write '**/*.md'",
+    "assist": "biome check --formatter-enabled=false --linter-enabled=false --assist-enabled=true --no-errors-on-unmatched",
+    "assist:apply": "biome check --write --formatter-enabled=false --linter-enabled=false --assist-enabled=true --no-errors-on-unmatched",
+    "check:ci": "biome ci --formatter-enabled=true --linter-enabled=true --assist-enabled=true --no-errors-on-unmatched",
+    "format": "biome format --write --no-errors-on-unmatched",
+    "format:markdown": "prettier --no-error-on-unmatched-pattern --write '**/*.md' \"!**/{CODE_OF_CONDUCT.md,COPYRIGHT,LICENSE,SECURITY.md,CONTRIBUTING.md}\"",
+    "format:check": "biome format --no-errors-on-unmatched",
+    "lint": "biome lint --no-errors-on-unmatched",
+    "lint:fix": "biome lint --write --no-errors-on-unmatched",
+    "typecheck": "tsc --noEmit && echo '✅ No type errors found.'",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
+  },
+  "dependencies": {
+    "@adobe/aio-commerce-lib-auth": "^0.3.4",
+    "ky": "^1.9.0"
+  },
+  "devDependencies": {
+    "@aio-commerce-sdk/config-tsdown": "workspace:*",
+    "@aio-commerce-sdk/config-typedoc": "workspace:*",
+    "@aio-commerce-sdk/config-typescript": "workspace:*",
+    "@aio-commerce-sdk/config-vitest": "workspace:*"
+  },
+  "sideEffects": false
+}

--- a/packages-private/aio-commerce-lib-api/source/index.ts
+++ b/packages-private/aio-commerce-lib-api/source/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** biome-ignore-all lint/performance/noBarrelFile: This is the entrypoint of the package API */
+
+export { buildApiClient } from "./lib/api-client";
+export { buildCommerceHttpClient } from "./lib/commerce/http-client";
+export * from "./lib/commerce/types";
+export { buildIoEventsHttpClient } from "./lib/io-events/http-client";
+export * from "./lib/io-events/types";

--- a/packages-private/aio-commerce-lib-api/source/lib/api-client.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/api-client.ts
@@ -1,0 +1,45 @@
+import type { KyInstance } from "ky";
+
+/**
+ * Defines an API function. This is a function that takes an
+ * HTTP client and some arguments and returns a result.
+ */
+type ApiFunction<
+  TClient extends KyInstance,
+  TArgs extends unknown[],
+  TResult,
+> = (client: TClient, ...args: TArgs) => TResult;
+
+/**
+ * Defines an API client. This is a client that wraps an HTTP client and
+ * provides a set of functions that can be used to make requests to the API.
+ */
+type ApiClient<
+  TClient extends KyInstance,
+  T extends Record<string, ApiFunction<TClient, unknown[], unknown>>,
+> = {
+  [K in keyof T]: (
+    ...args: Parameters<T[K]> extends [unknown, ...infer Rest] ? Rest : never
+  ) => ReturnType<T[K]>;
+};
+
+/**
+ * Creates an API client for the given HTTP client and functions.
+ * @param client The HTTP client.
+ * @param fns The functions to wrap.
+ */
+export function buildApiClient<
+  TClient extends KyInstance,
+  // biome-ignore lint/suspicious/noExplicitAny: We can't know the type of the arguments here.
+  T extends Record<string, ApiFunction<TClient, any[], any>>,
+>(client: TClient, fns: T): ApiClient<TClient, T> {
+  const wrapped = {} as ApiClient<TClient, T>;
+
+  for (const key in fns) {
+    if (Object.hasOwn(fns, key)) {
+      wrapped[key] = (...args: unknown[]) => fns[key](client, ...args);
+    }
+  }
+
+  return wrapped;
+}

--- a/packages-private/aio-commerce-lib-api/source/lib/commerce/http-client.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/commerce/http-client.ts
@@ -1,0 +1,132 @@
+import ky from "ky";
+
+import {
+  buildImsAuthBeforeRequestHook,
+  buildIntegrationAuthBeforeRequestHook,
+  isAuthProvider,
+} from "~/utils/auth/hooks";
+import {
+  BASE_IMS_REQUIRED_SCOPES,
+  ensureImsScopes,
+} from "~/utils/auth/ims-scopes";
+import { optionallyExtendKy } from "~/utils/http/ky";
+
+import type { KyInstance } from "ky";
+import type {
+  CommerceHttpClient,
+  CommerceHttpClientConfig,
+  CommerceHttpClientParams,
+  PaaSClientParams,
+  SaaSClientParams,
+} from "./types";
+
+const COMMERCE_SAAS_IMS_REQUIRED_SCOPES = [
+  ...BASE_IMS_REQUIRED_SCOPES,
+  "commerce.accs",
+];
+
+/**
+ * Gets the Commerce URL for the given configuration and flavor.
+ * @param config The Commerce HTTP client configuration.
+ * @param fetchOptions The fetch options to use for the Commerce HTTP requests.
+ * @returns The Commerce URL.
+ */
+function getCommerceUrl(config: CommerceHttpClientConfig) {
+  const { baseUrl, storeViewCode = "all", version = "v1", flavor } = config;
+  const basePaths = {
+    paas: "/rest",
+    saas: "",
+  };
+
+  const basePath = `${basePaths[flavor]}/${storeViewCode}/${version?.toUpperCase()}`;
+  const commerceUrl = new URL(basePath, baseUrl);
+
+  return commerceUrl.toString();
+}
+
+/**
+ * Builds a Commerce HTTP client for PaaS.
+ * @param params The parameters for building the Commerce PaaS HTTP client.
+ */
+function buildCommerceHttpClientPaaS(params: PaaSClientParams) {
+  const { auth, config, fetchOptions } = params;
+  const commerceUrl = getCommerceUrl(config);
+  const beforeRequestAuthHook = buildIntegrationAuthBeforeRequestHook(auth);
+
+  const httpClient = ky.create({
+    prefixUrl: commerceUrl,
+    hooks: {
+      beforeRequest: [beforeRequestAuthHook],
+    },
+  });
+
+  return optionallyExtendKy(httpClient, fetchOptions);
+}
+
+/**
+ * Builds a Commerce HTTP client for SaaS.
+ * @param params The parameters for building the Commerce SaaS HTTP client.
+ */
+function buildCommerceHttpClientSaaS(params: SaaSClientParams) {
+  const { auth, config, fetchOptions } = params;
+  const commerceUrl = getCommerceUrl(config);
+
+  const beforeRequestAuthHook = isAuthProvider(auth)
+    ? buildImsAuthBeforeRequestHook(auth)
+    : buildImsAuthBeforeRequestHook(
+        ensureImsScopes(auth, COMMERCE_SAAS_IMS_REQUIRED_SCOPES),
+      );
+
+  const httpClient = ky.create({
+    prefixUrl: commerceUrl,
+    hooks: {
+      beforeRequest: [beforeRequestAuthHook],
+    },
+  });
+
+  return optionallyExtendKy(httpClient, fetchOptions);
+}
+
+/**
+ * Type guard to check if params are for PaaS
+ */
+function isPaaSParams(
+  params: CommerceHttpClientParams,
+): params is PaaSClientParams {
+  return params.config.flavor === "paas";
+}
+
+/**
+ * Type guard to check if params are for SaaS
+ */
+function isSaaSParams(
+  params: CommerceHttpClientParams,
+): params is SaaSClientParams {
+  return params.config.flavor === "saas";
+}
+
+/**
+ * Builds a Commerce HTTP client with proper authentication based on the flavor.
+ * @param params The parameters for building the Commerce HTTP client.
+ * @returns A configured Commerce HTTP client.
+ */
+export function buildCommerceHttpClient(
+  params: CommerceHttpClientParams,
+): CommerceHttpClient {
+  const flavor = params.config.flavor;
+  let commerceHttpClient: KyInstance;
+
+  if (isPaaSParams(params)) {
+    commerceHttpClient = buildCommerceHttpClientPaaS(params);
+  } else if (isSaaSParams(params)) {
+    commerceHttpClient = buildCommerceHttpClientSaaS(params);
+  } else {
+    throw new Error(
+      `Invalid Commerce configuration. Unknown flavor: ${flavor}`,
+    );
+  }
+
+  return Object.assign(commerceHttpClient, {
+    config: params.config,
+  });
+}

--- a/packages-private/aio-commerce-lib-api/source/lib/commerce/types.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/commerce/types.ts
@@ -1,0 +1,63 @@
+import type {
+  ImsAuthProvider,
+  IntegrationAuthParams,
+  IntegrationAuthProvider,
+} from "@adobe/aio-commerce-lib-auth";
+import type { KyInstance, Options } from "ky";
+import type { ImsAuthParamsWithOptionalScopes } from "~/utils/auth/ims-scopes";
+
+/** Defines the flavor of the Commerce instance. */
+export type CommerceFlavor = "paas" | "saas";
+
+/** Defines the configuration required to build an Adobe Commerce HTTP client. */
+export type CommerceHttpClientConfig = {
+  /** The base URL of the Commerce API. */
+  baseUrl: string;
+
+  /** Whether the target Commerce instance is a PaaS or SaaS. */
+  flavor: CommerceFlavor;
+
+  /**
+   * The store view code use to make requests to the Commerce API.
+   * @default "all"
+   */
+  storeViewCode?: string;
+
+  /**
+   * The version of the Commerce API to use. Currently only `v1` is supported.
+   * @default "v1"
+   */
+  version?: "v1";
+};
+
+/** Defines the configuration required to build an Adobe Commerce HTTP client for PaaS. */
+export type CommerceHttpClientConfigPaaS = CommerceHttpClientConfig & {
+  flavor: "paas";
+};
+
+/** Defines the configuration required to build an Adobe Commerce HTTP client for SaaS. */
+export type CommerceHttpClientConfigSaaS = CommerceHttpClientConfig & {
+  flavor: "saas";
+};
+
+// Type for SaaS configuration
+export type SaaSClientParams = {
+  auth: ImsAuthProvider | ImsAuthParamsWithOptionalScopes; // We provide default scopes.
+  config: CommerceHttpClientConfigSaaS;
+  fetchOptions?: Options;
+};
+
+// Type for PaaS configuration
+export type PaaSClientParams = {
+  auth: IntegrationAuthProvider | IntegrationAuthParams;
+  config: CommerceHttpClientConfigPaaS;
+  fetchOptions?: Options;
+};
+
+// Discriminated union of both types
+export type CommerceHttpClientParams = SaaSClientParams | PaaSClientParams;
+
+/** Defines a {@link KyInstance} which targets an Adobe Commerce instance. */
+export type CommerceHttpClient = KyInstance & {
+  config: CommerceHttpClientConfig;
+};

--- a/packages-private/aio-commerce-lib-api/source/lib/io-events/http-client.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/io-events/http-client.ts
@@ -1,0 +1,55 @@
+import ky from "ky";
+
+import {
+  buildImsAuthBeforeRequestHook,
+  isAuthProvider,
+} from "~/utils/auth/hooks";
+import {
+  BASE_IMS_REQUIRED_SCOPES,
+  ensureImsScopes,
+} from "~/utils/auth/ims-scopes";
+import { optionallyExtendKy } from "~/utils/http/ky";
+
+import type { IoEventsHttpClient, IoEventsHttpClientParams } from "./types";
+
+const IO_EVENTS_IMS_REQUIRED_SCOPES = [
+  ...BASE_IMS_REQUIRED_SCOPES,
+  "event_receiver_api",
+];
+
+/**
+ * Builds an HTTP client for the Adobe I/O Events API.
+ * @param imsAuth - The IMS authentication parameters.
+ * @param config - The configuration for the Adobe I/O HTTP client.
+ */
+export function buildIoEventsHttpClient(
+  params: IoEventsHttpClientParams,
+): IoEventsHttpClient {
+  const { auth, config, fetchOptions } = params;
+  const beforeRequestAuthHook = isAuthProvider(auth)
+    ? buildImsAuthBeforeRequestHook(auth)
+    : buildImsAuthBeforeRequestHook(
+        ensureImsScopes(auth, IO_EVENTS_IMS_REQUIRED_SCOPES),
+      );
+
+  const adobeIoBaseUrl =
+    config.environment === "stage"
+      ? "https://api-stage.adobe.io/events"
+      : "https://api.adobe.io/events";
+
+  const httpClient = ky.create({
+    prefixUrl: adobeIoBaseUrl,
+    headers: {
+      Accept: "application/hal+json",
+    },
+
+    hooks: {
+      beforeRequest: [beforeRequestAuthHook],
+    },
+  });
+
+  const extendedHttpClient = optionallyExtendKy(httpClient, fetchOptions);
+  return Object.assign(extendedHttpClient, {
+    config,
+  });
+}

--- a/packages-private/aio-commerce-lib-api/source/lib/io-events/types.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/io-events/types.ts
@@ -1,0 +1,29 @@
+import type { ImsAuthProvider } from "@adobe/aio-commerce-lib-auth";
+import type { KyInstance, Options } from "ky";
+import type { ImsAuthParamsWithOptionalScopes } from "~/utils/auth/ims-scopes";
+
+/** Defines the configuration required to build an Adobe I/O HTTP client. */
+export type IoEventsHttpClientConfig = {
+  /** The consumer organization ID to use for the Adobe I/O API. */
+  consumerOrgId: string;
+
+  /** The environment to use for the Adobe I/O API. */
+  environment?: "prod" | "stage";
+};
+
+/** Defines the parameters required to build an HTTP client for the Adobe I/O Events API. */
+export type IoEventsHttpClientParams = {
+  /** The IMS authentication parameters. */
+  auth: ImsAuthProvider | ImsAuthParamsWithOptionalScopes;
+
+  /** The configuration for the I/O Events HTTP client. */
+  config: IoEventsHttpClientConfig;
+
+  /** Additional fetch options to use for the I/O Events HTTP requests. */
+  fetchOptions?: Options;
+};
+
+/** Defines the HTTP client for the Adobe I/O Events API. */
+export type IoEventsHttpClient = KyInstance & {
+  config: IoEventsHttpClientConfig;
+};

--- a/packages-private/aio-commerce-lib-api/source/utils/auth/hooks.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/auth/hooks.ts
@@ -1,0 +1,70 @@
+import {
+  getImsAuthProvider,
+  getIntegrationAuthProvider,
+} from "@adobe/aio-commerce-lib-auth";
+
+import type {
+  ImsAuthParams,
+  ImsAuthProvider,
+  IntegrationAuthParams,
+  IntegrationAuthProvider,
+} from "@adobe/aio-commerce-lib-auth";
+import type { KyRequest } from "ky";
+import type { ImsAuthParamsWithOptionalScopes } from "~/utils/auth/ims-scopes";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/**
+ * Type guard to check if the given auth object is an auth provider.
+ * @param auth The auth object to check.
+ */
+export function isAuthProvider(
+  auth:
+    | ImsAuthParams
+    | ImsAuthProvider
+    | ImsAuthParamsWithOptionalScopes
+    | IntegrationAuthParams
+    | IntegrationAuthProvider,
+): auth is ImsAuthProvider | IntegrationAuthProvider {
+  return "getHeaders" in auth;
+}
+
+/**
+ * Builds a before request hook for integration authentication.
+ * @param integrationAuth The integration authentication parameters or integration auth provider.
+ */
+export function buildIntegrationAuthBeforeRequestHook(
+  integrationAuth: IntegrationAuthParams | IntegrationAuthProvider,
+) {
+  const integrationAuthProvider = isAuthProvider(integrationAuth)
+    ? integrationAuth
+    : getIntegrationAuthProvider(integrationAuth);
+
+  return (request: KyRequest) => {
+    const headers = integrationAuthProvider.getHeaders(
+      request.method.toUpperCase() as HttpMethod,
+      request.url,
+    );
+
+    request.headers.set("Authorization", headers.Authorization);
+  };
+}
+
+/**
+ * Builds a before request hook for IMS authentication.
+ * @param imsAuth The IMS authentication parameters or IMS auth provider.
+ */
+export function buildImsAuthBeforeRequestHook(
+  imsAuth: ImsAuthParams | ImsAuthProvider,
+) {
+  const imsAuthProvider = isAuthProvider(imsAuth)
+    ? imsAuth
+    : getImsAuthProvider(imsAuth);
+
+  return async (request: KyRequest) => {
+    const headers = await imsAuthProvider.getHeaders();
+
+    request.headers.set("Authorization", headers.Authorization);
+    request.headers.set("x-api-key", headers["x-api-key"]);
+  };
+}

--- a/packages-private/aio-commerce-lib-api/source/utils/auth/ims-scopes.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/auth/ims-scopes.ts
@@ -1,0 +1,32 @@
+import type { ImsAuthParams } from "@adobe/aio-commerce-lib-auth";
+import type { SetOptional } from "type-fest";
+
+/** Common IMS required scopes. */
+export const BASE_IMS_REQUIRED_SCOPES = [
+  "adobeio_api",
+  "openid",
+  "AdobeID",
+  "read_organizations",
+];
+
+/** Defines the IMS authentication parameters with optional scopes. */
+export type ImsAuthParamsWithOptionalScopes = SetOptional<
+  ImsAuthParams,
+  "scopes"
+>;
+
+/**
+ * Ensures the correct scopes are set for the given IMS authentication parameters.
+ * @param imsAuth - The IMS authentication parameters.
+ * @param requiredScopes - The required scopes.
+ */
+export function ensureImsScopes(
+  imsAuth: ImsAuthParamsWithOptionalScopes,
+  requiredScopes: string[],
+): ImsAuthParams {
+  const scopes = new Set([...(imsAuth.scopes ?? []), ...requiredScopes]);
+  return {
+    ...imsAuth,
+    scopes: Array.from(scopes),
+  };
+}

--- a/packages-private/aio-commerce-lib-api/source/utils/http/codes.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/http/codes.ts
@@ -1,0 +1,35 @@
+/**
+ * The HTTP status code for a successful request.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+ */
+export const HTTP_OK = 200;
+
+/**
+ * The HTTP status code for a bad request.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+ */
+export const HTTP_BAD_REQUEST = 400;
+
+/**
+ * The HTTP status code for an unauthorized request.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+ */
+export const HTTP_UNAUTHORIZED = 401;
+
+/**
+ * The HTTP status code for a forbidden request.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+ */
+export const HTTP_FORBIDDEN = 403;
+
+/**
+ * The HTTP status code for a not found request.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+ */
+export const HTTP_NOT_FOUND = 404;
+
+/**
+ * The HTTP status code for an internal server error.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+ */
+export const HTTP_INTERNAL_SERVER_ERROR = 500;

--- a/packages-private/aio-commerce-lib-api/source/utils/http/ky.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/http/ky.ts
@@ -1,0 +1,13 @@
+import type { KyInstance, Options } from "ky";
+
+/**
+ * Extends the given Ky instance with the provided options if they are provided.
+ * @param ky - The Ky instance to extend.
+ * @param options - The options to extend the Ky instance with.
+ */
+export function optionallyExtendKy<TKy extends KyInstance>(
+  ky: TKy,
+  options?: Options | ((parentOptions: Options) => Options),
+): TKy {
+  return options ? (ky.extend(options) as TKy) : ky;
+}

--- a/packages-private/aio-commerce-lib-api/tsconfig.json
+++ b/packages-private/aio-commerce-lib-api/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@aio-commerce-sdk/config-typescript/tsconfig.base.json"
+}

--- a/packages-private/aio-commerce-lib-api/tsdown.config.ts
+++ b/packages-private/aio-commerce-lib-api/tsdown.config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { baseConfig } from "@aio-commerce-sdk/config-tsdown/tsdown.config.base";
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  ...baseConfig,
+  entry: ["./source/index.ts"],
+});

--- a/packages-private/aio-commerce-lib-api/typedoc.json
+++ b/packages-private/aio-commerce-lib-api/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://typedoc-plugin-markdown.org/schema.json",
+  "extends": ["@aio-commerce-sdk/config-typedoc/typedoc.json"],
+
+  "entryPoints": ["./source/index.ts"],
+  "out": "docs/api-reference",
+
+  "validation": {
+    "notExported": false
+  }
+}

--- a/packages/aio-commerce-lib-events/README.md
+++ b/packages/aio-commerce-lib-events/README.md
@@ -1,0 +1,3 @@
+# `@adobe/aio-commerce-lib-events`
+
+Description for `@adobe/aio-commerce-lib-events`

--- a/packages/aio-commerce-lib-events/biome.jsonc
+++ b/packages/aio-commerce-lib-events/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "extends": "//"
+}

--- a/packages/aio-commerce-lib-events/package.json
+++ b/packages/aio-commerce-lib-events/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@adobe/aio-commerce-lib-events",
+  "type": "module",
+  "author": "Adobe Inc.",
+
+  "version": "1.0.0",
+  "private": false,
+  "engines": {
+    "node": ">=20 <=24"
+  },
+
+  "license": "Apache-2.0",
+  "description": "Description for @adobe/aio-commerce-lib-events",
+  "keywords": [],
+
+  "bugs": {
+    "url": "https://github.com/adobe/aio-commerce-sdk/issues"
+  },
+
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/aio-commerce-sdk.git",
+    "directory": "packages/aio-commerce-lib-events"
+  },
+
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/es/index.d.ts",
+        "default": "./dist/es/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+
+  "files": [
+    "dist",
+    "package.json",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+
+  "scripts": {
+    "build": "tsdown",
+    "docs": "typedoc && prettier --write '**/*.md'",
+    "assist": "biome check --formatter-enabled=false --linter-enabled=false --assist-enabled=true --no-errors-on-unmatched",
+    "assist:apply": "biome check --write --formatter-enabled=false --linter-enabled=false --assist-enabled=true --no-errors-on-unmatched",
+    "check:ci": "biome ci --formatter-enabled=true --linter-enabled=true --assist-enabled=true --no-errors-on-unmatched",
+    "format": "biome format --write --no-errors-on-unmatched",
+    "format:markdown": "prettier --no-error-on-unmatched-pattern --write '**/*.md' \"!**/{CODE_OF_CONDUCT.md,COPYRIGHT,LICENSE,SECURITY.md,CONTRIBUTING.md}\"",
+    "format:check": "biome format --no-errors-on-unmatched",
+    "lint": "biome lint --no-errors-on-unmatched",
+    "lint:fix": "biome lint --write --no-errors-on-unmatched",
+    "typecheck": "tsc --noEmit && echo '✅ No type errors found.'",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
+  },
+
+  "dependencies": {},
+  "devDependencies": {
+    "@aio-commerce-sdk/config-tsdown": "workspace:*",
+    "@aio-commerce-sdk/config-typedoc": "workspace:*",
+    "@aio-commerce-sdk/config-typescript": "workspace:*",
+    "@aio-commerce-sdk/config-vitest": "workspace:*"
+  },
+
+  "sideEffects": false
+}

--- a/packages/aio-commerce-lib-events/source/index.ts
+++ b/packages/aio-commerce-lib-events/source/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Export your package's public API here
+export {};

--- a/packages/aio-commerce-lib-events/test/index.test.ts
+++ b/packages/aio-commerce-lib-events/test/index.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("aio-commerce-lib-events", () => {
+  it("should work", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/aio-commerce-lib-events/tsconfig.json
+++ b/packages/aio-commerce-lib-events/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@aio-commerce-sdk/config-typescript/tsconfig.base.json"
+}

--- a/packages/aio-commerce-lib-events/tsdown.config.ts
+++ b/packages/aio-commerce-lib-events/tsdown.config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { baseConfig } from "@aio-commerce-sdk/config-tsdown/tsdown.config.base";
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  ...baseConfig,
+  entry: ["./source/index.ts"],
+});

--- a/packages/aio-commerce-lib-events/typedoc.json
+++ b/packages/aio-commerce-lib-events/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://typedoc-plugin-markdown.org/schema.json",
+  "extends": ["@aio-commerce-sdk/config-typedoc/typedoc.json"],
+
+  "entryPoints": ["./source/index.ts"],
+  "out": "docs/api-reference",
+
+  "validation": {
+    "notExported": false
+  }
+}

--- a/packages/aio-commerce-lib-events/vitest.config.ts
+++ b/packages/aio-commerce-lib-events/vitest.config.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { baseConfig } from "@aio-commerce-sdk/config-vitest/vitest.config";
+import { defineConfig, mergeConfig } from "vitest/config";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    // Write your Vitest configuration here.
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,21 @@ importers:
         specifier: workspace:*
         version: link:../../configs/vitest
 
+  packages/aio-commerce-lib-events:
+    devDependencies:
+      '@aio-commerce-sdk/config-tsdown':
+        specifier: workspace:*
+        version: link:../../configs/tsdown
+      '@aio-commerce-sdk/config-typedoc':
+        specifier: workspace:*
+        version: link:../../configs/typedoc
+      '@aio-commerce-sdk/config-typescript':
+        specifier: workspace:*
+        version: link:../../configs/typescript
+      '@aio-commerce-sdk/config-vitest':
+        specifier: workspace:*
+        version: link:../../configs/vitest
+
   packages/aio-commerce-sdk:
     dependencies:
       '@adobe/aio-commerce-lib-auth':
@@ -189,10 +204,12 @@ packages:
   '@adobe/aio-lib-core-networking@5.0.4':
     resolution: {integrity: sha512-LsFPKIXqfWiMwSjD9NJbb6uUSlZ+DZiV8p9NhpqPyzqAAl9NNONAH0jcIKtsKWSULcHc20INaRAw8dqKzQBTbw==}
     engines: {node: '>=18'}
+    bundledDependencies: []
 
   '@adobe/aio-lib-env@3.0.1':
     resolution: {integrity: sha512-UaLosV8jBowEA2ho4BNmWuHhrNCFbx26kJAr2SAIdEm4lZ/D8av8FUSMOEyAKJ/dfO2HCnLKMy77ie2AU7HI3g==}
     engines: {node: '>=18'}
+    bundledDependencies: []
 
   '@adobe/aio-lib-ims-jwt@5.0.2':
     resolution: {integrity: sha512-KaK+RB4FbfF5llYJueoOd9r6NeJp+d8pUE2QxqP6tpfr8NGt40Fw68XduQSTnPoOxKLn2piTD+IfaQ9a5teKHg==}

--- a/turbo/generators/create-package/index.ts
+++ b/turbo/generators/create-package/index.ts
@@ -51,7 +51,7 @@ function getPackageData(options: WizardOptions) {
     : `@adobe/${name}`;
 
   const packageDir = isPrivate
-    ? `packages/internal/${name}`
+    ? `packages-private/${name}`
     : `packages/${name}`;
 
   return {
@@ -114,9 +114,9 @@ async function createPackageWizard() {
 
 /** Returns the template files to be used for the package. */
 function getTemplateFiles({ willContainTests }: PackageData) {
-  // This test files are excluded conditionally based on the answers.
   const templateFiles = ["create-package/template/**/*.hbs"];
 
+  // This test files are excluded conditionally based on the answers.
   if (!willContainTests) {
     templateFiles.push("!create-package/template/vitest.config.ts.hbs");
     templateFiles.push("!create-package/template/test/*.hbs");

--- a/turbo/generators/create-package/template/biome.jsonc.hbs
+++ b/turbo/generators/create-package/template/biome.jsonc.hbs
@@ -1,4 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+
+  "root": false,
   "extends": "//"
 }


### PR DESCRIPTION
## Description

> [!NOTE]
> Ignore the changes in the `turbo` folder, they are related to private packages generator which I tweaked to generate this private package.

This PR contains utilities for working with the Commerce and I/O Events APIs. This will be used in follow-up PRs for the implementation of the events library. 