### PR TITLE
CEXT-6093: syncImsCredentials crashes when .env file does not exist

### DIFF
--- a/.changeset/wacky-rice-tie.md
+++ b/.changeset/wacky-rice-tie.md
@@ -1,0 +1,6 @@
+---
+"@adobe/aio-commerce-lib-auth": patch
+"@aio-commerce-sdk/scripting-utils": patch
+---
+
+Fix `syncImsCredentials` crashing when `.env` file does not exist; warns with an actionable message when credentials cannot be synced

--- a/packages-private/scripting-utils/source/env.ts
+++ b/packages-private/scripting-utils/source/env.ts
@@ -15,7 +15,7 @@
  * @packageDocumentation
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 // @ts-expect-error - The library doesn't export types.
@@ -106,17 +106,26 @@ function resolveImsS2SContext(): Promise<ImsContext | null> {
   return context.get(credential);
 }
 
+export type SyncImsCredentialsResult =
+  | { ok: true }
+  | { ok: false; reason: "missing-env" | "no-ims-context" };
+
 /**
  * Syncs the IMS credentials environment variables from the configured IMS context in
- * the .env file, in a way that is compatible with `@adobe/aio-commerce-lib-auth`
+ * the .env file, in a way that is compatible with `@adobe/aio-commerce-lib-auth`.
  */
-export async function syncImsCredentials() {
+export async function syncImsCredentials(): Promise<SyncImsCredentialsResult> {
   const envPath = resolveEnvPath();
+
+  if (!existsSync(envPath)) {
+    return { ok: false, reason: "missing-env" };
+  }
+
   const envVars = dotenv.parse(readFileSync(envPath, "utf8"));
   const imsContext = await resolveImsS2SContext();
 
   if (!imsContext) {
-    return;
+    return { ok: false, reason: "no-ims-context" };
   }
 
   const { data } = imsContext;
@@ -131,4 +140,6 @@ export async function syncImsCredentials() {
       replaceEnvVar(envPath, oauthKey, value);
     }
   }
+
+  return { ok: true };
 }

--- a/packages-private/scripting-utils/test/env.test.ts
+++ b/packages-private/scripting-utils/test/env.test.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -46,6 +46,23 @@ describe("syncImsCredentials", () => {
     delete process.env.INIT_CWD;
   });
 
+  test("should do nothing when .env file does not exist", async () => {
+    vi.mocked(config.get).mockReturnValue([
+      { integration_type: "oauth_server_to_server", name: "my-s2s-context" },
+    ]);
+    vi.mocked(context.get).mockResolvedValue({
+      name: "my-s2s-context",
+      data: { client_id: "test-client-id" },
+    });
+
+    await withTempFiles({}, async (tempDir) => {
+      process.env.INIT_CWD = tempDir;
+      const result = await syncImsCredentials();
+      expect(result).toEqual({ ok: false, reason: "missing-env" });
+      expect(existsSync(join(tempDir, ".env"))).toBe(false);
+    });
+  });
+
   test("should do nothing when no IMS context is found", async () => {
     vi.mocked(config.get).mockReturnValue([]);
     await withTempFiles(
@@ -54,8 +71,9 @@ describe("syncImsCredentials", () => {
       },
       async (tempDir) => {
         process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        const result = await syncImsCredentials();
 
+        expect(result).toEqual({ ok: false, reason: "no-ims-context" });
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toBe("SOME_VAR=value\n");
       },
@@ -73,8 +91,9 @@ describe("syncImsCredentials", () => {
       },
       async (tempDir) => {
         process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        const result = await syncImsCredentials();
 
+        expect(result).toEqual({ ok: false, reason: "no-ims-context" });
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toBe("SOME_VAR=value\n");
       },

--- a/packages/aio-commerce-lib-auth/source/commands/sync-ims-credentials.ts
+++ b/packages/aio-commerce-lib-auth/source/commands/sync-ims-credentials.ts
@@ -7,7 +7,28 @@ export async function run() {
   consola.start("Syncing IMS credentials...");
 
   try {
-    await syncImsCredentials();
+    const result = await syncImsCredentials();
+
+    if (!result.ok) {
+      switch (result.reason) {
+        case "missing-env":
+          consola.warn(
+            ".env not found — run `aio app use` to configure your workspace.",
+          );
+          break;
+        case "no-ims-context":
+          consola.warn(
+            "No IMS context configured — run `aio login` to authenticate.",
+          );
+          break;
+        default: {
+          // exhaustiveness check — errors if a new reason is added without handling it
+          const _: never = result.reason;
+        }
+      }
+      return;
+    }
+
     consola.success(
       "IMS credentials successfully synced to their AIO_COMMERCE_IMS_AUTH counterparts!",
     );


### PR DESCRIPTION
## Description

`syncImsCredentials` called `readFileSync` on the `.env` file before checking whether it exists, crashing with ENOENT on fresh projects that haven't run `aio app use` yet. The function now returns a discriminated union so callers can surface an actionable message per failure reason.

## Related Issue

N/A

## Motivation and Context

The `commerce-app-init` skill being added in https://github.com/adobe/aio-commerce-sdk/pull/428 runs `syncImsCredentials` as part of the post-init setup. On a brand-new project there is no `.env` file yet, so the skill was crashing instead of warning gracefully. This fix makes the skill resilient to that state.

## How Has This Been Tested?

Added a unit test covering the missing `.env` case. All existing tests pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.