### PR TITLE
Add header template for source files in `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@
 
   ```ts
   /*
-   * Copyright 2026 Adobe. All rights reserved.
+   * Copyright <current_year> Adobe. All rights reserved.
    * This file is licensed to you under the Apache License, Version 2.0 (the "License");
    * you may not use this file except in compliance with the License. You may obtain a copy
    * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,24 @@
 
 # Workflow
 
+## Files
+
+- Every source file **that supports comments** needs to include the following header, where <current_year> is the current calendar year.
+
+  ```ts
+  /*
+   * Copyright 2026 Adobe. All rights reserved.
+   * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License. You may obtain a copy
+   * of the License at http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software distributed under
+   * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+   * OF ANY KIND, either express or implied. See the License for the specific language
+   * governing permissions and limitations under the License.
+   */
+  ```
+
 ## Commits
 
 - Keep commit messages terse (e.g. `fix auth token refresh`)


### PR DESCRIPTION
## Description

Add a simple workflow requirement for `AGENTS.md` that require adding the copyright header