### PR TITLE
Revert "CEXT-6105: Use global as default level in byCode()"

### DIFF
--- a/.changeset/open-rules-clap.md
+++ b/.changeset/open-rules-clap.md
@@ -1,5 +1,0 @@
----
-"@adobe/aio-commerce-lib-config": minor
----
-
-Make scope selector optional in getConfiguration, getConfigurationByKey and setConfiguration, defaulting to the global scope

--- a/packages/aio-commerce-lib-config/docs/usage.md
+++ b/packages/aio-commerce-lib-config/docs/usage.md
@@ -178,13 +178,10 @@ import {
   byCodeAndLevel,
 } from "@adobe/aio-commerce-lib-config";
 
-// Get configuration for the global scope (selector is optional, defaults to global)
-const config = await getConfiguration();
-
 // Get configuration by scope ID
 const config1 = await getConfiguration(byScopeId("scope-id-123"));
 
-// Get configuration by scope code (uses default level global)
+// Get configuration by scope code (uses default level base)
 const config2 = await getConfiguration(byCode("us-east"));
 
 // Get configuration by scope code and level

--- a/packages/aio-commerce-lib-config/source/config-manager.ts
+++ b/packages/aio-commerce-lib-config/source/config-manager.ts
@@ -10,16 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { byCode } from "#config-utils";
 import {
   requireGlobalSchema,
   setGlobalSchema,
 } from "#modules/schema/config-schema-repository";
