### PR TITLE
CEXT-6221: drop Node 20 support (EOL April 2026)

### DIFF
--- a/.changeset/itchy-teeth-like.md
+++ b/.changeset/itchy-teeth-like.md
@@ -1,0 +1,12 @@
+---
+"@adobe/aio-commerce-lib-api": minor
+"@adobe/aio-commerce-lib-app": minor
+"@adobe/aio-commerce-lib-auth": minor
+"@adobe/aio-commerce-lib-config": minor
+"@adobe/aio-commerce-lib-core": minor
+"@adobe/aio-commerce-lib-events": minor
+"@adobe/aio-commerce-lib-webhooks": minor
+"@adobe/aio-commerce-sdk": minor
+---
+
+Drop Node 20 support (EOL April 2026).

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
       # We want to run checks on all versions, even if some fail.
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.33.3",
   "engines": {
-    "node": ">=20 <=24",
+    "node": ">=22 <=24",
     "pnpm": ">=10"
   },
   "scripts": {

--- a/packages-private/common-utils/package.json
+++ b/packages-private/common-utils/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.3",
   "private": true,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Description for @aio-commerce-sdk/common-utils",

--- a/packages-private/scripting-utils/package.json
+++ b/packages-private/scripting-utils/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.1",
   "private": true,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Utility functions for Adobe Commerce SDK scripts and build tools",

--- a/packages/aio-commerce-lib-api/package.json
+++ b/packages/aio-commerce-lib-api/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.0",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "A set of utilities to build HTTP/API clients for I/O Events and Adobe Commerce",

--- a/packages/aio-commerce-lib-app/package.json
+++ b/packages/aio-commerce-lib-app/package.json
@@ -5,7 +5,7 @@
   "version": "1.4.0",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "App configuration management library for Adobe Commerce applications",

--- a/packages/aio-commerce-lib-auth/package.json
+++ b/packages/aio-commerce-lib-auth/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.2",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Authentication utilities for Adobe Commerce apps deployed in Adobe App Builder.",

--- a/packages/aio-commerce-lib-config/package.json
+++ b/packages/aio-commerce-lib-config/package.json
@@ -5,7 +5,7 @@
   "version": "1.3.0",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Configuration management utilities for Adobe Commerce apps deployed in Adobe App Builder",

--- a/packages/aio-commerce-lib-core/package.json
+++ b/packages/aio-commerce-lib-core/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Core utilities for Adobe Commerce SDK libraries",

--- a/packages/aio-commerce-lib-events/package.json
+++ b/packages/aio-commerce-lib-events/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.1",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "A library to interact with the Adobe I/O and Commerce Eventing APIs",

--- a/packages/aio-commerce-lib-webhooks/package.json
+++ b/packages/aio-commerce-lib-webhooks/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "A library to interact with the Adobe Commerce Webhooks API",

--- a/packages/aio-commerce-sdk/package.json
+++ b/packages/aio-commerce-sdk/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.2",
   "private": false,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Meta-package re-exporting Adobe Commerce SDK libraries for Adobe App Builder applications.",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
   "license": "Apache-2.0",
   "description": "Scripts for the AIO Commerce SDK monorepo",

--- a/specs/features/CEXT-6221-node-version-policy.md
+++ b/specs/features/CEXT-6221-node-version-policy.md
@@ -2,7 +2,7 @@
 
 - **Ticket:** [CEXT-6221](https://jira.corp.adobe.com/browse/CEXT-6221)
 - **Created:** 2026-05-11
-- [ ] **Implemented**
+- [x] **Implemented**
 
 ## Summary
 

--- a/turbo/generators/create-package/template/package.json.hbs
+++ b/turbo/generators/create-package/template/package.json.hbs
@@ -8,7 +8,7 @@
   "version": "1.0.0",
   "private": {{isPrivate}},
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   },
 
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Drops Node 20 from the supported range and CI matrix. Node 20 reached EOL in April 2026.

Unblocks: https://github.com/adobe/aio-commerce-sdk/pull/379, https://github.com/adobe/aio-commerce-sdk/pull/431, https://github.com/adobe/aio-commerce-sdk/pull/433, https://github.com/adobe/aio-commerce-sdk/pull/434

## Related Issue

[CEXT-6221](https://jira.corp.adobe.com/browse/CEXT-6221)

## Motivation and Context

Node 20 reached EOL in April 2026. Per the SDK's [Node.js version support policy](specs/features/CEXT-6221-node-version-policy.md), support is dropped in a dedicated standalone release after a version's EOL date. This release raises the `engines.node` lower bound to `>=22` across all packages and removes Node 20 from the CI matrix.

Node 26 support is explicitly excluded from this PR — it enters Active LTS in October 2026 and will be added then, per policy.

## How Has This Been Tested?

CI matrix now runs on Node 22 and 24.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.