### PR TITLE
RENOVATE: run code:fix after upgrades to auto-apply linting fixes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,10 @@
 
   "labels": ["dependencies"],
   "postUpdateOptions": ["pnpmDedupe"],
+  "postUpgradeTasks": {
+    "commands": ["pnpm code:fix"],
+    "executionMode": "branch"
+  },
   "packageRules": [
     {
       "description": "Update tsdown and rolldown",


### PR DESCRIPTION
## Description

Adds `postUpgradeTasks` to the Renovate config so that `pnpm code:fix` runs after each dependency upgrade branch is created. This auto-applies any fixable Biome lint/format issues introduced by a new version before CI runs.

## Motivation and Context

PR #422 (all non-major deps) failed because a Biome update introduced a new `lint/style/useReadonlyClassProperties` rule that flagged existing code. The errors were auto-fixable, but Renovate had no way to apply them. With this change, Renovate will run `pnpm code:fix` on each upgrade branch, preventing this class of failure.

Note: `postUpgradeTasks` requires the Renovate instance to allowlist the command via `allowedPostUpgradeCommands`. If not configured at the instance level, the task is silently skipped.

## How Has This Been Tested?

Config-only change; verified `pnpm code:fix` runs `biome check --write` across all packages via Turbo.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] All new and existing tests passed.