### PR TITLE
CEXT-6232: Getting 400 in event subscription during installation

### DIFF
--- a/.changeset/quick-pens-shake.md
+++ b/.changeset/quick-pens-shake.md
@@ -5,3 +5,5 @@
 Fix event subscriptions failing with 400 when a Commerce event provider exists with the same instance ID but a stale provider ID from a previous installation.
 
 Add character validation to provider and event label/description fields in the eventing schema, rejecting values with characters not accepted by the Adobe I/O Events API (valid characters: letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /).
+
+Add validation for at least one field requirement in the Commerce event `fields` arrays.

--- a/.changeset/quick-pens-shake.md
+++ b/.changeset/quick-pens-shake.md
@@ -1,0 +1,7 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Fix event subscriptions failing with 400 when a Commerce event provider exists with the same instance ID but a stale provider ID from a previous installation.
+
+Add character validation to provider and event label/description fields in the eventing schema, rejecting values with characters not accepted by the Adobe I/O Events API (valid characters: letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /).

--- a/packages/aio-commerce-lib-app/source/commands/init/constants.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/constants.ts
@@ -57,7 +57,7 @@ export const DOMAIN_DEFAULTS = {
       events: [
         {
           name: "plugin.sample_event",
-          fields: [],
+          fields: [{ name: "*" }],
 
           label: "Sample Event",
           description: "Use case description for the event.",

--- a/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
@@ -223,7 +223,7 @@ const CommerceEventSchema = v.object({
       commerceEventFieldSchema(),
       "Expected an array of event field objects with a 'name' property",
     ),
-    v.minLength(1, "Commerce event must have at least one field"),
+    v.minLength(1, "The Commerce event configuration must define at least one field"),
   ),
   rules: v.optional(
     v.array(

--- a/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
@@ -109,6 +109,14 @@ function fieldNameSchema() {
   );
 }
 
+/** Validates that a text field contains only characters accepted by the Adobe I/O Events API. */
+function ioEventsTextSchema(name: string) {
+  return v.regex(
+    IO_EVENTS_TEXT_REGEX,
+    `${name} can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /`,
+  );
+}
+
 /**
  * Schema for field objects in Commerce events.
  * Each field has a required name and an optional source.
@@ -124,10 +132,7 @@ function commerceEventFieldSchema() {
 const ProviderSchema = v.object({
   label: v.pipe(
     nonEmptyStringValueSchema("provider label"),
-    v.regex(
-      IO_EVENTS_TEXT_REGEX,
-      "Provider label can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
-    ),
+    ioEventsTextSchema("Provider label"),
     v.maxLength(
       MAX_LABEL_LENGTH,
       `The provider label must not be longer than ${MAX_LABEL_LENGTH} characters`,
@@ -135,10 +140,7 @@ const ProviderSchema = v.object({
   ),
   description: v.pipe(
     nonEmptyStringValueSchema("provider description"),
-    v.regex(
-      IO_EVENTS_TEXT_REGEX,
-      "Provider description can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
-    ),
+    ioEventsTextSchema("Provider description"),
     v.maxLength(
       MAX_DESCRIPTION_LENGTH,
       `The provider description must not be longer than ${MAX_DESCRIPTION_LENGTH} characters`,
@@ -159,10 +161,7 @@ const ProviderSchema = v.object({
 const BaseEventSchema = v.object({
   label: v.pipe(
     nonEmptyStringValueSchema("event label"),
-    v.regex(
-      IO_EVENTS_TEXT_REGEX,
-      "Event label can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
-    ),
+    ioEventsTextSchema("Event label"),
     v.maxLength(
       MAX_LABEL_LENGTH,
       `The event label must not be longer than ${MAX_LABEL_LENGTH} characters`,
@@ -171,10 +170,7 @@ const BaseEventSchema = v.object({
 
   description: v.pipe(
     nonEmptyStringValueSchema("event description"),
-    v.regex(
-      IO_EVENTS_TEXT_REGEX,
-      "Event description can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
-    ),
+    ioEventsTextSchema("Event description"),
     v.maxLength(
       MAX_DESCRIPTION_LENGTH,
       `The event description must not be longer than ${MAX_DESCRIPTION_LENGTH} characters`,

--- a/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
@@ -218,9 +218,12 @@ const CommerceEventSchema = v.object({
   ...BaseEventSchema.entries,
 
   name: commerceEventNameSchema(),
-  fields: v.array(
-    commerceEventFieldSchema(),
-    "Expected an array of event field objects with a 'name' property",
+  fields: v.pipe(
+    v.array(
+      commerceEventFieldSchema(),
+      "Expected an array of event field objects with a 'name' property",
+    ),
+    v.minLength(1, "Commerce event must have at least one field"),
   ),
   rules: v.optional(
     v.array(

--- a/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
@@ -49,6 +49,13 @@ const EXTERNAL_EVENT_NAME_REGEX = /^[\w\-_.]+$/;
 const FIELD_NAME_REGEX = /^([a-zA-Z0-9_\-.[\]]+|\*)$/;
 
 /**
+ * Regex for Adobe I/O Events API text fields (label, description).
+ * Valid characters per API: letters, numbers, spaces, underscores, hyphens,
+ * dots, colons, parentheses, commas, @, and /.
+ */
+const IO_EVENTS_TEXT_REGEX = /^[a-zA-Z0-9 _.:()\-,@/]+$/;
+
+/**
  * Schema for Commerce event names.
  * Validates that the event name starts with "plugin." or "observer."
  * followed by one or more dot-separated lowercase segments containing letters
@@ -117,6 +124,10 @@ function commerceEventFieldSchema() {
 const ProviderSchema = v.object({
   label: v.pipe(
     nonEmptyStringValueSchema("provider label"),
+    v.regex(
+      IO_EVENTS_TEXT_REGEX,
+      "Provider label can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
+    ),
     v.maxLength(
       MAX_LABEL_LENGTH,
       `The provider label must not be longer than ${MAX_LABEL_LENGTH} characters`,
@@ -124,6 +135,10 @@ const ProviderSchema = v.object({
   ),
   description: v.pipe(
     nonEmptyStringValueSchema("provider description"),
+    v.regex(
+      IO_EVENTS_TEXT_REGEX,
+      "Provider description can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
+    ),
     v.maxLength(
       MAX_DESCRIPTION_LENGTH,
       `The provider description must not be longer than ${MAX_DESCRIPTION_LENGTH} characters`,
@@ -144,6 +159,10 @@ const ProviderSchema = v.object({
 const BaseEventSchema = v.object({
   label: v.pipe(
     nonEmptyStringValueSchema("event label"),
+    v.regex(
+      IO_EVENTS_TEXT_REGEX,
+      "Event label can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
+    ),
     v.maxLength(
       MAX_LABEL_LENGTH,
       `The event label must not be longer than ${MAX_LABEL_LENGTH} characters`,
@@ -152,6 +171,10 @@ const BaseEventSchema = v.object({
 
   description: v.pipe(
     nonEmptyStringValueSchema("event description"),
+    v.regex(
+      IO_EVENTS_TEXT_REGEX,
+      "Event description can only contain letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /",
+    ),
     v.maxLength(
       MAX_DESCRIPTION_LENGTH,
       `The event description must not be longer than ${MAX_DESCRIPTION_LENGTH} characters`,

--- a/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/eventing.ts
@@ -223,7 +223,10 @@ const CommerceEventSchema = v.object({
       commerceEventFieldSchema(),
       "Expected an array of event field objects with a 'name' property",
     ),
-    v.minLength(1, "The Commerce event configuration must define at least one field"),
+    v.minLength(
+      1,
+      "The Commerce event configuration must define at least one field",
+    ),
   ),
   rules: v.optional(
     v.array(

--- a/packages/aio-commerce-lib-app/source/management/installation/events/helpers.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/events/helpers.ts
@@ -390,7 +390,7 @@ export async function createCommerceProvider(
 /**
  * Creates or retrieves an existing Commerce event provider.
  * @param params - Parameters needed to create or get the Commerce provider.
- * @param existingData - Existing Commerce providers.
+ * @param existingProviders - Existing Commerce providers.
  */
 export async function createOrGetCommerceProvider(
   params: CreateCommerceProviderParams,
@@ -405,11 +405,18 @@ export async function createOrGetCommerceProvider(
   );
 
   if (existing) {
-    logger.info(
-      `Provider "${provider.label}" already exists with ID "${existing.id}", skipping creation.`,
-    );
+    if (existing.provider_id === provider.id) {
+      logger.info(
+        `Provider "${provider.label}" already exists with provider ID "${existing.provider_id}", skipping creation.`,
+      );
 
-    return existing;
+      return existing;
+    }
+
+    logger.warn(
+      `Provider "${provider.label}" exists (instance ID: ${provider.instance_id}) but with a different ` +
+        `provider ID ("${existing.provider_id}" → "${provider.id}"). Registering updated provider in Commerce.`,
+    );
   }
 
   return createCommerceProvider(params);

--- a/packages/aio-commerce-lib-app/source/management/installation/events/helpers.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/events/helpers.ts
@@ -389,6 +389,12 @@ export async function createCommerceProvider(
 
 /**
  * Creates or retrieves an existing Commerce event provider.
+ *
+ * Checks by `provider_id` first, since Commerce validates subscriptions against that field.
+ * A previous partial run may have left multiple records sharing the same `instance_id` but
+ * with different `provider_id` values; checking by `provider_id` first avoids re-creating a
+ * provider that is already correctly registered.
+ *
  * @param params - Parameters needed to create or get the Commerce provider.
  * @param existingProviders - Existing Commerce providers.
  */
@@ -399,23 +405,27 @@ export async function createOrGetCommerceProvider(
   const { context, provider } = params;
   const { logger } = context;
 
-  const existing = findExistingProvider(
+  const existingByProviderId = existingProviders.find(
+    (p) => p.provider_id === provider.id,
+  );
+
+  if (existingByProviderId) {
+    logger.info(
+      `Provider "${provider.label}" already exists with provider ID "${provider.id}", skipping creation.`,
+    );
+
+    return existingByProviderId;
+  }
+
+  const existingByInstanceId = findExistingProvider(
     existingProviders,
     provider.instance_id,
   );
 
-  if (existing) {
-    if (existing.provider_id === provider.id) {
-      logger.info(
-        `Provider "${provider.label}" already exists with provider ID "${existing.provider_id}", skipping creation.`,
-      );
-
-      return existing;
-    }
-
+  if (existingByInstanceId) {
     logger.warn(
       `Provider "${provider.label}" exists (instance ID: ${provider.instance_id}) but with a different ` +
-        `provider ID ("${existing.provider_id}" → "${provider.id}"). Registering updated provider in Commerce.`,
+        `provider ID ("${existingByInstanceId.provider_id}" → "${provider.id}"). Registering updated provider in Commerce.`,
     );
   }
 

--- a/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
@@ -1485,4 +1485,12 @@ describe("validateConfigDomain", () => {
 
     expect(() => validateCommerceAppConfig(config)).not.toThrow();
   });
+
+  test("should throw when commerce event fields array is empty", () => {
+    const config = createCommerceEventConfig("observer.order_placed", {
+      fields: [],
+    });
+
+    expect(() => validateCommerceAppConfig(config)).toThrow();
+  });
 });

--- a/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
@@ -885,6 +885,99 @@ describe("validateConfig", () => {
     expect(() => validateCommerceAppConfig(config)).toThrow();
   });
 
+  test("should throw when provider label contains invalid characters", () => {
+    const config = {
+      metadata: {
+        id: "test-app",
+        displayName: "Test App",
+        description: "A test application",
+        version: "1.0.0",
+      },
+      eventing: {
+        external: [
+          {
+            provider: {
+              label: "Catalog & Sales Rules Events", // & is not a valid character
+              description: "Provider description",
+            },
+            events: [
+              {
+                name: "event",
+                label: "Event",
+                description: "An event",
+                runtimeActions: ["my-package/event-handler"],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(() => validateCommerceAppConfig(config)).toThrow();
+  });
+
+  test("should throw when provider description contains invalid characters", () => {
+    const config = {
+      metadata: {
+        id: "test-app",
+        displayName: "Test App",
+        description: "A test application",
+        version: "1.0.0",
+      },
+      eventing: {
+        external: [
+          {
+            provider: {
+              label: "Provider",
+              description: "Events for <Commerce>", // < and > are not valid characters
+            },
+            events: [
+              {
+                name: "event",
+                label: "Event",
+                description: "An event",
+                runtimeActions: ["my-package/event-handler"],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(() => validateCommerceAppConfig(config)).toThrow();
+  });
+
+  test("should accept provider label with all valid special characters", () => {
+    const config = {
+      metadata: {
+        id: "test-app",
+        displayName: "Test App",
+        description: "A test application",
+        version: "1.0.0",
+      },
+      eventing: {
+        external: [
+          {
+            provider: {
+              label: "Events: (Commerce) v1.0, @Adobe / sales_rules-test.v2",
+              description: "Provider description",
+            },
+            events: [
+              {
+                name: "event",
+                label: "Event",
+                description: "An event",
+                runtimeActions: ["my-package/event-handler"],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(() => validateCommerceAppConfig(config)).not.toThrow();
+  });
+
   test("should throw when commerce event description exceeds max length", () => {
     const config = {
       metadata: {

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/events/helpers.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/events/helpers.test.ts
@@ -614,6 +614,39 @@ describe("onboardCommerceEventing", () => {
     expect(commerceEventsClient.createEventSubscription).toHaveBeenCalledOnce();
   });
 
+  test("skips creation when an existing provider has the correct provider ID but a different instance ID", async () => {
+    const { context, metadata, provider, ioProvider, ioData } =
+      createCommerceOnboardingScenario();
+
+    const { commerceEventsClient } = context;
+
+    const existingCommerceProvider = createMockCommerceEventProvider({
+      provider_id: ioProvider.id,
+      instance_id: "different-instance-id",
+    });
+
+    vi.mocked(commerceEventsClient.createEventSubscription).mockResolvedValue(
+      undefined,
+    );
+
+    const result = await onboardCommerceEventing(
+      { context, metadata, provider, ioData },
+      createMockExistingCommerceEventingData({
+        providers: [existingCommerceProvider],
+      }),
+    );
+
+    expect(commerceEventsClient.createEventProvider).not.toHaveBeenCalled();
+    expect(result.commerceProvider).toEqual({
+      id: existingCommerceProvider.id,
+      provider_id: ioProvider.id,
+      label: existingCommerceProvider.label,
+      description: existingCommerceProvider.description,
+      instance_id: "different-instance-id",
+    });
+    expect(commerceEventsClient.createEventSubscription).toHaveBeenCalledOnce();
+  });
+
   test("rethrows and logs when creating a Commerce provider fails", async () => {
     const { context, metadata, provider, ioData } =
       createCommerceOnboardingScenario();

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/events/helpers.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/events/helpers.test.ts
@@ -573,6 +573,47 @@ describe("onboardCommerceEventing", () => {
     expect(commerceEventsClient.createEventSubscription).not.toHaveBeenCalled();
   });
 
+  test("registers a new Commerce provider when the existing one has a different provider ID", async () => {
+    const { context, metadata, provider, ioProvider, ioData } =
+      createCommerceOnboardingScenario();
+
+    const { commerceEventsClient } = context;
+
+    const staleCommerceProvider = createMockCommerceEventProvider({
+      provider_id: "old-provider-id",
+      instance_id: ioProvider.instance_id,
+    });
+
+    const newCommerceProvider = createMockCommerceEventProvider({
+      provider_id: ioProvider.id,
+      instance_id: ioProvider.instance_id,
+    });
+
+    vi.mocked(commerceEventsClient.createEventProvider).mockResolvedValue(
+      newCommerceProvider,
+    );
+    vi.mocked(commerceEventsClient.createEventSubscription).mockResolvedValue(
+      undefined,
+    );
+
+    const result = await onboardCommerceEventing(
+      { context, metadata, provider, ioData },
+      createMockExistingCommerceEventingData({
+        providers: [staleCommerceProvider],
+      }),
+    );
+
+    expect(commerceEventsClient.createEventProvider).toHaveBeenCalledOnce();
+    expect(result.commerceProvider).toEqual({
+      id: newCommerceProvider.id,
+      provider_id: ioProvider.id,
+      label: newCommerceProvider.label,
+      description: newCommerceProvider.description,
+      instance_id: ioProvider.instance_id,
+    });
+    expect(commerceEventsClient.createEventSubscription).toHaveBeenCalledOnce();
+  });
+
   test("rethrows and logs when creating a Commerce provider fails", async () => {
     const { context, metadata, provider, ioData } =
       createCommerceOnboardingScenario();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


1. Fixed event subscriptions failing with 400 when a Commerce event provider exists with the same instance ID but a stale provider ID from a previous installation.
2. Added validation for at least one field requirement in the Commerce event `fields` arrays.
3. Added character validation to provider and event label/description fields in the eventing schema, rejecting values with characters not accepted by the Adobe I/O Events API (valid characters: letters, numbers, spaces, underscores, hyphens, dots, colons, parentheses, commas, @, and /).

https://jira.corp.adobe.com/browse/CEXT-6232

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