-import {
-  DEFAULT_CACHE_TIMEOUT,
-  DEFAULT_CUSTOM_SCOPE_LEVEL,
-  DEFAULT_NAMESPACE,
-} from "#utils/constants";
+import { DEFAULT_CACHE_TIMEOUT, DEFAULT_NAMESPACE } from "#utils/constants";
 import { setGlobalStateOptions } from "#utils/repository";
 
 import {
@@ -308,7 +303,7 @@ export async function unsyncCommerceScopes() {
  * ```
  */
 export async function getConfiguration(
-  selector: SelectorBy = byCode(DEFAULT_CUSTOM_SCOPE_LEVEL),
+  selector: SelectorBy,
   options?: ConfigOptions,
 ) {
   const context = {
@@ -360,7 +355,7 @@ export async function getConfiguration(
  */
 export async function getConfigurationByKey(
   configKey: string,
-  selector: SelectorBy = byCode(DEFAULT_CUSTOM_SCOPE_LEVEL),
+  selector: SelectorBy,
   options?: ConfigOptions,
 ) {
   const context = {
@@ -430,7 +425,7 @@ export async function getConfigurationByKey(
  */
 export async function setConfiguration(
   request: SetConfigurationRequest,
-  selector: SelectorBy = byCode(DEFAULT_CUSTOM_SCOPE_LEVEL),
+  selector: SelectorBy,
   options?: ConfigOptions,
 ) {
   const context = {

--- a/packages/aio-commerce-lib-config/source/config-utils.ts
+++ b/packages/aio-commerce-lib-config/source/config-utils.ts
@@ -155,7 +155,7 @@ export function deriveScopeFromId(
 /**
  * Derives scope from code with optional level (applies default if missing)
  * @param code - The code of the scope to find.
- * @param level - The level of the scope to find (optional, defaults to global level).
+ * @param level - The level of the scope to find (optional, defaults to base level).
  * @param tree - The scope tree to search.
  * @returns The derived scope information including code, level, id, and path.
  */

--- a/packages/aio-commerce-lib-config/source/types/api.ts
+++ b/packages/aio-commerce-lib-config/source/types/api.ts
@@ -101,7 +101,7 @@ export type CustomScopeInput = {
   code: string;
   /** Human-readable label for the scope. */
   label: string;
-  /** Optional level. Defaults to global level if not provided. */
+  /** Optional level. Defaults to base level if not provided. */
   level?: string;
   /** Whether the scope configuration can be edited. */
   is_editable: boolean;

--- a/packages/aio-commerce-lib-config/source/utils/constants.ts
+++ b/packages/aio-commerce-lib-config/source/utils/constants.ts
@@ -20,4 +20,4 @@ export const DEFAULT_NAMESPACE = "aio-commerce-config";
 export const DEFAULT_CACHE_TIMEOUT = 300;
 
 /** Default custom scope level. */
-export const DEFAULT_CUSTOM_SCOPE_LEVEL = "global";
+export const DEFAULT_CUSTOM_SCOPE_LEVEL = "base";

--- a/packages/aio-commerce-lib-config/test/fixtures/scope-tree.ts
+++ b/packages/aio-commerce-lib-config/test/fixtures/scope-tree.ts
@@ -68,13 +68,13 @@ export const mockScopeTree: ScopeTree = [
     ],
   },
 
-  // Default level when using `byCode` is `global`. For tests to be able to test
+  // Default level when using `byCode` is `base`. For tests to be able to test
   // any path using the above selector we need a scope with that level
   {
-    id: "id-global-region",
-    code: "global_region",
-    label: "Global Region",
-    level: "global",
+    id: "id-base-region",
+    code: "base_region",
+    label: "Base Region",
+    level: "base",
     is_editable: true,
     is_final: true,
     is_removable: true,

--- a/packages/aio-commerce-lib-config/test/integration/config-manager.test.ts
+++ b/packages/aio-commerce-lib-config/test/integration/config-manager.test.ts
@@ -325,31 +325,29 @@ describe("config-manager", () => {
 
   test("resolves scope by code only using byCode selector", async () => {
     await configRepository.saveConfig(
-      "global_region",
-      buildPayload("id-global-region", "global_region", "global", [
+      "base_region",
+      buildPayload("id-base-region", "base_region", "base", [
         {
           name: "currency",
           value: "AUD",
-          origin: { code: "global_region", level: "global" },
+          origin: { code: "base_region", level: "base" },
         },
       ]),
     );
 
-    const result = await getConfiguration(byCode("global_region"));
-    expect(result.scope.code).toBe("global_region");
-    expect(result.scope.level).toBe("global");
+    const result = await getConfiguration(byCode("base_region"));
+    expect(result.scope.code).toBe("base_region");
     expect(result.config.find((e) => e.name === "currency")?.value).toBe("AUD");
   });
 
   test("sets configuration using byCode selector", async () => {
     await setConfiguration(
       { config: [{ name: "currency", value: "NZD" }] },
-      byCode("global_region"),
+      byCode("base_region"),
     );
 
-    const result = await getConfiguration(byCode("global_region"));
-    expect(result.scope.code).toBe("global_region");
-    expect(result.scope.level).toBe("global");
+    const result = await getConfiguration(byCode("base_region"));
+    expect(result.scope.code).toBe("base_region");
     expect(result.config.find((e) => e.name === "currency")?.value).toBe("NZD");
   });
 
@@ -362,27 +360,6 @@ describe("config-manager", () => {
     const result = await getConfiguration(byScopeId("id-global"));
     expect(result.scope.id).toBe("id-global");
     expect(result.config.find((e) => e.name === "currency")?.value).toBe("SEK");
-  });
-
-  test("resolves to global scope when no selector is provided", async () => {
-    const result = await getConfiguration();
-    expect(result.scope.code).toBe("global");
-    expect(result.scope.level).toBe("global");
-  });
-
-  test("sets configuration using default global selector when no selector is provided", async () => {
-    await setConfiguration({ config: [{ name: "currency", value: "EUR" }] });
-
-    const result = await getConfiguration();
-    expect(result.scope.code).toBe("global");
-    expect(result.scope.level).toBe("global");
-    expect(result.config.find((e) => e.name === "currency")?.value).toBe("EUR");
-  });
-
-  test("schema defaults have system level as origin", async () => {
-    const result = await getConfiguration(byCodeAndLevel("global", "global"));
-    const schemaDefault = result.config.find((e) => e.name === "currency");
-    expect(schemaDefault?.origin.level).toBe("system");
   });
 
   test("throws when setting a password field without an encryption key", async () => {

--- a/packages/aio-commerce-lib-config/test/integration/get-config-by-key.test.ts
+++ b/packages/aio-commerce-lib-config/test/integration/get-config-by-key.test.ts
@@ -250,23 +250,22 @@ describe("getConfigurationByKey", () => {
 
   test("resolves scope using byCode selector", async () => {
     await configRepository.saveConfig(
-      "global_region",
-      buildPayload("id-global-region", "global_region", "global", [
+      "base_region",
+      buildPayload("id-base-region", "base_region", "base", [
         {
           name: "currency",
           value: "CHF",
-          origin: { code: "global_region", level: "global" },
+          origin: { code: "base_region", level: "base" },
         },
       ]),
     );
 
     const result = await getConfigurationByKey(
       "currency",
-      byCode("global_region"),
+      byCode("base_region"),
     );
 
-    expect(result.scope.code).toBe("global_region");
-    expect(result.scope.level).toBe("global");
+    expect(result.scope.code).toBe("base_region");
     expect(result.config?.value).toBe("CHF");
   });
 
@@ -289,24 +288,6 @@ describe("getConfigurationByKey", () => {
 
     expect(result.scope.id).toBe("id-global");
     expect(result.config?.value).toBe("SGD");
-  });
-
-  test("resolves to global scope when no selector is provided", async () => {
-    await configRepository.saveConfig(
-      "global",
-      buildPayload("id-global", "global", "global", [
-        {
-          name: "currency",
-          value: "USD",
-          origin: { code: "global", level: "global" },
-        },
-      ]),
-    );
-
-    const result = await getConfigurationByKey("currency");
-    expect(result.scope.code).toBe("global");
-    expect(result.scope.level).toBe("global");
-    expect(result.config?.value).toBe("USD");
   });
 
   test("returns scope information alongside the config value", async () => {


### PR DESCRIPTION
Reverts adobe/aio-commerce-sdk#406