### PR TITLE
CEXT-6274: fix event subscription rules not forwarded to Commerce API

### DIFF
--- a/.changeset/some-phones-knock.md
+++ b/.changeset/some-phones-knock.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Fix event subscription rules not being forwarded to Commerce when installing an app

--- a/packages/aio-commerce-lib-app/source/management/installation/events/helpers.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/events/helpers.ts
@@ -451,6 +451,7 @@ async function createCommerceEventSubscription(
     name: eventName,
     parent: event.config.name,
     fields: event.config.fields,
+    rules: event.config.rules,
     provider_id: provider.id,
     destination: event.config.destination,
     hipaa_audit_required: event.config.hipaa_audit_required,

--- a/packages/aio-commerce-lib-app/test/fixtures/config.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/config.ts
@@ -34,6 +34,9 @@ const commerceEventingPart = {
           name: "plugin.order_placed",
           label: "Order Placed",
           fields: [{ name: "order_id" }, { name: "customer_id" }],
+          rules: [
+            { field: "order_total", operator: "greaterThan", value: "100" },
+          ],
           runtimeActions: ["my-package/handle-order"],
           description: "Triggered when an order is placed",
         },

--- a/packages/aio-commerce-lib-app/test/integration/management/events.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/management/events.test.ts
@@ -88,6 +88,7 @@ afterEach(() => {
 describe("eventing installation", () => {
   let capture: {
     updateConfiguration: UpdateEventingConfigurationParams | null;
+    subscribeBody: unknown;
   };
 
   beforeEach(() => {
@@ -99,6 +100,7 @@ describe("eventing installation", () => {
 
     capture = {
       updateConfiguration: null,
+      subscribeBody: null,
     };
 
     apiServer.use(
@@ -219,8 +221,12 @@ describe("eventing installation", () => {
         },
       ),
 
-      http.post(`${COMMERCE_BASE_URL}/eventing/eventSubscribe`, () =>
-        HttpResponse.json([]),
+      http.post(
+        `${COMMERCE_BASE_URL}/eventing/eventSubscribe`,
+        async ({ request }) => {
+          capture.subscribeBody = await request.json();
+          return HttpResponse.json([]);
+        },
       ),
     );
   });
@@ -241,6 +247,12 @@ describe("eventing installation", () => {
         workspace_configuration: expect.any(String),
       }),
     });
+
+    expect(capture.subscribeBody).toEqual(
+      expect.objectContaining({
+        event: expect.objectContaining({ rules: commerceEvent.rules }),
+      }),
+    );
 
     expect(result.data).toMatchObject({
       installation: {
@@ -285,6 +297,7 @@ describe("eventing installation", () => {
                           name: `${config.metadata.id}.${commerceEvent.name}`.toLowerCase(),
                           provider_id: "io-provider-commerce",
                           parent: commerceEvent.name,
+                          rules: commerceEvent.rules,
                         },
                       },
                     },

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/events/branch.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/events/branch.test.ts
@@ -141,6 +141,57 @@ describe("events installation module", () => {
         mockContext.commerceEventsClient.getAllEventProviders,
       ).toHaveBeenCalled();
     });
+
+    test("should forward rules to createEventSubscription", async () => {
+      const mockCreateEventSubscription = vi.fn().mockResolvedValue({
+        name: "test-subscription",
+        enabled: true,
+      });
+
+      const mockContext = createMockEventingInstallationContext({
+        params: {
+          AIO_COMMERCE_API_BASE_URL: "https://api.commerce.adobe.com",
+          AIO_COMMERCE_API_FLAVOR: "saas",
+        },
+        ioEventsClient: {
+          getAllEventProviders: vi.fn().mockResolvedValue({
+            _embedded: { providers: [] },
+          }),
+          getAllRegistrations: vi.fn().mockResolvedValue({
+            _embedded: { registrations: [] },
+          }),
+          createEventProvider: vi.fn().mockResolvedValue({
+            id: "provider-123",
+            provider_metadata: "dx_commerce_events",
+          }),
+          createEventMetadataForProvider: vi
+            .fn()
+            .mockResolvedValue({ event_code: "test-event-code" }),
+          createRegistration: vi
+            .fn()
+            .mockResolvedValue({ id: "registration-123" }),
+          deleteRegistration: vi.fn().mockResolvedValue(undefined),
+        },
+        commerceEventsClient: {
+          getAllEventProviders: vi.fn().mockResolvedValue([]),
+          getAllEventSubscriptions: vi.fn().mockResolvedValue([]),
+          updateEventingConfiguration: vi.fn().mockResolvedValue({}),
+          createEventProvider: vi
+            .fn()
+            .mockResolvedValue({ id: "commerce-provider-123" }),
+          createEventSubscription: mockCreateEventSubscription,
+        },
+      });
+
+      await commerceEventsStep.install(configWithCommerceEventing, mockContext);
+
+      const [commerceSource] = configWithCommerceEventing.eventing.commerce;
+      const [event] = commerceSource.events;
+
+      expect(mockCreateEventSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ rules: event.rules }),
+      );
+    });
   });
 
   describe("externalEventsStep leaf step", () => {


### PR DESCRIPTION
## Description

Rules defined on a Commerce event in `app.commerce.config.ts` were silently dropped during installation. The `eventSpec` object built in `createCommerceEventSubscription` included all other event properties but never read `event.config.rules`, so the Commerce API was called without any rules regardless of what the user configured.

## Related Issue

CEXT-6274

## Motivation and Context

Any app relying on conditional event filtering via `rules` in `app.commerce.config.ts` would have those rules ignored at installation time, with no error or warning surfaced to the user.

## How Has This Been Tested?

- Added a unit test asserting `createEventSubscription` is called with the correct `rules` when the event config defines them
- Added an integration test capturing the `eventSubscribe` HTTP request body and asserting it contains the configured rules
- Updated the shared `commerceEventingPart` fixture to include a rule so existing tests exercise the rules path
- All 732 tests pass

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.