### PR TITLE
[2.5/3] CEXT-4993: Polish `aio-commerce-lib-events`

### DIFF
--- a/.changeset/calm-cameras-taste.md
+++ b/.changeset/calm-cameras-taste.md
@@ -1,0 +1,7 @@
+---
+"@adobe/aio-commerce-lib-events": minor
+---
+
+- Introduce return types for API operations
+- Fixes some validation pipelines and wrongful API payloads.
+- Transform API responses to camel case.

--- a/.changeset/sour-candles-obey.md
+++ b/.changeset/sour-candles-obey.md
@@ -1,0 +1,6 @@
+---
+"@aio-commerce-sdk/aio-commerce-lib-api": minor
+---
+
+- Introduce transformation hooks and utils.
+- Ensure config is required on HTTP client creation.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,7 +53,7 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # For PRs, compare the feature branch against the target branch
             export TURBO_SCM_BASE=origin/${{ github.base_ref }}
-            export TURBO_SCM_HEAD=${{ github.sha }}
+            export TURBO_SCM_HEAD=${{ github.event.pull_request.head.sha }}
             echo "Comparing $TURBO_SCM_HEAD against $TURBO_SCM_BASE"
           else
             # For pushes to main, compare against the previous commit

--- a/configs/tsdown/tsdown.config.base.ts
+++ b/configs/tsdown/tsdown.config.base.ts
@@ -52,6 +52,7 @@ export const baseConfig: UserConfig = {
   nodeProtocol: "strip",
   minify: {
     compress: true,
+    mangle: false,
   },
 
   dts: true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "prepare": "husky",
-    "turbo:clean-cache": "rimraf ./**/.turbo/",
     "turbo": "turbo",
     "assist": "turbo run assist",
     "assist:apply": "turbo run assist:apply",
@@ -20,7 +19,11 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "test": "turbo test",
-    "typecheck": "turbo typecheck"
+    "typecheck": "turbo typecheck",
+    "clean:turbo": "pnpx rimraf './**/.turbo' --glob",
+    "clean:modules": "pnpx rimraf './**/node_modules' --glob",
+    "clean:dist": "pnpx rimraf './**/dist' --glob",
+    "clean:all": "pnpm clean:turbo && pnpm clean:dist && pnpm clean:modules"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",
@@ -32,7 +35,6 @@
     "@vitest/ui": "^3.2.4",
     "husky": "^9.1.7",
     "prettier": "^3.6.2",
-    "rimraf": "^6.0.1",
     "tsdown": "^0.14.0",
     "turbo": "^2.5.4",
     "type-fest": "^4.41.0",

--- a/packages-private/aio-commerce-lib-api/package.json
+++ b/packages-private/aio-commerce-lib-api/package.json
@@ -8,27 +8,34 @@
   },
   "license": "Apache-2.0",
   "description": "A set of utilities to build HTTP/API clients for I/O Events and Adobe Commerce",
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/es/index.d.ts",
+          "default": "./dist/es/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/index.d.cts",
+          "default": "./dist/cjs/index.cjs"
+        }
+      },
+      "./utils/*": {
+        "import": {
+          "types": "./dist/es/utils/*/index.d.ts",
+          "default": "./dist/es/utils/*/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/utils/*/index.d.cts",
+          "default": "./dist/cjs/utils/*/index.cjs"
+        }
+      },
+      "./package.json": "./package.json"
+    }
+  },
   "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/es/index.d.ts",
-        "default": "./dist/es/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
-      }
-    },
-    "./utils/*": {
-      "import": {
-        "types": "./dist/es/utils/*/index.d.ts",
-        "default": "./dist/es/utils/*/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/utils/*/index.d.cts",
-        "default": "./dist/cjs/utils/*/index.cjs"
-      }
-    },
+    ".": "./source/index.ts",
+    "./utils/*": "./source/utils/*/index.ts",
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages-private/aio-commerce-lib-api/package.json
+++ b/packages-private/aio-commerce-lib-api/package.json
@@ -20,11 +20,22 @@
           "default": "./dist/cjs/index.cjs"
         }
       },
+      "./utils/*": {
+        "import": {
+          "types": "./dist/es/utils/*/index.d.ts",
+          "default": "./dist/es/utils/*/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/utils/*/index.d.cts",
+          "default": "./dist/cjs/utils/*/index.cjs"
+        }
+      },
       "./package.json": "./package.json"
     }
   },
   "exports": {
     ".": "./source/index.ts",
+    "./utils/*": "./source/utils/*/index.ts",
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages-private/aio-commerce-lib-api/package.json
+++ b/packages-private/aio-commerce-lib-api/package.json
@@ -56,7 +56,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@adobe/aio-commerce-lib-auth": "^0.3.4",
+    "@adobe/aio-commerce-lib-auth": "workspace:*",
     "camelcase": "^8.0.0",
     "ky": "^1.9.0"
   },

--- a/packages-private/aio-commerce-lib-api/package.json
+++ b/packages-private/aio-commerce-lib-api/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@adobe/aio-commerce-lib-auth": "^0.3.4",
+    "camelcase": "^8.0.0",
     "ky": "^1.9.0"
   },
   "devDependencies": {

--- a/packages-private/aio-commerce-lib-api/package.json
+++ b/packages-private/aio-commerce-lib-api/package.json
@@ -8,34 +8,27 @@
   },
   "license": "Apache-2.0",
   "description": "A set of utilities to build HTTP/API clients for I/O Events and Adobe Commerce",
