### PR TITLE
CEXT-6073: add AGENTS.md and CLAUDE.md with repo conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Claude Code — Repo Conventions
+
+## Commits
+
+- Keep commit messages terse (e.g. `fix auth token refresh`)
+
+## Branches
+
+- Prefix with the Jira ticket (e.g. `CEXT-1234/short-description`)
+
+## Git push
+
+- Always run `pnpm test` and `pnpm typecheck` before pushing (`pnpm check:ci` already runs on commit via lint-staged)
+- Always ask before pushing code
+
+## Pull requests
+
+- Always ask before creating a PR
+- Prefix the PR title with the Jira ticket (e.g. `CEXT-1234: short description`)
+- Always follow `.github/PULL_REQUEST_TEMPLATE.md` when writing PR descriptions
+
+## Changesets
+
+- Every code change that requires a release must include a changeset (test-only changes do not need one)
+- Create one with `pnpm changeset add --empty`, then edit the generated `.changeset/<name>.md` file
+- Changeset messages must be user-facing and concise — avoid implementation details
+- Derive the bump type from semver rules:
+  - `patch` — bug fixes, no API surface change
+  - `minor` — additive non-breaking changes (new exports, new optional fields, enriched responses)
+  - `major` — breaking changes (removed exports, required fields added to input/write types, renamed types)
+- If the bump type is ambiguous, ask before proceeding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@
   - `minor` — additive non-breaking changes (new exports, new optional fields, enriched responses)
   - `major` — breaking changes (removed exports, required fields added to input/write types, renamed types)
 - If the bump type is ambiguous, ask before proceeding
+- Before each commit, check if the changeset message still accurately describes the change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Description

Adds a `AGENTS.md` and `CLAUDE.md` file to the repo root so Claude Code automatically picks up project conventions at the start of every session. Covers commit/branch naming, pre-push checks, PR creation, and changeset rules.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-6073

## Motivation and Context

Avoids having to repeat project conventions in every Claude Code session.

## How Has This Been Tested?

Manual — no code changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.