### PR TITLE
CEXT-6117: mark Admin UI SDK APIs as experimental

### DIFF
--- a/.changeset/clear-falcons-tell.md
+++ b/.changeset/clear-falcons-tell.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Mark Admin UI SDK APIs as experimental.

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -464,6 +464,8 @@ export default defineCustomInstallationStep(async (config, context) => {
 
 #### Admin UI SDK Configuration
 
+> **Experimental:** Admin UI SDK support is not yet production-ready. The API may change in future releases.
+
 The `adminUiSdk.registration` field declares the registration payload served by the Admin UI SDK runtime action. When defined, `init` and `generate all` automatically wire up the `commerce/backend-ui/1` extension, including the generated runtime action and the `pre-app-build` hook that keeps it in sync with your config. For details on each extension point, see the [Admin UI SDK Extension Points documentation](https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/extension-points/).
 
 ```javascript

--- a/packages/aio-commerce-lib-app/source/actions/registration.ts
+++ b/packages/aio-commerce-lib-app/source/actions/registration.ts
@@ -49,6 +49,7 @@ router.get("/", {
 /**
  * Factory to create the route handler for the `registration` action.
  * @param args - The registration configuration to inline in the action.
+ * @experimental
  */
 export const registrationRuntimeAction =
   ({ registration }: RegistrationActionArgs) =>

--- a/packages/aio-commerce-lib-app/source/config/schema/admin-ui-sdk.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/admin-ui-sdk.ts
@@ -256,44 +256,80 @@ const AdminUiSdkRegistrationSchema = v.object({
   bannerNotification: v.optional(BannerNotificationSchema),
 });
 
-/** Schema for Admin UI SDK configuration. */
+/**
+ * Schema for Admin UI SDK configuration.
+ * @experimental
+ */
 export const AdminUiSdkSchema = v.object({
   registration: AdminUiSdkRegistrationSchema,
 });
 
-/** The Admin UI SDK configuration for an Adobe Commerce application. */
+/**
+ * The Admin UI SDK configuration for an Adobe Commerce application.
+ * @experimental
+ */
 export type AdminUiSdkConfiguration = v.InferInput<typeof AdminUiSdkSchema>;
 
-/** The Admin UI SDK registration configuration. */
+/**
+ * The Admin UI SDK registration configuration.
+ * @experimental
+ */
 export type AdminUiSdkRegistration = v.InferInput<
   typeof AdminUiSdkRegistrationSchema
 >;
 
-/** An order mass action registration entry (uses `selectionLimit`). */
+/**
+ * An order mass action registration entry (uses `selectionLimit`).
+ * @experimental
+ */
 export type OrderMassAction = v.InferInput<typeof OrderMassActionSchema>;
 
-/** A product mass action registration entry (uses `productSelectLimit`). */
+/**
+ * A product mass action registration entry (uses `productSelectLimit`).
+ * @experimental
+ */
 export type ProductMassAction = v.InferInput<typeof ProductMassActionSchema>;
 
-/** A customer mass action registration entry (uses `customerSelectLimit`). */
+/**
+ * A customer mass action registration entry (uses `customerSelectLimit`).
+ * @experimental
+ */
 export type CustomerMassAction = v.InferInput<typeof CustomerMassActionSchema>;
 
-/** An order view button registration entry. */
+/**
+ * An order view button registration entry.
+ * @experimental
+ */
 export type OrderViewButton = v.InferInput<typeof OrderViewButtonSchema>;
 
-/** A custom fee registration entry. */
+/**
+ * A custom fee registration entry.
+ * @experimental
+ */
 export type CustomFee = v.InferInput<typeof CustomFeeSchema>;
 
-/** Grid columns registration configuration. */
+/**
+ * Grid columns registration configuration.
+ * @experimental
+ */
 export type GridColumns = v.InferInput<typeof GridColumnsSchema>;
 
-/** Banner notification registration configuration. */
+/**
+ * Banner notification registration configuration.
+ * @experimental
+ */
 export type BannerNotification = v.InferInput<typeof BannerNotificationSchema>;
 
-/** A menu item registration entry. */
+/**
+ * A menu item registration entry.
+ * @experimental
+ */
 export type MenuItem = v.InferInput<typeof MenuItemSchema>;
 
-/** Check if config has Admin UI SDK registration configuration. */
+/**
+ * Check if config has Admin UI SDK registration configuration.
+ * @experimental
+ */
 export function hasAdminUiSdk(
   config: CommerceAppConfigOutputModel,
 ): config is AdminUiSdkConfig {


### PR DESCRIPTION
## Description

Marks all public Admin UI SDK APIs as `@experimental` in JSDoc and adds an experimental callout to the documentation. This unblocks releasing the rest of the SDK without implying Admin UI SDK is production-ready.

## Related Issue

[CEXT-6117](https://jira.corp.adobe.com/browse/CEXT-6117)

## Motivation and Context

Admin UI SDK support is not yet production-ready. Adding `@experimental` tags to the public API surface and a prose callout in `usage.md` sets the right expectation for consumers without requiring a separate package or version scheme.

## How Has This Been Tested?

Typecheck and full test suite pass with no regressions.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.