### PR TITLE
CEXT-6288: Fix CJS interop for ESM-only dependencies (camelcase, ky)

### DIFF
--- a/.changeset/big-falcons-agree.md
+++ b/.changeset/big-falcons-agree.md
@@ -1,0 +1,7 @@
+---
+"@adobe/aio-commerce-lib-api": patch
+"@adobe/aio-commerce-lib-app": patch
+"@adobe/aio-commerce-lib-core": patch
+---
+
+Fix CJS interop for ESM-only dependencies (`camelcase`, `ky`) on Node.js 22+

--- a/packages/aio-commerce-lib-api/source/lib/commerce/helpers.ts
+++ b/packages/aio-commerce-lib-api/source/lib/commerce/helpers.ts
@@ -16,7 +16,6 @@ import {
   resolveAuthParams,
 } from "@adobe/aio-commerce-lib-auth";
 import { allNonEmpty } from "@adobe/aio-commerce-lib-core/params";
-import * as kyModule from "ky";
 
 import {
   buildImsAuthBeforeRequestHook,
@@ -24,7 +23,7 @@ import {
   isAuthProvider,
 } from "#utils/auth/hooks";
 import { ensureImsScopes } from "#utils/auth/ims-scopes";
-import { optionallyExtendKy } from "#utils/http/ky";
+import { createKy, optionallyExtendKy } from "#utils/http/ky";
 
 import type {
   ImsAuthParams,
@@ -33,11 +32,6 @@ import type {
   IntegrationAuthProvider,
 } from "@adobe/aio-commerce-lib-auth";
 import type { ImsAuthParamsWithOptionalScopes } from "#utils/auth/ims-scopes";
-
-type KyInterop = typeof kyModule.default & {
-  default?: typeof kyModule.default;
-};
-const ky = (kyModule.default as KyInterop).default ?? kyModule.default;
 
 /** A regex matching a regular SaaS API URL, with a tenant ID and optional trailing slash. */
 const COMMERCE_API_URL_REGEX =
@@ -128,7 +122,7 @@ function buildCommerceHttpClientPaaS(
   const commerceUrl = getCommerceUrl(config);
 
   const beforeRequestAuthHook = buildAuthBeforeRequestHook("paas", auth);
-  const httpClient = ky.create({
+  const httpClient = createKy({
     prefixUrl: commerceUrl,
     hooks: {
       beforeRequest: [beforeRequestAuthHook],
@@ -149,7 +143,7 @@ function buildCommerceHttpClientSaaS(
   const commerceUrl = getCommerceUrl(config);
 
   const beforeRequestAuthHook = buildAuthBeforeRequestHook("saas", auth);
-  const httpClient = ky.create({
+  const httpClient = createKy({
     prefixUrl: commerceUrl,
     hooks: {
       beforeRequest: [

--- a/packages/aio-commerce-lib-api/source/lib/commerce/helpers.ts
+++ b/packages/aio-commerce-lib-api/source/lib/commerce/helpers.ts
@@ -16,7 +16,7 @@ import {
   resolveAuthParams,
 } from "@adobe/aio-commerce-lib-auth";
 import { allNonEmpty } from "@adobe/aio-commerce-lib-core/params";
-import ky from "ky";
+import * as kyModule from "ky";
 
 import {
   buildImsAuthBeforeRequestHook,
@@ -33,6 +33,11 @@ import type {
   IntegrationAuthProvider,
 } from "@adobe/aio-commerce-lib-auth";
 import type { ImsAuthParamsWithOptionalScopes } from "#utils/auth/ims-scopes";
+
+type KyInterop = typeof kyModule.default & {
+  default?: typeof kyModule.default;
+};
+const ky = (kyModule.default as KyInterop).default ?? kyModule.default;
 
 /** A regex matching a regular SaaS API URL, with a tenant ID and optional trailing slash. */
 const COMMERCE_API_URL_REGEX =

--- a/packages/aio-commerce-lib-api/source/lib/io-events/helpers.ts
+++ b/packages/aio-commerce-lib-api/source/lib/io-events/helpers.ts
@@ -14,25 +14,19 @@ import {
   forwardImsAuthProvider,
   resolveAuthParams,
 } from "@adobe/aio-commerce-lib-auth";
-import * as kyModule from "ky";
 
 import {
   buildImsAuthBeforeRequestHook,
   isAuthProvider,
 } from "#utils/auth/hooks";
 import { ensureImsScopes } from "#utils/auth/ims-scopes";
-import { optionallyExtendKy } from "#utils/http/ky";
+import { createKy, optionallyExtendKy } from "#utils/http/ky";
 
 import type { IoEventsHttpClientParamsWithRequiredConfig } from "./http-client";
 import type {
   IoEventsHttpClientParams,
   ResolveIoEventsHttpClientParamsOptions,
 } from "./types";
-
-type KyInterop = typeof kyModule.default & {
-  default?: typeof kyModule.default;
-};
-const ky = (kyModule.default as KyInterop).default ?? kyModule.default;
 
 const IO_EVENTS_IMS_REQUIRED_SCOPES = ["adobeio_api"];
 
@@ -51,7 +45,7 @@ export function buildIoEventsHttpClient(
       );
 
   const adobeIoBaseUrl = config.baseUrl;
-  const httpClient = ky.create({
+  const httpClient = createKy({
     prefixUrl: adobeIoBaseUrl,
     headers: {
       Accept: "application/hal+json",

--- a/packages/aio-commerce-lib-api/source/lib/io-events/helpers.ts
+++ b/packages/aio-commerce-lib-api/source/lib/io-events/helpers.ts
@@ -14,7 +14,7 @@ import {
   forwardImsAuthProvider,
   resolveAuthParams,
 } from "@adobe/aio-commerce-lib-auth";
-import ky from "ky";
+import * as kyModule from "ky";
 
 import {
   buildImsAuthBeforeRequestHook,
@@ -28,6 +28,11 @@ import type {
   IoEventsHttpClientParams,
   ResolveIoEventsHttpClientParamsOptions,
 } from "./types";
+
+type KyInterop = typeof kyModule.default & {
+  default?: typeof kyModule.default;
+};
+const ky = (kyModule.default as KyInterop).default ?? kyModule.default;
 
 const IO_EVENTS_IMS_REQUIRED_SCOPES = ["adobeio_api"];
 

--- a/packages/aio-commerce-lib-api/source/utils/http/ky.ts
+++ b/packages/aio-commerce-lib-api/source/utils/http/ky.ts
@@ -10,7 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
+import * as kyModule from "ky";
+
 import type { KyInstance, Options } from "ky";
+
+type KyInterop = KyInstance & { default?: KyInstance };
+const ky = (kyModule.default as KyInterop).default ?? kyModule.default;
+
+/**
+ * Creates a Ky instance with the provided options.
+ * @param options - The options for the Ky instance.
+ */
+export function createKy(options: Options): KyInstance {
+  return ky.create(options);
+}
 
 /**
  * Extends the given Ky instance with the provided options if they are provided.
@@ -18,8 +31,8 @@ import type { KyInstance, Options } from "ky";
  * @param options - The options to extend the Ky instance with.
  */
 export function optionallyExtendKy<TKy extends KyInstance>(
-  ky: TKy,
+  kyInstance: TKy,
   options?: Options | ((parentOptions: Options) => Options),
 ): TKy {
-  return options ? (ky.extend(options) as TKy) : ky;
+  return options ? (kyInstance.extend(options) as TKy) : kyInstance;
 }

--- a/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import camelcase from "camelcase";
+import * as camelcaseModule from "camelcase";
 
 import { hasCustomInstallationSteps } from "#config/schema/installation";
 import { defineLeafStep } from "#management/installation/workflow/step";
@@ -28,6 +28,12 @@ import type {
   AnyStep,
   ExecutionContext,
 } from "#management/installation/workflow/step";
+
+type CamelcaseFn = typeof camelcaseModule.default;
+type CamelcaseInterop = CamelcaseFn & { default?: CamelcaseFn };
+const camelcase =
+  (camelcaseModule.default as CamelcaseInterop).default ??
+  camelcaseModule.default;
 
 function isCustomInstallationStepDefinition(
   obj: unknown,

--- a/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
@@ -29,8 +29,10 @@ import type {
   ExecutionContext,
 } from "#management/installation/workflow/step";
 
-type CamelcaseFn = typeof camelcaseModule.default;
-type CamelcaseInterop = CamelcaseFn & { default?: CamelcaseFn };
+type CamelcaseInterop = typeof camelcaseModule.default & {
+  default?: typeof camelcaseModule.default;
+};
+
 const camelcase =
   (camelcaseModule.default as CamelcaseInterop).default ??
   camelcaseModule.default;

--- a/packages/aio-commerce-lib-core/source/headers/accessor.ts
+++ b/packages/aio-commerce-lib-core/source/headers/accessor.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import camelcase from "camelcase";
+import * as camelcaseModule from "camelcase";
 
 import { getHeader } from "./helpers";
 import { assertRequiredHeaders } from "./validation";
@@ -20,6 +20,12 @@ import type {
   HttpHeaderAccessorMap,
   HttpHeaders,
 } from "./types";
+
+type CamelcaseFn = typeof camelcaseModule.default;
+type CamelcaseInterop = CamelcaseFn & { default?: CamelcaseFn };
+const camelcase =
+  (camelcaseModule.default as CamelcaseInterop).default ??
+  camelcaseModule.default;
 
 const LEADING_UNDERSCORES = /^_+/;
 

--- a/packages/aio-commerce-lib-core/source/headers/accessor.ts
+++ b/packages/aio-commerce-lib-core/source/headers/accessor.ts
@@ -10,8 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import * as camelcaseModule from "camelcase";
-
+import { camelcase } from "./camelcase";
 import { getHeader } from "./helpers";
 import { assertRequiredHeaders } from "./validation";
 
@@ -20,12 +19,6 @@ import type {
   HttpHeaderAccessorMap,
   HttpHeaders,
 } from "./types";
-
-type CamelcaseFn = typeof camelcaseModule.default;
-type CamelcaseInterop = CamelcaseFn & { default?: CamelcaseFn };
-const camelcase =
-  (camelcaseModule.default as CamelcaseInterop).default ??
-  camelcaseModule.default;
 
 const LEADING_UNDERSCORES = /^_+/;
 

--- a/packages/aio-commerce-lib-core/source/headers/camelcase.ts
+++ b/packages/aio-commerce-lib-core/source/headers/camelcase.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import * as camelcaseModule from "camelcase";
+
+type CamelcaseInterop = typeof camelcaseModule.default & {
+  default?: typeof camelcaseModule.default;
+};
+
+export const camelcase =
+  (camelcaseModule.default as CamelcaseInterop).default ??
+  camelcaseModule.default;


### PR DESCRIPTION
## Description

Fixes a runtime error affecting CJS consumers on Node.js 22+ where `require()` of ESM-only packages (`camelcase`, `ky`) returns an ESM namespace object `{ default: fn }`. Rolldown's `__toESM` helper (node mode) then wraps the entire namespace as `.default`, producing double-nesting: `{ default: { default: fn } }`. The call sites end up invoking `camelcase.default` or `ky.default.create` — neither of which is a function.

The fix switches to `import * as` and resolves the actual value with:
```ts
(module.default as Interop).default ?? module.default
```
This peels the extra nesting in CJS environments while falling back to the direct `.default` in ESM (where no double-nesting occurs).

## Related Issue

CEXT-6288

## Motivation and Context

Node.js 22 introduced stable `require()` of ESM-only modules. Bundlers like rolldown pre-date this and their `__toESM` interop helper was designed for CJS modules — it doesn't detect that `require()` returned an ESM namespace, so it double-wraps the default export. This surfaces as:

- `(0, camelcase.default) is not a function` — in `aio-commerce-lib-core` headers
- `ky.default.create is not a function` — in `aio-commerce-lib-api` commerce/io-events helpers
- Same issue in `aio-commerce-lib-app` custom installation scripts

## How Has This Been Tested?

`pnpm test` and `pnpm typecheck` pass across all three affected packages (1038 tests). The fix was also verified by inspecting the generated CJS dist — the resolved constants now correctly emit `module.default.default ?? module.default` at the call sites.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.