-  "publishConfig": {
-    "exports": {
-      ".": {
-        "import": {
-          "types": "./dist/es/index.d.ts",
-          "default": "./dist/es/index.js"
-        },
-        "require": {
-          "types": "./dist/cjs/index.d.cts",
-          "default": "./dist/cjs/index.cjs"
-        }
-      },
-      "./utils/*": {
-        "import": {
-          "types": "./dist/es/utils/*/index.d.ts",
-          "default": "./dist/es/utils/*/index.js"
-        },
-        "require": {
-          "types": "./dist/cjs/utils/*/index.d.cts",
-          "default": "./dist/cjs/utils/*/index.cjs"
-        }
-      },
-      "./package.json": "./package.json"
-    }
-  },
   "exports": {
-    ".": "./source/index.ts",
-    "./utils/*": "./source/utils/*/index.ts",
+    ".": {
+      "import": {
+        "types": "./dist/es/index.d.ts",
+        "default": "./dist/es/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    },
+    "./utils/*": {
+      "import": {
+        "types": "./dist/es/utils/*/index.d.ts",
+        "default": "./dist/es/utils/*/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/utils/*/index.d.cts",
+        "default": "./dist/cjs/utils/*/index.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages-private/aio-commerce-lib-api/source/lib/commerce/helpers.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/commerce/helpers.ts
@@ -21,15 +21,8 @@ import type {
 } from "./types";
 
 const COMMERCE_SAAS_IMS_REQUIRED_SCOPES = [
-  "adobeio_api",
-  "read_organizations",
-  "profile",
-  "email",
-  "additional_info.projectedProductContext",
-  "AdobeID",
   "openid",
-  "org.read",
-  "additional_info.roles",
+  "additional_info.projectedProductContext",
   "commerce.accs",
 ];
 

--- a/packages-private/aio-commerce-lib-api/source/lib/commerce/helpers.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/commerce/helpers.ts
@@ -5,37 +5,40 @@ import {
   buildIntegrationAuthBeforeRequestHook,
   isAuthProvider,
 } from "#utils/auth/hooks";
-import {
-  BASE_IMS_REQUIRED_SCOPES,
-  ensureImsScopes,
-} from "#utils/auth/ims-scopes";
+import { ensureImsScopes } from "#utils/auth/ims-scopes";
 import { optionallyExtendKy } from "#utils/http/ky";
 
 import type {
-  CommerceHttpClientConfig,
+  CommerceHttpClientParamsWithRequiredConfig,
+  PaaSClientParamsWithRequiredConfig,
+  RequiredComerceHttpClientConfig,
+  SaaSClientParamsWithRequiredConfig,
+} from "./http-client";
+import type {
   CommerceHttpClientParams,
   PaaSClientParams,
   SaaSClientParams,
 } from "./types";
 
 const COMMERCE_SAAS_IMS_REQUIRED_SCOPES = [
-  ...BASE_IMS_REQUIRED_SCOPES,
+  "adobeio_api",
+  "read_organizations",
+  "profile",
+  "email",
+  "additional_info.projectedProductContext",
+  "AdobeID",
+  "openid",
+  "org.read",
+  "additional_info.roles",
   "commerce.accs",
 ];
-
-const DEFAULT_STORE_VIEW_CODE = "all";
-const DEFAULT_API_VERSION = "V1";
 
 /**
  * Gets the Commerce URL for the given configuration and flavor.
  * @param config The Commerce HTTP client configuration.
  */
-function getCommerceUrl(config: CommerceHttpClientConfig) {
-  const {
-    baseUrl,
-    storeViewCode = DEFAULT_STORE_VIEW_CODE,
-    version = DEFAULT_API_VERSION,
-  } = config;
+function getCommerceUrl(config: RequiredComerceHttpClientConfig) {
+  const { baseUrl, storeViewCode, version } = config;
 
   const commerceUrl = new URL(baseUrl);
   const uppercasedVersion = version?.toUpperCase();
@@ -53,7 +56,9 @@ function getCommerceUrl(config: CommerceHttpClientConfig) {
  * Builds a Commerce HTTP client for PaaS.
  * @param params The parameters for building the Commerce PaaS HTTP client.
  */
-function buildCommerceHttpClientPaaS(params: PaaSClientParams) {
+function buildCommerceHttpClientPaaS(
+  params: PaaSClientParamsWithRequiredConfig,
+) {
   const { auth, config, fetchOptions } = params;
   const commerceUrl = getCommerceUrl(config);
   const beforeRequestAuthHook = buildIntegrationAuthBeforeRequestHook(auth);
@@ -72,7 +77,9 @@ function buildCommerceHttpClientPaaS(params: PaaSClientParams) {
  * Builds a Commerce HTTP client for SaaS.
  * @param params The parameters for building the Commerce SaaS HTTP client.
  */
-function buildCommerceHttpClientSaaS(params: SaaSClientParams) {
+function buildCommerceHttpClientSaaS(
+  params: SaaSClientParamsWithRequiredConfig,
+) {
   const { auth, config, fetchOptions } = params;
   const commerceUrl = getCommerceUrl(config);
 
@@ -88,10 +95,7 @@ function buildCommerceHttpClientSaaS(params: SaaSClientParams) {
       beforeRequest: [
         beforeRequestAuthHook,
         (request) => {
-          request.headers.set(
-            "Store",
-            config.storeViewCode ?? DEFAULT_STORE_VIEW_CODE,
-          );
+          request.headers.set("Store", config.storeViewCode);
         },
       ],
     },
@@ -122,7 +126,9 @@ function isSaaSParams(
  * Builds the Commerce HTTP client for the given parameters.
  * @param params The configuration, authentication and fetch options parameters.
  */
-export function buildCommerceHttpClient(params: CommerceHttpClientParams) {
+export function buildCommerceHttpClient(
+  params: CommerceHttpClientParamsWithRequiredConfig,
+) {
   const flavor = params.config.flavor;
 
   if (isPaaSParams(params)) {

--- a/packages-private/aio-commerce-lib-api/source/lib/commerce/http-client.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/commerce/http-client.ts
@@ -1,22 +1,58 @@
 import { HttpClientBase } from "../http-client-base";
 import { buildCommerceHttpClient } from "./helpers";
 
+import type { RequiredDeep } from "type-fest";
 import type {
   CommerceHttpClientConfig,
+  CommerceHttpClientConfigPaaS,
+  CommerceHttpClientConfigSaaS,
   CommerceHttpClientParams,
+  PaaSClientParams,
+  SaaSClientParams,
 } from "./types";
+
+const DEFAULT_STORE_VIEW_CODE = "all";
+const DEFAULT_API_VERSION = "V1";
+
+export type RequiredComerceHttpClientConfig =
+  RequiredDeep<CommerceHttpClientConfig>;
+
+export type PaaSClientParamsWithRequiredConfig = PaaSClientParams & {
+  config: RequiredDeep<CommerceHttpClientConfigPaaS> & { flavor: "paas" };
+};
+
+export type SaaSClientParamsWithRequiredConfig = SaaSClientParams & {
+  config: RequiredDeep<CommerceHttpClientConfigSaaS> & { flavor: "saas" };
+};
+
+export type CommerceHttpClientParamsWithRequiredConfig =
+  | PaaSClientParamsWithRequiredConfig
+  | SaaSClientParamsWithRequiredConfig;
 
 /**
  * A Ky-based HTTP client used to make requests to the Commerce API.
  * @see https://github.com/sindresorhus/ky
  */
-export class AdobeCommerceHttpClient extends HttpClientBase<CommerceHttpClientConfig> {
+export class AdobeCommerceHttpClient extends HttpClientBase<RequiredComerceHttpClientConfig> {
   /**
    * Creates a new Commerce HTTP client instance.
    * @param params The parameters for building the Commerce HTTP client.
    */
   public constructor(params: CommerceHttpClientParams) {
-    const httpClient = buildCommerceHttpClient(params);
-    super(params.config, httpClient);
+    // A deep-required version of the config to ensure all default values are set. */
+    const config: RequiredComerceHttpClientConfig = {
+      ...params.config,
+
+      storeViewCode: params.config.storeViewCode ?? DEFAULT_STORE_VIEW_CODE,
+      version: params.config.version ?? DEFAULT_API_VERSION,
+    };
+
+    const requiredParams = {
+      ...params,
+      config,
+    } as CommerceHttpClientParamsWithRequiredConfig;
+
+    const httpClient = buildCommerceHttpClient(requiredParams);
+    super(config, httpClient);
   }
 }

--- a/packages-private/aio-commerce-lib-api/source/lib/io-events/helpers.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/io-events/helpers.ts
@@ -9,9 +9,7 @@ import { optionallyExtendKy } from "#utils/http/ky";
 
 import type { IoEventsHttpClientParamsWithRequiredConfig } from "./http-client";
 
-const IO_EVENTS_IMS_REQUIRED_SCOPES = [
-  "openid, AdobeID, event_receiver_api, read_organizations",
-];
+const IO_EVENTS_IMS_REQUIRED_SCOPES = ["adobeio_api"];
 
 /**
  * Builds the Adobe I/O Events HTTP client for the given parameters.

--- a/packages-private/aio-commerce-lib-api/source/lib/io-events/helpers.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/io-events/helpers.ts
@@ -4,25 +4,22 @@ import {
   buildImsAuthBeforeRequestHook,
   isAuthProvider,
 } from "#utils/auth/hooks";
-import {
-  BASE_IMS_REQUIRED_SCOPES,
-  ensureImsScopes,
-} from "#utils/auth/ims-scopes";
+import { ensureImsScopes } from "#utils/auth/ims-scopes";
 import { optionallyExtendKy } from "#utils/http/ky";
 
-import type { IoEventsHttpClientParams } from "./types";
+import type { IoEventsHttpClientParamsWithRequiredConfig } from "./http-client";
 
-const DEFAULT_IO_EVENTS_BASE_URL = "https://api.adobe.io/events";
 const IO_EVENTS_IMS_REQUIRED_SCOPES = [
-  ...BASE_IMS_REQUIRED_SCOPES,
-  "event_receiver_api",
+  "openid, AdobeID, event_receiver_api, read_organizations",
 ];
 
 /**
  * Builds the Adobe I/O Events HTTP client for the given parameters.
  * @param params The configuration, authentication and fetch options parameters.
  */
-export function buildIoEventsHttpClient(params: IoEventsHttpClientParams) {
+export function buildIoEventsHttpClient(
+  params: IoEventsHttpClientParamsWithRequiredConfig,
+) {
   const { auth, config, fetchOptions } = params;
   const beforeRequestAuthHook = isAuthProvider(auth)
     ? buildImsAuthBeforeRequestHook(auth)
@@ -30,7 +27,7 @@ export function buildIoEventsHttpClient(params: IoEventsHttpClientParams) {
         ensureImsScopes(auth, IO_EVENTS_IMS_REQUIRED_SCOPES),
       );
 
-  const adobeIoBaseUrl = config.baseUrl ?? DEFAULT_IO_EVENTS_BASE_URL;
+  const adobeIoBaseUrl = config.baseUrl;
   const httpClient = ky.create({
     prefixUrl: adobeIoBaseUrl,
     headers: {

--- a/packages-private/aio-commerce-lib-api/source/lib/io-events/http-client.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/io-events/http-client.ts
@@ -1,22 +1,39 @@
 import { HttpClientBase } from "../http-client-base";
 import { buildIoEventsHttpClient } from "./helpers";
 
+import type { RequiredDeep } from "type-fest";
 import type {
   IoEventsHttpClientConfig,
   IoEventsHttpClientParams,
 } from "./types";
 
+const DEFAULT_IO_EVENTS_BASE_URL = "https://api.adobe.io/events";
+
+export type RequiredIoEventsHttpClientConfig =
+  RequiredDeep<IoEventsHttpClientConfig>;
+
+export type IoEventsHttpClientParamsWithRequiredConfig =
+  IoEventsHttpClientParams & {
+    config: RequiredIoEventsHttpClientConfig;
+  };
+
 /**
  * A Ky-based HTTP client used to make requests to the Adobe I/O Events API.
  * @see https://github.com/sindresorhus/ky
  */
-export class AdobeIoEventsHttpClient extends HttpClientBase<IoEventsHttpClientConfig> {
+export class AdobeIoEventsHttpClient extends HttpClientBase<RequiredIoEventsHttpClientConfig> {
   /**
    * Creates a new Adobe I/O Events HTTP client instance.
    * @param params The parameters for building the Adobe I/O Events HTTP client.
    */
   public constructor(params: IoEventsHttpClientParams) {
-    const httpClient = buildIoEventsHttpClient(params);
-    super(params.config, httpClient);
+    // A deep-required version of the config to ensure all default values are set. */
+    const config: RequiredIoEventsHttpClientConfig = {
+      ...params.config,
+      baseUrl: params.config?.baseUrl ?? DEFAULT_IO_EVENTS_BASE_URL,
+    };
+
+    const httpClient = buildIoEventsHttpClient({ ...params, config });
+    super(config, httpClient);
   }
 }

--- a/packages-private/aio-commerce-lib-api/source/lib/io-events/types.ts
+++ b/packages-private/aio-commerce-lib-api/source/lib/io-events/types.ts
@@ -17,7 +17,9 @@ export type IoEventsHttpClientParams = {
   auth: ImsAuthProvider | ImsAuthParamsWithOptionalScopes;
 
   /** The configuration for the I/O Events HTTP client. */
-  config: IoEventsHttpClientConfig;
+  // Optional because all config values are optional. If ever more are added,
+  // the optionality should be re-evaluated (would imply breaking changes).
+  config?: IoEventsHttpClientConfig;
 
   /** Additional fetch options to use for the I/O Events HTTP requests. */
   fetchOptions?: Options;

--- a/packages-private/aio-commerce-lib-api/source/utils/auth/ims-scopes.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/auth/ims-scopes.ts
@@ -1,14 +1,6 @@
 import type { ImsAuthParams } from "@adobe/aio-commerce-lib-auth";
 import type { SetOptional } from "type-fest";
 
-/** Common IMS required scopes. */
-export const BASE_IMS_REQUIRED_SCOPES = [
-  "adobeio_api",
-  "openid",
-  "AdobeID",
-  "read_organizations",
-];
-
 /** Defines the IMS authentication parameters with optional scopes. */
 export type ImsAuthParamsWithOptionalScopes = SetOptional<
   ImsAuthParams,

--- a/packages-private/aio-commerce-lib-api/source/utils/http/index.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/http/index.ts
@@ -1,0 +1,3 @@
+/** biome-ignore-all lint/performance/noBarrelFile: This is the public API for the utils/http entrypoint */
+
+export * from "./codes";

--- a/packages-private/aio-commerce-lib-api/source/utils/transformations/hooks.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/transformations/hooks.ts
@@ -1,0 +1,38 @@
+import type { AfterResponseHook, KyResponse } from "ky";
+
+/**
+ * Builds a hook that transforms the keys of an object using the provided transformer function.
+ * @param transformer - The function to transform the keys of the object.
+ * @param recursive - Whether to transform the keys of the object recursively.
+ */
+export function buildObjectKeyTransformerResponseHook(
+  transformer: (key: string) => string,
+  recursive = true,
+): AfterResponseHook {
+  const transformObject = (obj: unknown): unknown => {
+    if (typeof obj !== "object" || obj === null) {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      return recursive ? obj.map(transformObject) : obj;
+    }
+
+    const transformedData = Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => {
+        const transformedKey = transformer(key);
+        const transformedValue = recursive ? transformObject(value) : value;
+        return [transformedKey, transformedValue];
+      }),
+    );
+
+    return transformedData;
+  };
+
+  return (_req, _opt, response: KyResponse) => {
+    return response.json().then((data) => {
+      const transformedData = transformObject(data);
+      return new Response(JSON.stringify(transformedData), response);
+    });
+  };
+}

--- a/packages-private/aio-commerce-lib-api/source/utils/transformations/hooks.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/transformations/hooks.ts
@@ -1,3 +1,5 @@
+import camelcase from "camelcase";
+
 import type { AfterResponseHook, KyResponse } from "ky";
 
 /**
@@ -35,4 +37,9 @@ export function buildObjectKeyTransformerResponseHook(
       return new Response(JSON.stringify(transformedData), response);
     });
   };
+}
+
+/** Builds a hook that transforms the keys of an object to camel case. */
+export function buildCamelCaseKeysResponseHook(): AfterResponseHook {
+  return buildObjectKeyTransformerResponseHook(camelcase);
 }

--- a/packages-private/aio-commerce-lib-api/source/utils/transformations/index.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/transformations/index.ts
@@ -1,0 +1,3 @@
+/** biome-ignore-all lint/performance/noBarrelFile: This is the public API for the utils/transformations entrypoint */
+
+export { buildObjectKeyTransformerResponseHook } from "./hooks";

--- a/packages-private/aio-commerce-lib-api/source/utils/transformations/index.ts
+++ b/packages-private/aio-commerce-lib-api/source/utils/transformations/index.ts
@@ -1,3 +1,6 @@
 /** biome-ignore-all lint/performance/noBarrelFile: This is the public API for the utils/transformations entrypoint */
 
-export { buildObjectKeyTransformerResponseHook } from "./hooks";
+export {
+  buildCamelCaseKeysResponseHook,
+  buildObjectKeyTransformerResponseHook,
+} from "./hooks";

--- a/packages-private/aio-commerce-lib-api/tsdown.config.ts
+++ b/packages-private/aio-commerce-lib-api/tsdown.config.ts
@@ -15,5 +15,9 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   ...baseConfig,
-  entry: ["./source/index.ts"],
+  entry: [
+    "./source/index.ts",
+    "./source/utils/http/index.ts",
+    "./source/utils/transformations/index.ts",
+  ],
 });

--- a/packages/aio-commerce-lib-events/package.json
+++ b/packages/aio-commerce-lib-events/package.json
@@ -53,8 +53,8 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@adobe/aio-commerce-lib-auth": "^0.3.4",
-    "@adobe/aio-commerce-lib-core": "^0.4.1",
+    "@adobe/aio-commerce-lib-auth": "workspace:*",
+    "@adobe/aio-commerce-lib-core": "workspace:*",
     "@aio-commerce-sdk/aio-commerce-lib-api": "workspace:*",
     "ky": "^1.9.0",
     "valibot": "^1.1.0"

--- a/packages/aio-commerce-lib-events/package.json
+++ b/packages/aio-commerce-lib-events/package.json
@@ -65,11 +65,11 @@
   "dependencies": {
     "@adobe/aio-commerce-lib-auth": "workspace:*",
     "@adobe/aio-commerce-lib-core": "workspace:*",
-    "@aio-commerce-sdk/aio-commerce-lib-api": "workspace:*",
     "ky": "^1.9.0",
     "valibot": "^1.1.0"
   },
   "devDependencies": {
+    "@aio-commerce-sdk/aio-commerce-lib-api": "workspace:*",
     "@aio-commerce-sdk/config-tsdown": "workspace:*",
     "@aio-commerce-sdk/config-typedoc": "workspace:*",
     "@aio-commerce-sdk/config-typescript": "workspace:*",

--- a/packages/aio-commerce-lib-events/package.json
+++ b/packages/aio-commerce-lib-events/package.json
@@ -8,7 +8,7 @@
     "node": ">=20 <=24"
   },
   "license": "Apache-2.0",
-  "description": "Description for @adobe/aio-commerce-lib-events",
+  "description": "A library to interact with the Adobe I/O and Commerce Eventing APIs",
   "keywords": [],
   "bugs": {
     "url": "https://github.com/adobe/aio-commerce-sdk/issues"
@@ -18,17 +18,27 @@
     "url": "git+https://github.com/adobe/aio-commerce-sdk.git",
     "directory": "packages/aio-commerce-lib-events"
   },
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/es/index.d.ts",
-        "default": "./dist/es/index.js"
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/es/index.js",
+  "types": "./dist/cjs/index.d.cts",
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/es/index.d.ts",
+          "default": "./dist/es/index.js"
+        },
+        "require": {
+          "types": "./dist/cjs/index.d.cts",
+          "default": "./dist/cjs/index.cjs"
+        }
       },
-      "require": {
-        "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
-      }
-    },
+      "./package.json": "./package.json"
+    }
+  },
+  "exports": {
+    "./commerce": "./source/commerce/index.ts",
+    "./io-events": "./source/io-events/index.ts",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-providers/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-providers/endpoints.ts
@@ -14,7 +14,10 @@ import type {
   EventProviderCreateParams,
   EventProviderGetByIdParams,
 } from "./schema";
-import type { CommerceEventProvider } from "./types";
+import type {
+  CommerceEventProviderManyResponse,
+  CommerceEventProviderOneResponse,
+} from "./types";
 
 /**
  * Lists all event providers of the Commerce instance bound to the given {@link AdobeCommerceHttpClient}.
@@ -38,7 +41,7 @@ export function getAllEventProviders(
 
   return withHooksClient
     .get("eventing/eventProvider", fetchOptions)
-    .json<CommerceEventProvider[]>();
+    .json<CommerceEventProviderManyResponse>();
 }
 
 /**
@@ -70,7 +73,7 @@ export function getEventProviderById(
 
   return withHooksClient
     .get(`eventing/eventProvider/${validatedParams.providerId}`, fetchOptions)
-    .json<CommerceEventProvider>();
+    .json<CommerceEventProviderOneResponse>();
 }
 
 /**
@@ -110,5 +113,5 @@ export function createEventProvider(
         },
       },
     })
-    .json<CommerceEventProvider>();
+    .json<CommerceEventProviderOneResponse>();
 }

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-providers/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-providers/endpoints.ts
@@ -13,6 +13,7 @@ import type {
   EventProviderCreateParams,
   EventProviderGetByIdParams,
 } from "./schema";
+import type { CommerceEventProvider } from "./types";
 
 /**
  * Lists all event providers of the Commerce instance bound to the given {@link AdobeCommerceHttpClient}.
@@ -28,7 +29,9 @@ export function getAllEventProviders(
   httpClient: AdobeCommerceHttpClient,
   fetchOptions?: Options,
 ) {
-  return httpClient.get("eventing/eventProvider", fetchOptions);
+  return httpClient
+    .get("eventing/eventProvider", fetchOptions)
+    .json<CommerceEventProvider[]>();
 }
 
 /**
@@ -52,10 +55,9 @@ export function getEventProviderById(
     params,
   );
 
-  return httpClient.get(
-    `eventing/eventProvider/${validatedParams.providerId}`,
-    fetchOptions,
-  );
+  return httpClient
+    .get(`eventing/eventProvider/${validatedParams.providerId}`, fetchOptions)
+    .json<CommerceEventProvider>();
 }
 
 /**
@@ -76,17 +78,19 @@ export function createEventProvider(
 ) {
   const validatedParams = parseOrThrow(EventProviderCreateParamsSchema, params);
 
-  return httpClient.post("eventing/eventProvider", {
-    ...fetchOptions,
-    json: {
-      eventProvider: {
-        provider_id: validatedParams.providerId,
-        instance_id: validatedParams.instanceId,
-        label: validatedParams.label,
-        description: validatedParams.description,
-        associated_workspace_configuration:
-          validatedParams.associatedWorkspaceConfiguration,
+  return httpClient
+    .post("eventing/eventProvider", {
+      ...fetchOptions,
+      json: {
+        eventProvider: {
+          provider_id: validatedParams.providerId,
+          instance_id: validatedParams.instanceId,
+          label: validatedParams.label,
+          description: validatedParams.description,
+          workspace_configuration:
+            validatedParams.associatedWorkspaceConfiguration,
+        },
       },
-    },
-  });
+    })
+    .json<CommerceEventProvider>();
 }

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-providers/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-providers/endpoints.ts
@@ -1,4 +1,5 @@
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
+import { buildCamelCaseKeysResponseHook } from "@aio-commerce-sdk/aio-commerce-lib-api/utils/transformations";
 
 import { parseOrThrow } from "~/utils/valibot";
 
@@ -29,7 +30,13 @@ export function getAllEventProviders(
   httpClient: AdobeCommerceHttpClient,
   fetchOptions?: Options,
 ) {
-  return httpClient
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
+    },
+  });
+
+  return withHooksClient
     .get("eventing/eventProvider", fetchOptions)
     .json<CommerceEventProvider[]>();
 }
@@ -55,7 +62,13 @@ export function getEventProviderById(
     params,
   );
 
-  return httpClient
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
+    },
+  });
+
+  return withHooksClient
     .get(`eventing/eventProvider/${validatedParams.providerId}`, fetchOptions)
     .json<CommerceEventProvider>();
 }
@@ -77,8 +90,13 @@ export function createEventProvider(
   fetchOptions?: Options,
 ) {
   const validatedParams = parseOrThrow(EventProviderCreateParamsSchema, params);
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
+    },
+  });
 
-  return httpClient
+  return withHooksClient
     .post("eventing/eventProvider", {
       ...fetchOptions,
       json: {

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-providers/types.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-providers/types.ts
@@ -1,3 +1,5 @@
+import type { CamelCasedPropertiesDeep } from "type-fest";
+
 /** Defines the structure of a Commerce event provider. */
 export type CommerceEventProvider = {
   id: string;
@@ -7,3 +9,11 @@ export type CommerceEventProvider = {
   description?: string;
   workspace_configuration?: string;
 };
+
+/** Defines the fields of an event provider entity returned by the Commerce API. */
+export type CommerceEventProviderOneResponse =
+  CamelCasedPropertiesDeep<CommerceEventProvider>;
+
+/** Defines the fields of many event provider entities returned by the Commerce API. */
+export type CommerceEventProviderManyResponse =
+  CommerceEventProviderOneResponse[];

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-providers/types.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-providers/types.ts
@@ -1,0 +1,9 @@
+/** Defines the structure of a Commerce event provider. */
+export type CommerceEventProvider = {
+  id: string;
+  provider_id: string;
+  instance_id?: string;
+  label?: string;
+  description?: string;
+  workspace_configuration?: string;
+};

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/endpoints.ts
@@ -8,7 +8,7 @@ import type { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/er
 import type { AdobeCommerceHttpClient } from "@aio-commerce-sdk/aio-commerce-lib-api";
 import type { HTTPError, Options } from "ky";
 import type { EventSubscriptionCreateParams } from "./schema";
-import type { CommerceEventSubscriptionGetResponse } from "./types";
+import type { CommerceEventSubscriptionManyResponse } from "./types";
 
 /**
  * Gets all event subscriptions in the Commerce instance bound to the given {@link AdobeCommerceHttpClient}.
@@ -29,7 +29,7 @@ export function getAllEventSubscriptions(
 
   return withHooksClient
     .get("eventing/getEventSubscriptions", fetchOptions)
-    .json<CommerceEventSubscriptionGetResponse[]>();
+    .json<CommerceEventSubscriptionManyResponse>();
 }
 
 /**

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/endpoints.ts
@@ -1,3 +1,5 @@
+import { buildCamelCaseKeysResponseHook } from "@aio-commerce-sdk/aio-commerce-lib-api/utils/transformations";
+
 import { parseOrThrow } from "~/utils/valibot";
 
 import { EventSubscriptionCreateParamsSchema } from "./schema";
@@ -19,7 +21,13 @@ export function getAllEventSubscriptions(
   httpClient: AdobeCommerceHttpClient,
   fetchOptions?: Options,
 ) {
-  return httpClient
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
+    },
+  });
+
+  return withHooksClient
     .get("eventing/getEventSubscriptions", fetchOptions)
     .json<CommerceEventSubscriptionGetResponse[]>();
 }

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/endpoints.ts
@@ -6,6 +6,7 @@ import type { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/er
 import type { AdobeCommerceHttpClient } from "@aio-commerce-sdk/aio-commerce-lib-api";
 import type { HTTPError, Options } from "ky";
 import type { EventSubscriptionCreateParams } from "./schema";
+import type { CommerceEventSubscriptionGetResponse } from "./types";
 
 /**
  * Gets all event subscriptions in the Commerce instance bound to the given {@link AdobeCommerceHttpClient}.
@@ -18,7 +19,9 @@ export function getAllEventSubscriptions(
   httpClient: AdobeCommerceHttpClient,
   fetchOptions?: Options,
 ) {
-  return httpClient.get("eventing/getEventSubscriptions", fetchOptions);
+  return httpClient
+    .get("eventing/getEventSubscriptions", fetchOptions)
+    .json<CommerceEventSubscriptionGetResponse[]>();
 }
 
 /**
@@ -43,17 +46,21 @@ export function createEventSubscription(
   );
 
   const { force, ...event } = validatedParams;
-  return httpClient.post("eventing/eventSubscribe", {
-    ...fetchOptions,
-    json: {
-      force,
-      event: {
-        ...event,
-
-        hipaa_audit_required: event.hipaaAuditRequired,
-        priority: event.prioritary,
-        provider_id: event.providerId,
+  httpClient
+    .post("eventing/eventSubscribe", {
+      ...fetchOptions,
+      json: {
+        force,
+        event: {
+          name: event.name,
+          parent: event.parent,
+          fields: event.fields,
+          destination: event.destination,
+          hipaa_audit_required: event.hipaaAuditRequired,
+          priority: event.prioritary,
+          provider_id: event.providerId,
+        },
       },
-    },
-  });
+    })
+    .json<void>();
 }

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/types.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/types.ts
@@ -1,0 +1,32 @@
+import type { CamelCasedProperties } from "type-fest";
+
+/** Defines the structure of a field in a Commerce event subscription. */
+export type CommerceEventSubscriptionField = {
+  name: string;
+  converter?: string;
+};
+
+/** Defines the structure of a filtering rule in a Commerce event subscription. */
+export type CommerceEventSubscriptionRule = {
+  field: string;
+  value: string;
+  operator: string;
+};
+
+/** Defines the structure of a Commerce event subscription. */
+export type CommerceEventSubscription = {
+  name: string;
+  parent: string;
+  provider_id: "default" | string;
+
+  fields: CommerceEventSubscriptionField[];
+  rules: CommerceEventSubscriptionRule[];
+
+  destination: "default" | string;
+  priority: boolean;
+  hipaa_audit_required: boolean;
+};
+
+/** Defines the structure of the response of the GET Commerce API endpoint for event subscriptions. */
+export type CommerceEventSubscriptionGetResponse =
+  CamelCasedProperties<CommerceEventSubscription>;

--- a/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/types.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/event-subscriptions/types.ts
@@ -1,4 +1,4 @@
-import type { CamelCasedProperties } from "type-fest";
+import type { CamelCasedPropertiesDeep } from "type-fest";
 
 /** Defines the structure of a field in a Commerce event subscription. */
 export type CommerceEventSubscriptionField = {
@@ -27,6 +27,10 @@ export type CommerceEventSubscription = {
   hipaa_audit_required: boolean;
 };
 
-/** Defines the structure of the response of the GET Commerce API endpoint for event subscriptions. */
-export type CommerceEventSubscriptionGetResponse =
-  CamelCasedProperties<CommerceEventSubscription>;
+/** Defines the fields of an event subscription entity returned by the Commerce API. */
+export type CommerceEventSubscriptionOneResponse =
+  CamelCasedPropertiesDeep<CommerceEventSubscription>;
+
+/** Defines the fields of many event subscription entities returned by the Commerce API. */
+export type CommerceEventSubscriptionManyResponse =
+  CommerceEventSubscriptionOneResponse[];

--- a/packages/aio-commerce-lib-events/source/commerce/api/eventing-configuration/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/api/eventing-configuration/endpoints.ts
@@ -30,8 +30,12 @@ export function updateEventingConfiguration(
     params,
   );
 
-  return httpClient.put("eventing/updateConfiguration", {
-    ...fetchOptions,
-    json: validatedParams,
-  });
+  return httpClient
+    .put("eventing/updateConfiguration", {
+      ...fetchOptions,
+      json: {
+        config: validatedParams,
+      },
+    })
+    .json<boolean>();
 }

--- a/packages/aio-commerce-lib-events/source/commerce/index.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/index.ts
@@ -6,5 +6,17 @@ export * from "./api/eventing-configuration/endpoints";
 export * from "./lib/api-client";
 
 export type * from "./api/event-providers/schema";
+export type {
+  CommerceEventProvider,
+  CommerceEventProviderManyResponse,
+  CommerceEventProviderOneResponse,
+} from "./api/event-providers/types";
 export type * from "./api/event-subscriptions/schema";
+export type {
+  CommerceEventSubscription,
+  CommerceEventSubscriptionField,
+  CommerceEventSubscriptionManyResponse,
+  CommerceEventSubscriptionOneResponse,
+  CommerceEventSubscriptionRule,
+} from "./api/event-subscriptions/types";
 export type * from "./api/eventing-configuration/schema";

--- a/packages/aio-commerce-lib-events/source/commerce/lib/schema.ts
+++ b/packages/aio-commerce-lib-events/source/commerce/lib/schema.ts
@@ -4,26 +4,26 @@ import { stringValueSchema } from "~/utils/schemas";
 
 /** The schema of the workspace configuration in the Developer Console. */
 export function workspaceConfigurationSchema(propertyName: string) {
-  return v.pipe(
-    // Input Format (JSON String or Object)
-    v.union([
-      v.pipe(
-        stringValueSchema(propertyName),
-        v.parseJson(
-          undefined,
-          `Expected valid JSON string for property '${propertyName}'`,
-        ),
-
-        v.record(v.string(), v.unknown()),
-        v.stringifyJson(),
+  return v.union([
+    // Input Format (Empty String, JSON String or Object)
+    v.pipe(stringValueSchema(propertyName), v.empty()),
+    v.pipe(
+      stringValueSchema(propertyName),
+      v.parseJson(
+        undefined,
+        `Expected valid JSON string for property '${propertyName}'`,
       ),
 
       v.record(v.string(), v.unknown()),
-    ]),
-    // Output Format (JSON String)
-    v.stringifyJson(
-      undefined,
-      `Expected valid JSON data for property '${propertyName}'`,
+      v.stringifyJson(),
     ),
-  );
+
+    v.pipe(
+      v.record(v.string(), v.unknown()),
+      v.stringifyJson(
+        undefined,
+        `Expected valid JSON data for property '${propertyName}'`,
+      ),
+    ),
+  ]);
 }

--- a/packages/aio-commerce-lib-events/source/io-events/api/event-metadata/endpoints.ts
+++ b/packages/aio-commerce-lib-events/source/io-events/api/event-metadata/endpoints.ts
@@ -1,3 +1,5 @@
+import { buildCamelCaseKeysResponseHook } from "@aio-commerce-sdk/aio-commerce-lib-api/utils/transformations";
+
 import { parseOrThrow } from "~/utils/valibot";
 
 import {
@@ -14,6 +16,10 @@ import type {
   GetAllEventMetadataForProviderParams,
   GetEventMetadataForEventAndProviderParams,
 } from "./schema";
+import type {
+  IoEventMetadataManyResponse,
+  IoEventMetadataOneResponse,
+} from "./types";
 
 /**
  * Gets all event metadata for a specific provider.
@@ -36,10 +42,15 @@ export function getAllEventMetadataForProvider(
     params,
   );
 
-  return httpClient.get(
-    `providers/${validatedParams.providerId}/eventmetadata`,
-    fetchOptions,
-  );
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
+    },
+  });
+
+  return withHooksClient
+    .get(`providers/${validatedParams.providerId}/eventmetadata`, fetchOptions)
+    .json<IoEventMetadataManyResponse>();
 }
 
 /**
@@ -63,10 +74,18 @@ export function getEventMetadataForEventAndProvider(
     params,
   );
 
-  return httpClient.get(
-    `providers/${validatedParams.providerId}/eventmetadata/${validatedParams.eventCode}`,
-    fetchOptions,
-  );
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
+    },
+  });
+
+  return withHooksClient
+    .get(
+      `providers/${validatedParams.providerId}/eventmetadata/${validatedParams.eventCode}`,
+      fetchOptions,
+    )
+    .json<IoEventMetadataOneResponse>();
 }
 
 /**
@@ -90,16 +109,24 @@ export function createEventMetadataForProvider(
     params,
   );
 
-  return httpClient.post(
-    `${validatedParams.consumerOrgId}/${validatedParams.projectId}/${validatedParams.workspaceId}/providers/${validatedParams.providerId}/eventmetadata`,
-    {
-      ...fetchOptions,
-      json: {
-        label: validatedParams.label,
-        description: validatedParams.description,
-        event_code: validatedParams.eventCode,
-        sample_event_template: validatedParams.sampleEventTemplate,
-      },
+  const withHooksClient = httpClient.extend({
+    hooks: {
+      afterResponse: [buildCamelCaseKeysResponseHook()],
     },
-  );
+  });
+
+  return withHooksClient
+    .post(
+      `${validatedParams.consumerOrgId}/${validatedParams.projectId}/${validatedParams.workspaceId}/providers/${validatedParams.providerId}/eventmetadata`,
+      {
+        ...fetchOptions,
+        json: {
+          label: validatedParams.label,
+          description: validatedParams.description,
+          event_code: validatedParams.eventCode,
+          sample_event_template: validatedParams.sampleEventTemplate,
+        },
+      },
+    )
+    .json<IoEventMetadataOneResponse>();
 }

--- a/packages/aio-commerce-lib-events/source/io-events/api/event-metadata/types.ts
+++ b/packages/aio-commerce-lib-events/source/io-events/api/event-metadata/types.ts
@@ -1,0 +1,39 @@
+import type { CamelCasedPropertiesDeep } from "type-fest";
+import type { HALLink } from "~/io-events/types";
+
+/** Defines the base fields of an event metadata entity. */
+export type IoEventMetadata = {
+  description: string;
+  label: string;
+  event_code: string;
+};
+
+/** Defines the fields of a sample event entity returned by the Adobe I/O Events API. */
+export type SampleEventHalModel = {
+  format: string;
+  sample_payload?: string;
+  _links: {
+    self: HALLink;
+  };
+};
+
+/** Defines the fields of an event metadata entity returned by the Adobe I/O Events API. */
+export type IoEventMetadataHalModel = IoEventMetadata & {
+  _embedded?: {
+    sample_event?: SampleEventHalModel;
+  };
+  _links: {
+    "rel:sample_event"?: HALLink;
+    "rel:update"?: HALLink;
+    self: HALLink;
+  };
+};
+
+/** Defines the fields of an event metadata entity returned by the Adobe I/O Events API. */
+export type IoEventMetadataOneResponse =
+  CamelCasedPropertiesDeep<IoEventMetadataHalModel>;
+
+/** Defines the fields of many event metadata entities returned by the Adobe I/O Events API. */
+export type IoEventMetadataManyResponse = CamelCasedPropertiesDeep<{
+  _embedded: IoEventMetadataHalModel[];
+}>;

--- a/packages/aio-commerce-lib-events/source/io-events/api/event-providers/types.ts
+++ b/packages/aio-commerce-lib-events/source/io-events/api/event-providers/types.ts
@@ -1,0 +1,41 @@
+import type { CamelCasedPropertiesDeep } from "type-fest";
+import type { HALLink } from "~/io-events/types";
+import type { IoEventMetadataHalModel } from "../event-metadata/types";
+
+/** Defines the base fields of an I/O event provider entity. */
+export type IoEventProvider = {
+  id: string;
+  instance_id?: string;
+  label: string;
+  source: string;
+  publisher: string;
+  provider_metadata: string;
+  event_delivery_format: string;
+  description?: string;
+  docs_url?: string;
+};
+
+/** Defines the fields of an I/O event provider entity returned by the Adobe I/O Events API. */
+export type IoEventProviderHalModel = IoEventProvider & {
+  _embedded?: {
+    eventmetadata: IoEventMetadataHalModel[];
+  };
+  _links: {
+    self: HALLink;
+    "rel:eventmetadata"?: HALLink;
+  };
+};
+
+/** Defines the fields of an I/O event provider entity returned by the Adobe I/O Events API. */
+export type IoEventProviderOneResponse =
+  CamelCasedPropertiesDeep<IoEventProviderHalModel>;
+
+/** Defines the fields of many I/O event provider entities returned by the Adobe I/O Events API. */
+export type IoEventProviderManyResponse = CamelCasedPropertiesDeep<{
+  _embedded: {
+    providers: IoEventProviderHalModel[];
+  };
+  _links: {
+    self: HALLink;
+  };
+}>;

--- a/packages/aio-commerce-lib-events/source/io-events/index.ts
+++ b/packages/aio-commerce-lib-events/source/io-events/index.ts
@@ -6,4 +6,14 @@ export * from "./api/event-providers/shorthands";
 export * from "./lib/api-client";
 
 export type * from "./api/event-metadata/schema";
+export type {
+  IoEventMetadata,
+  IoEventMetadataManyResponse,
+  IoEventMetadataOneResponse,
+} from "./api/event-metadata/types";
 export type * from "./api/event-providers/schema";
+export type {
+  IoEventProvider,
+  IoEventProviderManyResponse,
+  IoEventProviderOneResponse,
+} from "./api/event-providers/types";

--- a/packages/aio-commerce-lib-events/source/io-events/types.ts
+++ b/packages/aio-commerce-lib-events/source/io-events/types.ts
@@ -1,11 +1,11 @@
 export type HALLink = {
   href: string;
-  templated: boolean;
-  type: string;
-  deprecation: string;
-  name: string;
-  profile: string;
-  title: string;
-  hreflang: string;
-  seen: string;
+  templated?: boolean;
+  type?: string;
+  deprecation?: string;
+  name?: string;
+  profile?: string;
+  title?: string;
+  hreflang?: string;
+  seen?: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
       tsdown:
         specifier: ^0.14.0
         version: 0.14.2(typescript@5.9.2)
@@ -1560,11 +1557,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -1791,10 +1783,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.1:
-    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
-    engines: {node: 20 || >=22}
-
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
@@ -1908,10 +1896,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
-    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -2141,10 +2125,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -2262,11 +2242,6 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
-    engines: {node: 20 || >=22}
     hasBin: true
 
   rolldown-plugin-dts@0.15.9:
@@ -4268,15 +4243,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.3:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.0.3
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
-
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4520,10 +4486,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-
   jiti@2.5.1: {}
 
   js-tokens@9.0.1: {}
@@ -4638,8 +4600,6 @@ snapshots:
   lower-case@1.1.4: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.1.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4880,11 +4840,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.1.0
-      minipass: 7.1.2
-
   path-type@4.0.0: {}
 
   path-type@6.0.0: {}
@@ -4993,11 +4948,6 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 11.0.3
-      package-json-from-dist: 1.0.1
 
   rolldown-plugin-dts@0.15.9(rolldown@1.0.0-beta.34)(typescript@5.9.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ importers:
       '@adobe/aio-commerce-lib-core':
         specifier: workspace:*
         version: link:../aio-commerce-lib-core
-      '@aio-commerce-sdk/aio-commerce-lib-api':
-        specifier: workspace:*
-        version: link:../../packages-private/aio-commerce-lib-api
       ky:
         specifier: ^1.9.0
         version: 1.9.0
@@ -184,6 +181,9 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.9.2)
     devDependencies:
+      '@aio-commerce-sdk/aio-commerce-lib-api':
+        specifier: workspace:*
+        version: link:../../packages-private/aio-commerce-lib-api
       '@aio-commerce-sdk/config-tsdown':
         specifier: workspace:*
         version: link:../../configs/tsdown

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
   packages-private/aio-commerce-lib-api:
     dependencies:
       '@adobe/aio-commerce-lib-auth':
-        specifier: ^0.3.4
-        version: 0.3.4(typescript@5.9.2)
+        specifier: workspace:*
+        version: link:../../packages/aio-commerce-lib-auth
       camelcase:
         specifier: ^8.0.0
         version: 8.0.0
@@ -253,10 +253,12 @@ packages:
   '@adobe/aio-lib-core-networking@5.0.4':
     resolution: {integrity: sha512-LsFPKIXqfWiMwSjD9NJbb6uUSlZ+DZiV8p9NhpqPyzqAAl9NNONAH0jcIKtsKWSULcHc20INaRAw8dqKzQBTbw==}
     engines: {node: '>=18'}
+    bundledDependencies: []
 
   '@adobe/aio-lib-env@3.0.1':
     resolution: {integrity: sha512-UaLosV8jBowEA2ho4BNmWuHhrNCFbx26kJAr2SAIdEm4lZ/D8av8FUSMOEyAKJ/dfO2HCnLKMy77ie2AU7HI3g==}
     engines: {node: '>=18'}
+    bundledDependencies: []
 
   '@adobe/aio-lib-ims-jwt@5.0.2':
     resolution: {integrity: sha512-KaK+RB4FbfF5llYJueoOd9r6NeJp+d8pUE2QxqP6tpfr8NGt40Fw68XduQSTnPoOxKLn2piTD+IfaQ9a5teKHg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,11 +172,11 @@ importers:
   packages/aio-commerce-lib-events:
     dependencies:
       '@adobe/aio-commerce-lib-auth':
-        specifier: ^0.3.4
-        version: 0.3.4(typescript@5.9.2)
+        specifier: workspace:*
+        version: link:../aio-commerce-lib-auth
       '@adobe/aio-commerce-lib-core':
-        specifier: ^0.4.1
-        version: 0.4.1(typescript@5.9.2)
+        specifier: workspace:*
+        version: link:../aio-commerce-lib-core
       '@aio-commerce-sdk/aio-commerce-lib-api':
         specifier: workspace:*
         version: link:../../packages-private/aio-commerce-lib-api
@@ -230,14 +230,6 @@ importers:
         version: link:../../configs/typescript
 
 packages:
-
-  '@adobe/aio-commerce-lib-auth@0.3.4':
-    resolution: {integrity: sha512-LiEPCtXbjKoccL+ljQUBgfWxUWUE/OXTvl8vZ44cApaGpy1Yb5/mwAj44P6yThqLJrxFFFim2Dvca48BA20cAw==}
-    engines: {node: '>=20 <=24'}
-
-  '@adobe/aio-commerce-lib-core@0.4.1':
-    resolution: {integrity: sha512-gkvHLoSdVHX9ByORVg2F6ITXyFj2HAY2AElvrXJUwXgtywcIs+j0xr4kG1yXQ1zglSRdsvuAH6zDpJGKrfJ6vg==}
-    engines: {node: '>=20 <=24'}
 
   '@adobe/aio-lib-core-config@5.0.1':
     resolution: {integrity: sha512-OQmQublmy/uXM1HC6qXfxSAXEl85nExh/yiajlEfJheKuJ9iPWwVWXR5vBHVVDlOXgWEVMWRUQPMIUu1lmR5lA==}
@@ -2865,25 +2857,6 @@ packages:
     resolution: {integrity: sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA==}
 
 snapshots:
-
-  '@adobe/aio-commerce-lib-auth@0.3.4(typescript@5.9.2)':
-    dependencies:
-      '@adobe/aio-commerce-lib-core': 0.4.1(typescript@5.9.2)
-      '@adobe/aio-lib-ims': 8.1.0
-      ansis: 4.1.0
-      oauth-1.0a: 2.2.6
-      valibot: 1.1.0(typescript@5.9.2)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-      - typescript
-
-  '@adobe/aio-commerce-lib-core@0.4.1(typescript@5.9.2)':
-    dependencies:
-      ansis: 4.1.0
-      valibot: 1.1.0(typescript@5.9.2)
-    transitivePeerDependencies:
-      - typescript
 
   '@adobe/aio-lib-core-config@5.0.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@adobe/aio-commerce-lib-auth':
         specifier: ^0.3.4
         version: 0.3.4(typescript@5.9.2)
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       ky:
         specifier: ^1.9.0
         version: 1.9.0
@@ -250,12 +253,10 @@ packages:
   '@adobe/aio-lib-core-networking@5.0.4':
     resolution: {integrity: sha512-LsFPKIXqfWiMwSjD9NJbb6uUSlZ+DZiV8p9NhpqPyzqAAl9NNONAH0jcIKtsKWSULcHc20INaRAw8dqKzQBTbw==}
     engines: {node: '>=18'}
-    bundledDependencies: []
 
   '@adobe/aio-lib-env@3.0.1':
     resolution: {integrity: sha512-UaLosV8jBowEA2ho4BNmWuHhrNCFbx26kJAr2SAIdEm4lZ/D8av8FUSMOEyAKJ/dfO2HCnLKMy77ie2AU7HI3g==}
     engines: {node: '>=18'}
-    bundledDependencies: []
 
   '@adobe/aio-lib-ims-jwt@5.0.2':
     resolution: {integrity: sha512-KaK+RB4FbfF5llYJueoOd9r6NeJp+d8pUE2QxqP6tpfr8NGt40Fw68XduQSTnPoOxKLn2piTD+IfaQ9a5teKHg==}
@@ -1148,6 +1149,10 @@ packages:
 
   camel-case@3.0.0:
     resolution: {integrity: sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -3850,6 +3855,8 @@ snapshots:
     dependencies:
       no-case: 2.3.2
       upper-case: 1.1.3
+
+  camelcase@8.0.0: {}
 
   chai@5.3.3:
     dependencies:


### PR DESCRIPTION
## Description

This library polishes the code introduced in #70. It introduces return types for each API call for maximum type safety, plus also fixes some bugs I found while testing, from many kinds, from invalid API calls (malformed payloads) to wrongful invalidation pipelines and some other things related to package configuration/building/publishing and/or dependencies.