### PR TITLE
CEXT-6071: Add PATCH endpoint for partial config updates

### DIFF
--- a/.changeset/quiet-dragons-listen.md
+++ b/.changeset/quiet-dragons-listen.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Adding that PATCH endpoint and deprecating the PUT

--- a/.changeset/quiet-dragons-listen.md
+++ b/.changeset/quiet-dragons-listen.md
@@ -2,4 +2,5 @@
 "@adobe/aio-commerce-lib-app": minor
 ---
 
-Adding that PATCH endpoint and deprecating the PUT
+Adding new PATCH endpoint for configuration which allows to set configuration values.
+Deprecating PUT endpoint in favor of PATCH.

--- a/.changeset/quiet-dragons-listen.md
+++ b/.changeset/quiet-dragons-listen.md
@@ -2,5 +2,4 @@
 "@adobe/aio-commerce-lib-app": minor
 ---
 
-Adding new PATCH endpoint for configuration which allows to set configuration values.
-Deprecating PUT endpoint in favor of PATCH.
+Adding new PATCH endpoint for configuration which allows to partially set configuration values. Deprecating PUT endpoint in favor of PATCH.

--- a/.changeset/yummy-beans-jump.md
+++ b/.changeset/yummy-beans-jump.md
@@ -1,0 +1,6 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+"@adobe/aio-commerce-lib-config": minor
+---
+
+Add PATCH handler to the config runtime action accepting partial payloads and null values for unsetting fields

--- a/.changeset/yummy-beans-jump.md
+++ b/.changeset/yummy-beans-jump.md
@@ -1,6 +1,5 @@
 ---
-"@adobe/aio-commerce-lib-app": minor
 "@adobe/aio-commerce-lib-config": minor
 ---
 
-Add PATCH handler to the config runtime action accepting partial payloads and null values for unsetting fields
+Adding support for config unsetting

--- a/.changeset/yummy-beans-jump.md
+++ b/.changeset/yummy-beans-jump.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-lib-config": minor
 ---
 
-Adding support for config unsetting
+Add support for unset configuration values.

