### PR TITLE
INTERNAL: Disable Prettier in Generated Changesets Changelogs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,6 @@
   "ignore": [],
   "linked": [],
 
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "prettier": false
 }


### PR DESCRIPTION
## Description

When a changeset file includes only a list of changes, the first item in the list gets formatted into a paragraph. Try if disabling prettier fixes this behavior.