### PR TITLE
CEXT-6301: Simplify release promotion and back-sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Collapse auto-generated API reference diffs in GitHub PRs (e.g. the Version Packages PR)
+packages/*/docs/api-reference/** linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Collapse auto-generated API reference diffs in GitHub PRs (e.g. the Version Packages PR)
 packages/*/docs/api-reference/** linguist-generated=true
+packages-private/*/docs/api-reference/** linguist-generated=true

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -461,21 +461,18 @@ You can also request a snapshot from any open PR by commenting `/snapshot`. This
 
 #### Public stable flow (`release`)
 
-> [!IMPORTANT]
-> Both the promotion PR and the back-sync PR **must be merged via a merge commit** (not squash or rebase). This preserves commit SHAs across both branches so that git's merge-base tracking correctly identifies what is already on each branch. Squashing or rebasing creates new SHAs, causing git to treat already-merged commits as new changes and producing conflicts on subsequent syncs.
-
 When ready to publish to npm, use the **Promote to Release** workflow dispatch (`promote.yml`):
 
 1. Trigger it from GitHub Actions, optionally specifying a commit SHA on `main` to promote (defaults to latest).
-2. The workflow creates a branch from that commit and opens a PR into `release`. No config changes needed — changeset files come along unconsumed.
-3. After merging the promotion PR, Changesets creates/updates a `[CI] Release Packages` PR on `release`.
-4. Merging that release PR publishes stable versions to npm, writes changelogs, and automatically opens a back-sync PR from `release` → `main`.
+2. The workflow merges that commit directly into `release` via a merge commit. No config changes needed — changeset files come along unconsumed.
+3. Changesets creates/updates a `[CI] Release Packages` PR on `release`, including regenerated API reference docs.
+4. Merging that PR publishes stable versions to npm and writes changelogs.
 
 If there were snapshot versions like `1.2.5-beta-20260313T120000` on Artifactory, the resulting stable release is `1.2.5`.
 
 #### Back-sync
 
-After a public release, a back-sync PR from `release` → `main` is created automatically. Merging it brings version bumps, updated changelogs, and consumed changeset files back to `main`.
+After a public release, the back-sync is automatic — the workflow merges `release` directly into `main` via a merge commit. No manual step needed.
 
 #### Hotfixes
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -449,23 +449,30 @@ This repository uses two release channels:
   - Uses stable semver and publishes to NPM via the standard changesets flow.
 
 ```mermaid
-flowchart TD
-    PR(["Feature PR"])
-    main(["main"])
-    release(["release"])
-    vpr["[CI] Release Packages PR"]
-    alpha["Artifactory · alpha snapshot"]
-    beta["Artifactory · beta snapshot"]
-    npm["npm · stable release"]
+flowchart LR
+    subgraph main ["main"]
+        direction TB
+        m1(["⬤  ci: my feature"])
+        m2(["⬤  ci: sync versioning changes from release (abc1234)"])
+    end
 
-    PR -->|"merge"| main
-    PR -. "/snapshot (on-demand)" .-> alpha
-    main -->|"publish-internal.yml (auto)"| beta
-    main -->|"promote.yml (manual)"| release
-    release -->|"publish-public.yml (auto)"| vpr
-    vpr -->|"merge"| npm
-    npm -->|"back-sync (auto)"| main
+    subgraph release ["release"]
+        direction TB
+        r1(["⬤  ci: promote main to release (abc1234)"])
+        r2["PR: [CI] Release Packages
+        • version bumps
+        • changelogs updated
+        • API docs regenerated"]
+        r3(["⬤  ci: release packages"])
+        r1 -->|"opens"| r2
+        r2 -->|"merges as"| r3
+    end
+
+    m1 -->|"promotes into"| r1
+    r3 -->|"syncs back into"| m2
 ```
+
+_⬤ commit · PR: pull request_
 
 #### Internal snapshot flow (`main`)
 

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -503,3 +503,16 @@ After a public release, the back-sync is automatic — the workflow merges `rele
 #### Hotfixes
 
 Urgent public fixes should be applied via a PR directly into `release` (patch changeset only) so the fix gets reviewed before going live. Once merged, changesets automatically opens a `[CI] Release Packages` PR — merge it to publish to npm. The back-sync to `main` runs automatically after publish.
+
+#### Repository secrets and deploy key
+
+The promotion and back-sync workflows push directly to `main` and `release`, both of which are protected branches. To allow this without a full admin bypass, the repository uses an SSH **deploy key** with write access, stored as the `DEPLOY_KEY` Actions secret.
+
+The corresponding public key is registered as a repository deploy key. Its `actor_id` is added to the branch ruleset as a `DeployKey` bypass actor (with `bypass_mode: always`), so CI pushes can land on protected branches without going through a pull request.
+
+If the deploy key ever needs to be rotated:
+
+1. Generate a new ed25519 key pair: `ssh-keygen -t ed25519 -C "ci deploy key" -f /tmp/deploy-key -N ""`
+2. Add the public key under **Settings → Deploy keys** (enable write access) and note the new key ID.
+3. Update the `DEPLOY_KEY` Actions secret with the new private key.
+4. Update the ruleset bypass actor with the new key ID via `gh api`.

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -502,7 +502,4 @@ After a public release, the back-sync is automatic — the workflow merges `rele
 
 #### Hotfixes
 
-Urgent public fixes can be applied directly on `release` (patch changeset only), then:
-
-1. Publish through the `release` branch release PR flow.
-2. Merge the auto-created back-sync PR to keep `main` aligned.
+Urgent public fixes should be applied via a PR directly into `release` (patch changeset only) so the fix gets reviewed before going live. Once merged, changesets automatically opens a `[CI] Release Packages` PR — merge it to publish to npm. The back-sync to `main` runs automatically after publish.

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -448,6 +448,25 @@ This repository uses two release channels:
 - `release` is the public channel
   - Uses stable semver and publishes to NPM via the standard changesets flow.
 
+```mermaid
+flowchart TD
+    PR(["Feature PR"])
+    main(["main"])
+    release(["release"])
+    vpr["[CI] Release Packages PR"]
+    alpha["Artifactory · alpha snapshot"]
+    beta["Artifactory · beta snapshot"]
+    npm["npm · stable release"]
+
+    PR -->|"merge"| main
+    PR -. "/snapshot (on-demand)" .-> alpha
+    main -->|"publish-internal.yml (auto)"| beta
+    main -->|"promote.yml (manual)"| release
+    release -->|"publish-public.yml (auto)"| vpr
+    vpr -->|"merge"| npm
+    npm -->|"back-sync (auto)"| main
+```
+
 #### Internal snapshot flow (`main`)
 
 Once your feature PR is merged to `main`:

--- a/.github/scripts/back-sync.sh
+++ b/.github/scripts/back-sync.sh
@@ -1,38 +1,19 @@
 #!/usr/bin/env bash
-# Creates a back-sync PR from release to main after a public release.
-# Skips if a back-sync PR already exists.
+# Merges the current release HEAD directly into main after a public release.
 
 set -euo pipefail
 
 SHA=$(git rev-parse HEAD)
-SHORT_SHA=$(echo "$SHA" | cut -c1-7)
-DATE=$(date +%Y%m%d)
-BRANCH="back-sync/release-to-main-${DATE}-${SHORT_SHA}"
 
-# Create a branch from current HEAD (release)
-git checkout -b "$BRANCH"
-git push origin "$BRANCH"
+# Extract the promoted SHA from the promotion merge commit so the back-sync message
+# references the same token as the corresponding promote commit.
+PROMOTE_COMMIT=$(git log origin/release --merges --grep="promote main to release" -1 --format="%H")
+SHORT_SHA=$(git rev-parse "${PROMOTE_COMMIT}^2" 2>/dev/null | cut -c1-7)
 
-EXISTING=$(gh pr list --base main --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
-if [ -n "$EXISTING" ]; then
-  echo "Back-sync PR #$EXISTING already exists for branch $BRANCH. Skipping."
-  exit 0
-fi
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
 
-gh pr create \
-  --base main \
-  --head "$BRANCH" \
-  --title "ci: sync versioning changes from release" \
-  --body "$(cat <<'EOF'
-## Summary
-
-Automated PR to sync version bumps and changelog updates from `release` back to `main`.
-
-This PR brings:
-- Updated package versions
-- Updated CHANGELOG.md files
-- Consumed changeset files
-
-> Created automatically after a public release.
-EOF
-)"
+git fetch origin main
+git checkout main
+git merge --no-ff "$SHA" -m "ci: sync versioning changes from release (${SHORT_SHA})"
+git push origin main

--- a/.github/scripts/back-sync.sh
+++ b/.github/scripts/back-sync.sh
@@ -5,15 +5,23 @@ set -euo pipefail
 
 SHA=$(git rev-parse HEAD)
 
-# Extract the promoted SHA from the promotion merge commit so the back-sync message
-# references the same token as the corresponding promote commit.
-PROMOTE_COMMIT=$(git log origin/release --merges --grep="promote main to release" -1 --format="%H")
-SHORT_SHA=$(git rev-parse "${PROMOTE_COMMIT}^2" 2>/dev/null | cut -c1-7)
+# Fetch main first so --not origin/main filters correctly below.
+git fetch origin main
+
+# Look for a promotion merge commit among commits not yet in main. Falls back to the
+# release HEAD SHA for hotfixes, which have no promotion merge commit in the new commits
+# (either because none exists, or because a prior one is already in main).
+PROMOTE_COMMIT=$(git log origin/release --not origin/main --merges \
+  --grep="promote main to release" -1 --format="%H")
+if [ -n "$PROMOTE_COMMIT" ]; then
+  SHORT_SHA=$(git rev-parse "${PROMOTE_COMMIT}^2" 2>/dev/null | cut -c1-7)
+else
+  SHORT_SHA=$(git rev-parse HEAD | cut -c1-7)
+fi
 
 git config user.email "github-actions[bot]@users.noreply.github.com"
 git config user.name "github-actions[bot]"
 
-git fetch origin main
 git checkout main
 git merge --no-ff "$SHA" -m "ci: sync versioning changes from release (${SHORT_SHA})"
 git push origin main

--- a/.github/scripts/promote.sh
+++ b/.github/scripts/promote.sh
@@ -18,5 +18,8 @@ git config user.email "github-actions[bot]@users.noreply.github.com"
 git config user.name "github-actions[bot]"
 
 git checkout release
+# --no-ff is required: back-sync.sh finds this merge commit via `git log --merges`
+# to recover SHORT_SHA for its own commit message. A fast-forward would leave no
+# merge commit to grep for, breaking SHA correlation.
 git merge --no-ff "$SHA" -m "ci: promote main to release (${SHORT_SHA})"
 git push origin release

--- a/.github/scripts/promote.sh
+++ b/.github/scripts/promote.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Creates a promotion PR from a commit on main to the release branch.
+# Promotes a commit from main to the release branch via a direct merge commit.
 #
 # Usage: promote.sh [commit_sha]
 #   commit_sha  Optional commit SHA to promote (defaults to latest on origin/main)
@@ -7,44 +7,16 @@
 set -euo pipefail
 
 SHA="${1:-}"
-REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
 
 if [ -z "$SHA" ]; then
   SHA=$(git rev-parse origin/main)
 fi
 
 SHORT_SHA=$(echo "$SHA" | cut -c1-7)
-DATE=$(date +%Y%m%d)
-BRANCH="promote/main-to-release-${DATE}-${SHORT_SHA}"
 
-# Create a branch from the specified commit
-git checkout -b "$BRANCH" "$SHA"
-git push origin "$BRANCH"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
 
-# Check if a promotion PR already exists for this branch
-EXISTING=$(gh pr list --base release --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
-if [ -n "$EXISTING" ]; then
-  echo "Promotion PR #$EXISTING already exists for branch $BRANCH."
-  exit 0
-fi
-
-gh pr create \
-  --base release \
-  --head "$BRANCH" \
-  --title "chore: promote main to release (${DATE})" \
-  --body "$(cat <<EOF
-## Summary
-
-Promotes changes from \`main\` to \`release\` for public publishing.
-
-- **Source commit**: [\`${SHORT_SHA}\`](https://github.com/${REPO}/commit/${SHA})
-- **Changesets included**: $(ls .changeset/*.md 2>/dev/null | grep -v README.md | wc -l | tr -d ' ') pending changeset(s)
-
-### What happens next
-
-1. Merge this PR into \`release\`
-2. The release workflow creates a **Version PR** with proper version bumps and changelogs
-3. Merge the Version PR to publish to NPM
-4. A back-sync PR from \`release\` → \`main\` is auto-created
-EOF
-)"
+git checkout release
+git merge --no-ff "$SHA" -m "chore: promote main to release (${SHORT_SHA})"
+git push origin release

--- a/.github/scripts/promote.sh
+++ b/.github/scripts/promote.sh
@@ -18,5 +18,5 @@ git config user.email "github-actions[bot]@users.noreply.github.com"
 git config user.name "github-actions[bot]"
 
 git checkout release
-git merge --no-ff "$SHA" -m "chore: promote main to release (${SHORT_SHA})"
+git merge --no-ff "$SHA" -m "ci: promote main to release (${SHORT_SHA})"
 git push origin release

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Promote to release
         env:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -10,12 +10,11 @@ on:
 
 jobs:
   promote:
-    name: Create Promotion PR
+    name: Promote to Release
     if: github.repository == 'adobe/aio-commerce-sdk'
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -23,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create promotion PR
+      - name: Promote to release
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -36,7 +36,7 @@ jobs:
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          version: pnpm changeset version
+          version: pnpm changeset version && pnpm turbo docs
           publish: pnpm changeset publish
           commit: "ci: release packages"
           title: "[CI] Release Packages"
@@ -60,12 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
-      - name: Create back-sync PR
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Merge release into main
         run: ./.github/scripts/back-sync.sh

--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Merge release into main
         run: ./.github/scripts/back-sync.sh


### PR DESCRIPTION
## Description

Replaces the PR-based promotion and back-sync gates with direct merge commits, reducing the public release flow from four manual steps to two (trigger promote, merge the Version Packages PR).

Also adds a deploy key so the CI workflows can push directly to the branch-protected `main` and `release` branches, regenerates API reference docs as part of the Version Packages PR, and documents the promotion flow with a diagram.

## Related Issue

CEXT-6301

## Motivation and Context

The promotion PR (main → release) and back-sync PR (release → main) were machine-generated and always merged as-is — they added friction without meaningful review value. Removing them shortens the release cycle and eliminates two no-op approval steps.

## How Has This Been Tested?

Infrastructure change — no automated tests apply. The deploy key and ruleset bypass have been configured on the repo. End-to-end verification requires triggering the promote workflow against a real release.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.