--- a/packages/aio-commerce-lib-app/source/actions/config.ts
+++ b/packages/aio-commerce-lib-app/source/actions/config.ts
@@ -134,6 +134,12 @@ router.put("/", {
     logger.debug(`Setting configuration with scope id: ${req.body.scopeId}`);
     const { scopeId, config } = req.body;
 
+    const validatedSchema = validateCommerceAppConfigDomain(
+      configSchema,
+      "businessConfig.schema",
+    );
+    initialize({ schema: validatedSchema });
+
     // The UI sent it to us as a masked value, which means the user didn't update it.
     const updatedFields = config.filter(
       (item) => item.value !== MASKED_PASSWORD_VALUE,
@@ -177,6 +183,12 @@ router.patch("/", {
 
     logger.debug(`Patching configuration with scope id: ${req.body.scopeId}`);
     const { scopeId, config } = req.body;
+
+    const validatedSchema = validateCommerceAppConfigDomain(
+      configSchema,
+      "businessConfig.schema",
+    );
+    initialize({ schema: validatedSchema });
 
     const result = await setConfiguration({ config }, byScopeId(scopeId), {
       encryptionKey: rawParams.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY,

--- a/packages/aio-commerce-lib-app/source/actions/config.ts
+++ b/packages/aio-commerce-lib-app/source/actions/config.ts
@@ -150,7 +150,10 @@ router.put("/", {
     result.config = filterPasswordFields(configSchema, result.config);
     return ok({
       body: result,
-      headers: { "Cache-Control": "no-store", Deprecation: "true" },
+      headers: {
+        "Cache-Control": "no-store",
+        Deprecation: "Wed, 15 Apr 2026 00:00:00 GMT",
+      },
     });
   },
 });

--- a/packages/aio-commerce-lib-app/source/actions/config.ts
+++ b/packages/aio-commerce-lib-app/source/actions/config.ts
@@ -111,7 +111,11 @@ router.get("/", {
   },
 });
 
-/** POST / - Set configuration */
+/**
+ * PUT / - Set configuration (deprecated)
+ * @deprecated Use PATCH instead. This endpoint overwrites all values for the scope
+ * and does not support partial updates or unset semantics.
+ */
 router.put("/", {
   body: v.object({
     scopeId: nonEmptyStringValueSchema("scopeId"),
@@ -142,6 +146,38 @@ router.put("/", {
         encryptionKey: rawParams.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY,
       },
     );
+
+    result.config = filterPasswordFields(configSchema, result.config);
+    return ok({
+      body: result,
+      headers: { "Cache-Control": "no-store", Deprecation: "true" },
+    });
+  },
+});
+
+/** PATCH / - Partially update configuration */
+router.patch("/", {
+  body: v.object({
+    scopeId: nonEmptyStringValueSchema("scopeId"),
+    config: v.array(
+      v.object({
+        name: nonEmptyStringValueSchema("config.name"),
+        // null unsets the field, restoring inheritance from the parent scope
+        value: v.nullable(v.union([v.string(), v.array(v.string())])),
+      }),
+    ),
+  }),
+
+  handler: async (req, ctx) => {
+    const { logger, rawParams } = ctx;
+    const { configSchema } = rawParams;
+
+    logger.debug(`Patching configuration with scope id: ${req.body.scopeId}`);
+    const { scopeId, config } = req.body;
+
+    const result = await setConfiguration({ config }, byScopeId(scopeId), {
+      encryptionKey: rawParams.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY,
+    });
 
     result.config = filterPasswordFields(configSchema, result.config);
     return ok({

--- a/packages/aio-commerce-lib-config/source/config-utils.ts
+++ b/packages/aio-commerce-lib-config/source/config-utils.ts
@@ -13,7 +13,10 @@
 import { DEFAULT_CUSTOM_SCOPE_LEVEL } from "#utils/constants";
 
 import type { ConfigValue } from "#modules/configuration/index";
-import type { ConfigValueWithOptionalOrigin } from "#modules/configuration/types";
+import type {
+  ConfigValueWithOptionalOrigin,
+  SetConfigValue,
+} from "#modules/configuration/types";
 import type {
   BusinessConfigSchema,
   BusinessConfigSchemaValue,
@@ -236,18 +239,24 @@ export function findScopePath(tree: ScopeTree, code: string, level: string) {
 }
 
 /**
- * Sanitize request config entries to contain only valid name/value pairs
+ * Sanitize request config entries to contain only valid name/value pairs.
+ * A `null` value is allowed and signals that the field should be unset
+ * (removing the explicit override at the current scope to restore inheritance).
  * @param entries - The entries to sanitize.
  * @returns The sanitized entries.
  */
 export function sanitizeRequestEntries(
-  entries: ConfigValueWithOptionalOrigin[],
-): ConfigValueWithOptionalOrigin[] {
+  entries: SetConfigValue[],
+): SetConfigValue[] {
   const list = Array.isArray(entries) ? entries : [];
   return list
     .filter((entry) => {
       if (!entry || typeof entry.name !== "string") {
         return false;
+      }
+
+      if (entry.value === null) {
+        return true; // null is valid: signals an unset
       }
 
       // TODO: This should be done via schema validation.
@@ -260,13 +269,14 @@ export function sanitizeRequestEntries(
     })
     .map((entry) => ({
       name: String(entry.name).trim(),
-      value: entry.value as BusinessConfigSchemaValue,
-      origin: entry.origin,
+      value: entry.value as BusinessConfigSchemaValue | null,
     }));
 }
 
 /**
- * Merge existing and requested entries, setting origin to the current scope for requested entries
+ * Merge existing and requested entries, setting origin to the current scope for requested entries.
+ * A `null` value in a requested entry removes that field from the persisted config,
+ * restoring inheritance from the parent scope.
  * @param existingScopeEntries - The existing scope entries.
  * @param requestedScopeEntries - The requested scope entries.
  * @param scopeCode - The code of the scope.
@@ -275,7 +285,7 @@ export function sanitizeRequestEntries(
  */
 export function mergeScopes(
   existingScopeEntries: ConfigValueWithOptionalOrigin[],
-  requestedScopeEntries: ConfigValueWithOptionalOrigin[],
+  requestedScopeEntries: SetConfigValue[],
   scopeCode: string,
   scopeLevel: string,
 ) {
@@ -289,11 +299,15 @@ export function mergeScopes(
   }
 
   for (const requestedEntry of requestedScopeEntries) {
-    mergedMap.set(requestedEntry.name, {
-      name: requestedEntry.name,
-      value: requestedEntry.value,
-      origin: { code: scopeCode, level: scopeLevel },
-    });
+    if (requestedEntry.value === null) {
+      mergedMap.delete(requestedEntry.name); // unset: remove override, restore inheritance
+    } else {
+      mergedMap.set(requestedEntry.name, {
+        name: requestedEntry.name,
+        value: requestedEntry.value,
+        origin: { code: scopeCode, level: scopeLevel },
+      });
+    }
   }
 
   return Array.from(mergedMap.values()).map((data) => ({

--- a/packages/aio-commerce-lib-config/source/modules/configuration/index.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/index.ts
@@ -15,4 +15,9 @@ export { getConfigurationByKey } from "./get-config-by-key";
 export { setConfiguration } from "./set-config";
 
 export type * as ConfigurationRepository from "./configuration-repository";
-export type { ConfigContext, ConfigOrigin, ConfigValue } from "./types";
+export type {
+  ConfigContext,
+  ConfigOrigin,
+  ConfigValue,
+  SetConfigValue,
+} from "./types";

--- a/packages/aio-commerce-lib-config/source/modules/configuration/set-config.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/set-config.ts
@@ -26,7 +26,7 @@ import type {
   SetConfigurationRequest,
   SetConfigurationResponse,
 } from "#types/index";
-import type { ConfigContext, ConfigValueWithOptionalOrigin } from "./types";
+import type { ConfigContext, SetConfigValue } from "./types";
 
 /**
  * Sets configuration values for a scope identified by code and level or id.
@@ -84,33 +84,31 @@ export async function setConfiguration(
   };
 
   await configRepository.persistConfig(scopeCode, payload);
-  const responseConfig = sanitizedEntries.map((entry) => ({
-    name: entry.name,
-    value: entry.value,
-  }));
 
   return {
     message: "Configuration values updated successfully",
     timestamp: new Date().toISOString(),
     scope: { id: String(scopeId), code: scopeCode, level: scopeLevel },
-    config: responseConfig,
+    config: mergedScopeConfig.map(({ name, value }) => ({ name, value })),
   };
 }
 
 /**
  * Encrypts password fields in the configuration entries.
+ * Entries with a `null` value (unset) are passed through unchanged.
  *
  * @param entries - Configuration entries to process.
  * @param passwordFields - Set of field names that should be encrypted.
  * @returns Configuration entries with password fields encrypted.
  */
 function encryptPasswordFields(
-  entries: ConfigValueWithOptionalOrigin[],
+  entries: SetConfigValue[],
   passwordFields: Set<string>,
   encryptionKey?: string,
-): ConfigValueWithOptionalOrigin[] {
+): SetConfigValue[] {
   return entries.map((entry) => {
     if (
+      entry.value !== null &&
       passwordFields.has(entry.name) &&
       typeof entry.value === "string" &&
       entry.value.length > 0

--- a/packages/aio-commerce-lib-config/source/modules/configuration/types.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/types.ts
@@ -46,6 +46,25 @@ export type ConfigValue = {
 export type ConfigValueWithOptionalOrigin = SetOptional<ConfigValue, "origin">;
 
 /**
+ * A configuration entry used in set/patch requests.
+ *
+ * Value can be `null` to unset the field, which removes the explicit override
+ * at the current scope and restores inheritance from the parent scope.
+ *
+ * @internal
+ */
+export type SetConfigValue = {
+  /** The name of the configuration field. */
+  name: string;
+  /**
+   * The value to set (string, number, or boolean).
+   * Pass `null` to unset the field, removing the explicit override at the
+   * current scope and restoring inheritance from the parent scope.
+   */
+  value: BusinessConfigSchemaValue | null;
+};
+
+/**
  * Context needed for configuration operations.
  */
 export type ConfigContext = {

--- a/packages/aio-commerce-lib-config/source/types/api.ts
+++ b/packages/aio-commerce-lib-config/source/types/api.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import type { ConfigValue } from "#modules/configuration/types";
+import type { ConfigValue, SetConfigValue } from "#modules/configuration/types";
 import type {
   BusinessConfigSchema,
   BusinessConfigSchemaValue,
@@ -59,12 +59,7 @@ export type GetConfigurationByKeyResponse = {
  */
 export type SetConfigurationRequest = {
   /** Array of configuration name-value pairs to set. */
-  config: Array<{
-    /** The name of the configuration field. */
-    name: string;
-    /** The value to set (string, number, or boolean). */
-    value: BusinessConfigSchemaValue;
-  }>;
+  config: SetConfigValue[];
 };
 
 /**

--- a/packages/aio-commerce-lib-config/test/fixtures/config-values.ts
+++ b/packages/aio-commerce-lib-config/test/fixtures/config-values.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { ConfigValueWithOptionalOrigin } from "#modules/configuration/types";
+
+/**
+ * Sample configuration values set at the global scope, used as a base for merging tests.
+ */
+export const mockGlobalConfigValues: ConfigValueWithOptionalOrigin[] = [
+  {
+    name: "currency",
+    value: "USD",
+    origin: { code: "global", level: "global" },
+  },
+  {
+    name: "locale",
+    value: "en_US",
+    origin: { code: "global", level: "global" },
+  },
+];

--- a/packages/aio-commerce-lib-config/test/integration/set-config-unset.test.ts
+++ b/packages/aio-commerce-lib-config/test/integration/set-config-unset.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getConfiguration, setConfiguration } from "#config-manager";
+import { byScopeId } from "#config-utils";
+import { setGlobalSchema } from "#modules/schema/config-schema-repository";
+import { getPersistedScopeTree } from "#modules/scope-tree/scope-tree-repository";
+import { mockScopeTree } from "#test/fixtures/scope-tree";
+import { createMockLibFiles } from "#test/mocks/lib-files";
+import { createMockLibState } from "#test/mocks/lib-state";
+
+import type { BusinessConfigSchema } from "#index";
+
+const MockState = createMockLibState();
+const MockFiles = createMockLibFiles();
+
+let mockStateInstance = new MockState();
+let mockFilesInstance = new MockFiles();
+
+vi.mock("#utils/repository", () => ({
+  getSharedState: vi.fn(async () => mockStateInstance),
+  getSharedFiles: vi.fn(async () => mockFilesInstance),
+}));
+
+vi.mock("#modules/scope-tree/scope-tree-repository", () => ({
+  getPersistedScopeTree: vi.fn(),
+  saveScopeTree: vi.fn(),
+  getCachedScopeTree: vi.fn(),
+  setCachedScopeTree: vi.fn(),
+  deleteCachedScopeTree: vi.fn(),
+}));
+
+vi.mock("#api/commerce", () => ({
+  getAllScopeData: vi.fn(() =>
+    Promise.resolve({ websites: [], storeGroups: [], storeViews: [] }),
+  ),
+}));
+
+const schema = [
+  { name: "currency", type: "text", label: "Currency", default: "" },
+  { name: "locale", type: "text", label: "Locale", default: "" },
+  { name: "apiKey", type: "password", label: "API Key", default: "" },
+] satisfies BusinessConfigSchema;
+
+// mockScopeTree has: global (id-global), commerce > base (idw) > main_store (ids) > default (idsv)
+const GLOBAL_ID = "id-global";
+const WEBSITE_ID = "idw";
+
+describe("setConfiguration — null/unset semantics", () => {
+  beforeEach(() => {
+    mockStateInstance = new MockState();
+    mockFilesInstance = new MockFiles();
+    setGlobalSchema(schema);
+    vi.clearAllMocks();
+    vi.mocked(getPersistedScopeTree).mockResolvedValue(mockScopeTree);
+  });
+
+  test("null value removes the explicit override from a scope", async () => {
+    // 1. Set currency on global scope
+    await setConfiguration(
+      { config: [{ name: "currency", value: "USD" }] },
+      byScopeId(GLOBAL_ID),
+    );
+
+    // 2. Override currency on website scope
+    await setConfiguration(
+      { config: [{ name: "currency", value: "EUR" }] },
+      byScopeId(WEBSITE_ID),
+    );
+
+    const before = await getConfiguration(byScopeId(WEBSITE_ID));
+    expect(before.config.find((e) => e.name === "currency")?.value).toBe("EUR");
+
+    // 3. Unset currency on website scope (null = remove override)
+    await setConfiguration(
+      { config: [{ name: "currency", value: null }] },
+      byScopeId(WEBSITE_ID),
+    );
+
+    // 4. Website should now inherit from global
+    const after = await getConfiguration(byScopeId(WEBSITE_ID));
+    const currencyEntry = after.config.find((e) => e.name === "currency");
+    expect(currencyEntry?.value).toBe("USD");
+    expect(currencyEntry?.origin).toMatchObject({
+      code: "global",
+      level: "global",
+    });
+  });
+
+  test("unsetting a field that was never set on the scope is a no-op", async () => {
+    // Set currency on global only
+    await setConfiguration(
+      { config: [{ name: "currency", value: "JPY" }] },
+      byScopeId(GLOBAL_ID),
+    );
+
+    // Unsetting currency on website (where it was never overridden) should not error
+    await expect(
+      setConfiguration(
+        { config: [{ name: "currency", value: null }] },
+        byScopeId(WEBSITE_ID),
+      ),
+    ).resolves.not.toThrow();
+
+    // Global value still accessible from website via inheritance
+    const result = await getConfiguration(byScopeId(WEBSITE_ID));
+    expect(result.config.find((e) => e.name === "currency")?.value).toBe("JPY");
+  });
+
+  test("null entries are excluded from the setConfiguration response", async () => {
+    // First set a value so it exists
+    await setConfiguration(
+      { config: [{ name: "currency", value: "USD" }] },
+      byScopeId(GLOBAL_ID),
+    );
+
+    // Unset it
+    const result = await setConfiguration(
+      { config: [{ name: "currency", value: null }] },
+      byScopeId(GLOBAL_ID),
+    );
+
+    expect(result.config.find((e) => e.name === "currency")).toBeUndefined();
+  });
+
+  test("mix of set, override, and unset in one call", async () => {
+    // Seed global scope
+    await setConfiguration(
+      {
+        config: [
+          { name: "currency", value: "USD" },
+          { name: "locale", value: "en_US" },
+        ],
+      },
+      byScopeId(GLOBAL_ID),
+    );
+
+    // On website: override locale, unset currency, add a new field via the existing values
+    await setConfiguration(
+      {
+        config: [
+          { name: "locale", value: "fr_FR" }, // override
+          { name: "currency", value: null }, // unset (should fall back to global)
+        ],
+      },
+      byScopeId(WEBSITE_ID),
+    );
+
+    const result = await getConfiguration(byScopeId(WEBSITE_ID));
+
+    // locale is overridden at website level
+    const localeEntry = result.config.find((e) => e.name === "locale");
+    expect(localeEntry?.value).toBe("fr_FR");
+    expect(localeEntry?.origin).toMatchObject({
+      code: "base",
+      level: "website",
+    });
+
+    // currency is inherited from global
+    const currencyEntry = result.config.find((e) => e.name === "currency");
+    expect(currencyEntry?.value).toBe("USD");
+    expect(currencyEntry?.origin).toMatchObject({
+      code: "global",
+      level: "global",
+    });
+  });
+
+  test("null for a password field does not throw an encryption error", async () => {
+    // apiKey is a password field — unsetting it should not trigger encryption
+    await expect(
+      setConfiguration(
+        { config: [{ name: "apiKey", value: null }] },
+        byScopeId(GLOBAL_ID),
+      ),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/aio-commerce-lib-config/test/unit/config-utils.test.ts
+++ b/packages/aio-commerce-lib-config/test/unit/config-utils.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, test } from "vitest";
 
 import { mergeScopes, sanitizeRequestEntries } from "#config-utils";
+import { mockGlobalConfigValues } from "#test/fixtures/config-values";
 
 import type { ConfigValueWithOptionalOrigin } from "#modules/configuration/types";
 
@@ -130,18 +131,7 @@ describe("config-utils", () => {
   });
 
   describe("mergeScopes", () => {
-    const existing: ConfigValueWithOptionalOrigin[] = [
-      {
-        name: "currency",
-        value: "USD",
-        origin: { code: "global", level: "global" },
-      },
-      {
-        name: "locale",
-        value: "en_US",
-        origin: { code: "global", level: "global" },
-      },
-    ];
+    const existing = mockGlobalConfigValues;
 
     test("adds new entries from requested with current scope as origin", () => {
       const result = mergeScopes(

--- a/packages/aio-commerce-lib-config/test/unit/config-utils.test.ts
+++ b/packages/aio-commerce-lib-config/test/unit/config-utils.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { mergeScopes, sanitizeRequestEntries } from "#config-utils";
+
+import type { ConfigValueWithOptionalOrigin } from "#modules/configuration/types";
+
+describe("config-utils", () => {
+  describe("sanitizeRequestEntries", () => {
+    test("passes valid string entries through", () => {
+      const entries: ConfigValueWithOptionalOrigin[] = [
+        {
+          name: "currency",
+          value: "USD",
+          origin: { code: "global", level: "global" },
+        },
+        { name: "locale", value: "en_US" },
+      ];
+
+      const result = sanitizeRequestEntries(entries);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ name: "currency", value: "USD" });
+      expect(result[1]).toMatchObject({ name: "locale", value: "en_US" });
+    });
+
+    test("passes string array values through", () => {
+      const entries: ConfigValueWithOptionalOrigin[] = [
+        { name: "listField", value: ["opt1", "opt2"] },
+      ];
+
+      const result = sanitizeRequestEntries(entries);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toEqual(["opt1", "opt2"]);
+    });
+
+    test("passes null values through as unset sentinels", () => {
+      const entries = [
+        { name: "currency", value: null },
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      const result = sanitizeRequestEntries(entries);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: "currency", value: null });
+    });
+
+    test("allows a mix of string values and null values", () => {
+      const entries = [
+        { name: "currency", value: "EUR" },
+        { name: "locale", value: null },
+        { name: "timezone", value: "UTC" },
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      const result = sanitizeRequestEntries(entries);
+
+      expect(result).toHaveLength(3);
+      expect(result.find((e) => e.name === "locale")?.value).toBeNull();
+    });
+
+    test("filters out entries with number values", () => {
+      const entries = [
+        { name: "count", value: 42 },
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      expect(sanitizeRequestEntries(entries)).toHaveLength(0);
+    });
+
+    test("filters out entries with boolean values", () => {
+      const entries = [
+        { name: "flag", value: true },
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      expect(sanitizeRequestEntries(entries)).toHaveLength(0);
+    });
+
+    test("filters out entries with undefined values", () => {
+      const entries = [
+        { name: "field", value: undefined },
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      expect(sanitizeRequestEntries(entries)).toHaveLength(0);
+    });
+
+    test("filters out entries with missing or empty name", () => {
+      const entries = [
+        { value: "value1" },
+        { name: "", value: "value2" },
+        { name: "   ", value: "value3" },
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      expect(sanitizeRequestEntries(entries)).toHaveLength(0);
+    });
+
+    test("filters out null/undefined entries", () => {
+      const entries = [
+        null,
+        undefined,
+      ] as unknown as ConfigValueWithOptionalOrigin[];
+
+      expect(sanitizeRequestEntries(entries)).toHaveLength(0);
+    });
+
+    test("trims whitespace from entry names", () => {
+      const entries: ConfigValueWithOptionalOrigin[] = [
+        { name: "  currency  ", value: "USD" },
+      ];
+
+      const result = sanitizeRequestEntries(entries);
+
+      expect(result[0].name).toBe("currency");
+    });
+
+    test("returns empty array for non-array input", () => {
+      expect(sanitizeRequestEntries(null as any)).toHaveLength(0);
+      expect(sanitizeRequestEntries(undefined as any)).toHaveLength(0);
+    });
+  });
+
+  describe("mergeScopes", () => {
+    const existing: ConfigValueWithOptionalOrigin[] = [
+      {
+        name: "currency",
+        value: "USD",
+        origin: { code: "global", level: "global" },
+      },
+      {
+        name: "locale",
+        value: "en_US",
+        origin: { code: "global", level: "global" },
+      },
+    ];
+
+    test("adds new entries from requested with current scope as origin", () => {
+      const result = mergeScopes(
+        existing,
+        [{ name: "timezone", value: "UTC" }],
+        "base",
+        "website",
+      );
+
+      expect(result.find((e) => e.name === "timezone")).toMatchObject({
+        name: "timezone",
+        value: "UTC",
+        origin: { code: "base", level: "website" },
+      });
+    });
+
+    test("overrides existing entries and updates origin to current scope", () => {
+      const result = mergeScopes(
+        existing,
+        [{ name: "currency", value: "EUR" }],
+        "base",
+        "website",
+      );
+
+      expect(result.find((e) => e.name === "currency")).toMatchObject({
+        value: "EUR",
+        origin: { code: "base", level: "website" },
+      });
+    });
+
+    test("preserves entries not in the requested list", () => {
+      const result = mergeScopes(
+        existing,
+        [{ name: "currency", value: "EUR" }],
+        "base",
+        "website",
+      );
+
+      expect(result.find((e) => e.name === "locale")).toMatchObject({
+        value: "en_US",
+        origin: { code: "global", level: "global" },
+      });
+    });
+
+    test("removes an existing entry when requested value is null (unset)", () => {
+      const result = mergeScopes(
+        existing,
+        [{ name: "currency", value: null }],
+        "base",
+        "website",
+      );
+
+      expect(result.find((e) => e.name === "currency")).toBeUndefined();
+    });
+
+    test("keeps all other entries intact when unsetting one field", () => {
+      const result = mergeScopes(
+        existing,
+        [{ name: "currency", value: null }],
+        "base",
+        "website",
+      );
+
+      expect(result.find((e) => e.name === "locale")).toBeDefined();
+      expect(result).toHaveLength(existing.length - 1);
+    });
+
+    test("unsetting a field that does not exist in persisted config is a no-op", () => {
+      const result = mergeScopes(
+        existing,
+        [{ name: "nonExistent", value: null }],
+        "base",
+        "website",
+      );
+
+      expect(result).toHaveLength(existing.length);
+    });
+
+    test("handles a mix of set, override, and unset operations in one call", () => {
+      const result = mergeScopes(
+        existing,
+        [
+          { name: "currency", value: "GBP" }, // override
+          { name: "locale", value: null }, // unset
+          { name: "newField", value: "newVal" }, // add
+        ],
+        "base",
+        "website",
+      );
+
+      expect(result.find((e) => e.name === "currency")?.value).toBe("GBP");
+      expect(result.find((e) => e.name === "locale")).toBeUndefined();
+      expect(result.find((e) => e.name === "newField")?.value).toBe("newVal");
+    });
+
+    test("returns empty array when both inputs are empty", () => {
+      expect(mergeScopes([], [], "base", "website")).toEqual([]);
+    });
+
+    test("returns requested entries when existing is empty", () => {
+      const result = mergeScopes(
+        [],
+        [{ name: "field", value: "value" }],
+        "base",
+        "website",
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ name: "field", value: "value" });
+    });
+
+    test("unsetting from empty existing is a no-op", () => {
+      const result = mergeScopes(
+        [],
+        [{ name: "field", value: null }],
+        "base",
+        "website",
+      );
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description
  - Add `PATCH ` handler to the config runtime action accepting partial payloads and null values for unsetting fields
  - Deprecate `PUT ` (still functional, returns `Deprecation: true` header)
  - Widen `sanitizeRequestEntries` to accept nullable config entries
  - Add unit tests covering PATCH semantics, null pass-through, masked-password behaviour, and deprecation header

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.