### PR TITLE
CEXT-6096: spec for Admin UI grid column extensions (v2)

### DIFF
--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -17,7 +17,9 @@ order, product, and customer grids on `commerce/backend-ui/2`. The v1 schema (`a
 will be removed in a future release — it remains functional for now. The v2 shape introduces
 `runtimeAction` (a `workerProcess` operation name resolved by App Registry at runtime), `columns`
 (replacing `properties`), and `key` (replacing `columnId`). The wire contract between Commerce and
-the handler is formally standardized for the first time.
+the handler is formally standardized for the first time. No separate registration action is
+generated for `commerce/backend-ui/2` — Commerce reads the `adminUi` config directly from the
+existing `app-config` endpoint on `commerce/extensibility/1`.
 
 ## Motivation
 
@@ -130,6 +132,11 @@ developer needs to provide alongside the config is the handler implementation it
 `orders/fetch-order-grid-data.js`). App Registry resolves the operation name to the deployed
 runtime action URL when Commerce fetches the extension.
 
+Commerce reads the `adminUi` registration config from the `app-config` endpoint on
+`commerce/extensibility/1` — no additional runtime action is needed on `commerce/backend-ui/2`.
+The only artifact generated for `commerce/backend-ui/2` is the `ext.config.yaml` that declares
+the `workerProcess` operations.
+
 ### Wire contract
 
 **Request** (sent by Commerce to the handler):
@@ -207,14 +214,16 @@ until those extension points are ported to `commerce/backend-ui/2` in a subseque
 ### Two config keys, two extension points
 
 `adminUiSdk` and `adminUi` are independent top-level keys in `defineConfig()`. They map to separate
-extension points and separate generated artifacts:
+extension points with different generated artifacts:
 
-| Config key   | Extension point         | Status                       |
-| ------------ | ----------------------- | ---------------------------- |
-| `adminUiSdk` | `commerce/backend-ui/1` | Deprecated — will be removed |
-| `adminUi`    | `commerce/backend-ui/2` | Current                      |
+| Config key   | Extension point         | Generated artifact                                       | Status                       |
+| ------------ | ----------------------- | -------------------------------------------------------- | ---------------------------- |
+| `adminUiSdk` | `commerce/backend-ui/1` | `registration/index.js` + `ext.config.yaml`              | Deprecated — will be removed |
+| `adminUi`    | `commerce/backend-ui/2` | `ext.config.yaml` with `workerProcess` declarations only | Current                      |
 
-Both keys are optional and can coexist. The SDK generates artifacts for whichever are present.
+For `adminUi`, no registration action is generated. Commerce reads the `adminUi` config directly
+from the `app-config` endpoint on `commerce/extensibility/1`, which already includes the full app
+manifest. Both keys are optional and can coexist.
 
 ### Schema
 
@@ -279,22 +288,22 @@ export const BACKEND_UI_V2_EXTENSION_POINT_ID = "commerce/backend-ui/2"; // v2
 The `Extension` union includes both values. Each routes to its own handler:
 
 - `"backend-ui/1"` → `generateRegistrationActionFile` (v1, unchanged behavior)
-- `"backend-ui/2"` → `updateExtConfig` + `generateGridColumnsRegistrationActionFile` (v2)
+- `"backend-ui/2"` → `updateExtConfig` (v2)
 
-When `hasAdminUi` is true, the v2 path performs two generation steps:
+When `hasAdminUi` is true, the v2 path performs one generation step:
 
-1. **Registration action** — generates the JS file that returns the registration config when
-   Commerce calls the extension.
+**`ext.config.yaml` workerProcess declarations** — collects all unique `runtimeAction` values
+across `order`, `product`, and `customer` grid column configs, then writes them as `workerProcess`
+entries in `ext.config.yaml` for `commerce/backend-ui/2`. No registration action is generated;
+Commerce reads the `adminUi` config directly from the `app-config` endpoint on
+`commerce/extensibility/1`. Developers do not declare `workerProcess` entries manually; the SDK
+derives them from `app.commerce.config.ts` and keeps `ext.config.yaml` in sync on every build.
 
-2. **`ext.config.yaml` workerProcess declarations** — collects all unique `runtimeAction` values
-   across `order`, `product`, and `customer` grid column configs, then writes them as `workerProcess`
-   entries in `ext.config.yaml` for `commerce/backend-ui/2`. Developers do not declare these
-   manually; the SDK derives them from `app.commerce.config.ts` and keeps `ext.config.yaml` in sync
-   on every build.
-
-Example generated `ext.config.yaml` fragment for the config above:
+Example generated `ext.config.yaml` for the config above:
 
 ```yaml
+hooks:
+  pre-app-build: "EXTENSION=backend-ui/2 $packageExec aio-commerce-lib-app hooks pre-app-build"
 operations:
   view:
     - type: web
@@ -306,13 +315,8 @@ operations:
       impl: products/fetch-product-grid-data
     - type: action
       impl: customers/fetch-customer-grid-data
+web: web-src
 ```
-
-### Registration action generation
-
-No template change is needed. The registration action inlines the config as a JS object literal;
-`runtimeAction` is serialized as-is. Commerce reads `runtimeAction` directly from the registration
-JSON — no field mapping is required on either side.
 
 ### Changeset bump
 

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -16,7 +16,7 @@ order, product, and customer grids on `commerce/backend-ui/2`. The v1 schema (`a
 `commerce/backend-ui/1`, `data.meshId`, `properties`, `columnId`, `float` type) is deprecated and
 will be removed in a future release — it remains functional for now. The v2 shape introduces
 `runtimeAction` (a `workerProcess` operation name resolved by App Registry at runtime), `columns`
-(replacing `properties`), and `key` (replacing `columnId`). The wire contract between Commerce and
+(replacing `properties`), and `columnId` (unchanged from v1). The wire contract between Commerce and
 the handler is formally standardized for the first time. No separate registration action is
 generated for `commerce/backend-ui/2` — Commerce reads the `adminUi` config directly from the
 existing `app-config` endpoint on `commerce/extensibility/1`.
@@ -42,7 +42,7 @@ The v1 grid column design has four concrete problems that compound each other:
 
 - Introduce `adminUi` as the new top-level config key for `commerce/backend-ui/2` registrations.
 - Replace `data.meshId` with `runtimeAction` (a `workerProcess` operation name) in all three grids.
-- Rename `properties` → `columns`, `columnId` → `key` for clarity.
+- Rename `properties` → `columns`; keep `columnId` unchanged from v1.
 - Add `label` and `description` to each `gridColumns` block for display during installation.
 - Formally specify the request/response wire contract.
 - Deprecate `adminUiSdk`/`commerce/backend-ui/1` grid columns; keep them functional until removal.
@@ -75,13 +75,13 @@ export default defineConfig({
         runtimeAction: "orders/fetch-order-grid-data",
         columns: [
           {
-            key: "fulfillment_status",
+            columnId: "fulfillment_status",
             label: "Fulfillment",
             type: "string",
             align: "left",
           },
           {
-            key: "risk_score",
+            columnId: "risk_score",
             label: "Risk",
             type: "integer",
             align: "right",
@@ -96,7 +96,7 @@ export default defineConfig({
         runtimeAction: "products/fetch-product-grid-data",
         columns: [
           {
-            key: "inventory_status",
+            columnId: "inventory_status",
             label: "Inventory",
             type: "string",
             align: "left",
@@ -111,7 +111,7 @@ export default defineConfig({
         runtimeAction: "customers/fetch-customer-grid-data",
         columns: [
           {
-            key: "loyalty_tier",
+            columnId: "loyalty_tier",
             label: "Loyalty Tier",
             type: "string",
             align: "left",
@@ -198,7 +198,7 @@ the `workerProcess` operations.
 | `adminUiSdk.registration.order`          | `adminUi.order`              | No `registration` wrapper in v2                               |
 | `data.meshId`                            | `runtimeAction`              | Operation name declared in `app.config.yaml`, not a Mesh hash |
 | `properties`                             | `columns`                    | Array of column declarations                                  |
-| `properties[].columnId`                  | `columns[].key`              | Doubles as the response data key — make them match            |
+| `properties[].columnId`                  | `columns[].columnId`         | Unchanged from v1                                             |
 | `properties[].type: "float"`             | `columns[].type: "decimal"`  | Renamed                                                       |
 | _(absent)_                               | `columns[].type: "datetime"` | New type in v2                                                |
 | _(absent)_                               | `label`, `description`       | New block-level metadata for App Management installation UI   |
@@ -232,7 +232,7 @@ The v2 schema lives in a dedicated file:
 
 ```ts
 const GridColumnSchema = v.object({
-  key: nonEmptyStringValueSchema("column key"),
+  columnId: nonEmptyStringValueSchema("column ID"),
   label: nonEmptyStringValueSchema("column label"),
   type: v.picklist([
     "boolean",
@@ -327,8 +327,6 @@ do not constitute a semver-major change under the SDK's stability policy.
 - Apps that genuinely need API Mesh federation must wire it inside the handler themselves. The SDK
   no longer manages the Mesh reference in v2. This is intentional — Mesh is now a handler
   implementation detail, not a config-level concern.
-- `key` doing double duty (response data key and column identifier) is explicit by design, but
-  developers used to v1's separate `columnId` field may find it surprising at first.
 - Keeping v1 functional alongside v2 means the SDK ships two schemas for the same concept during
   the deprecation window. This is intentional — removing v1 immediately would be a breaking change
   for existing apps.

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -5,12 +5,12 @@
 - [ ] **Implemented**
 
 > **Breaking change.** The v1 grid column schema (`commerce/backend-ui/1`, `data.meshId`,
-> `properties`, `columnId`) is removed. Existing apps must migrate to v2. See
-> [Migration from v1](#migration-from-v1) below.
+> `properties`, `columnId`) is removed, and the top-level config key is renamed from `adminUiSdk`
+> to `adminUi`. Existing apps must migrate to v2. See [Migration from v1](#migration-from-v1) below.
 
 ## Summary
 
-The SDK replaces the v1 Admin UI SDK grid column schema with a unified v2 schema covering order,
+The SDK replaces the v1 Admin UI grid column schema with a unified v2 schema covering order,
 product, and customer grids. Support for `commerce/backend-ui/1` and the mesh-based config
 (`data.meshId`, `properties`, `columnId`, `float` type) is removed. Apps must declare
 `commerce/backend-ui/2` and adopt the new shape: `runtimeAction` (a `workerProcess` operation name
@@ -39,8 +39,10 @@ The v1 grid column design has four concrete problems that compound each other:
 
 - Replace `data.meshId` with `runtimeAction` (a `workerProcess` operation name) in all three grids.
 - Rename `properties` → `columns`, `columnId` → `key` for clarity.
+- Add `label` and `description` to each `gridColumns` block for display during installation.
 - Formally specify the request/response wire contract.
 - Remove `commerce/backend-ui/1` and all v1 schema artifacts from the SDK.
+- Rename the top-level config key from `adminUiSdk` to `adminUi`.
 - Use a single unified column schema under `order.gridColumns`, `product.gridColumns`, and
   `customer.gridColumns`.
 
@@ -65,7 +67,10 @@ export default defineConfig({
     registration: {
       order: {
         gridColumns: {
-          runtimeAction: "fetch-order-grid-data",
+          label: "Order fulfillment data",
+          description:
+            "Adds fulfillment status and risk score to the order grid",
+          runtimeAction: "orders/fetch-order-grid-data",
           columns: [
             {
               key: "fulfillment_status",
@@ -84,11 +89,28 @@ export default defineConfig({
       },
       product: {
         gridColumns: {
-          runtimeAction: "fetch-product-grid-data",
+          label: "Product inventory data",
+          description: "Adds inventory status to the product grid",
+          runtimeAction: "products/fetch-product-grid-data",
           columns: [
             {
               key: "inventory_status",
               label: "Inventory",
+              type: "string",
+              align: "left",
+            },
+          ],
+        },
+      },
+      customer: {
+        gridColumns: {
+          label: "Customer loyalty data",
+          description: "Adds loyalty tier to the customer grid",
+          runtimeAction: "customers/fetch-customer-grid-data",
+          columns: [
+            {
+              key: "loyalty_tier",
+              label: "Loyalty Tier",
               type: "string",
               align: "left",
             },
@@ -164,11 +186,13 @@ runtime action URL when Commerce fetches the extension.
 
 | v1                                       | v2                           | Notes                                                         |
 | ---------------------------------------- | ---------------------------- | ------------------------------------------------------------- |
+| `adminUiSdk`                             | `adminUi`                    | Top-level config key rename in `defineConfig()`               |
 | `data.meshId`                            | `runtimeAction`              | Operation name declared in `app.config.yaml`, not a Mesh hash |
 | `properties`                             | `columns`                    | Array of column declarations                                  |
 | `properties[].columnId`                  | `columns[].key`              | Doubles as the response data key — make them match            |
 | `properties[].type: "float"`             | `columns[].type: "decimal"`  | Renamed                                                       |
 | _(absent)_                               | `columns[].type: "datetime"` | New type in v2                                                |
+| _(absent)_                               | `label`, `description`       | New block-level metadata for App Management installation UI   |
 | Extension point: `commerce/backend-ui/1` | `commerce/backend-ui/2`      | Required change in `app.config.yaml`                          |
 
 ## Design
@@ -206,6 +230,8 @@ const GridColumnSchema = v.object({
 });
 
 const GridColumnsSchema = v.object({
+  label: nonEmptyStringValueSchema("grid columns label"),
+  description: nonEmptyStringValueSchema("grid columns description"),
   runtimeAction: nonEmptyStringValueSchema("runtime action"),
   columns: v.pipe(
     v.array(GridColumnSchema),
@@ -262,6 +288,8 @@ operations:
       impl: orders/fetch-order-grid-data
     - type: action
       impl: products/fetch-product-grid-data
+    - type: action
+      impl: customers/fetch-customer-grid-data
 ```
 
 ### Registration action generation

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -180,6 +180,12 @@ the `workerProcess` operations.
 }
 ```
 
+### columnId uniqueness
+
+`columnId` values are declared by the developer as plain identifiers (e.g. `external_id`). The
+`app-config` endpoint serves them as-is; no SDK-side prefixing is applied. `columnId` collision
+handling across multiple installed apps is Commerce's responsibility.
+
 ### Column types
 
 | `type` value | Description                          |

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -304,9 +304,6 @@ Example generated `ext.config.yaml` for the config above:
 hooks:
   pre-app-build: "EXTENSION=backend-ui/2 $packageExec aio-commerce-lib-app hooks pre-app-build"
 operations:
-  view:
-    - type: web
-      impl: index.html
   workerProcess:
     - type: action
       impl: orders/fetch-order-grid-data
@@ -314,7 +311,6 @@ operations:
       impl: products/fetch-product-grid-data
     - type: action
       impl: customers/fetch-customer-grid-data
-web: web-src
 ```
 
 ### Changeset bump

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -1,4 +1,4 @@
-# Grid column extensions (v2)
+# Admin UI grid column extensions (v2)
 
 - **Ticket:** [CEXT-6096](https://jira.corp.adobe.com/browse/CEXT-6096)
 - **Created:** 2026-05-29

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -4,19 +4,20 @@
 - **Created:** 2026-05-29
 - [ ] **Implemented**
 
-> **Breaking change.** The v1 grid column schema (`commerce/backend-ui/1`, `data.meshId`,
-> `properties`, `columnId`) is removed, and the top-level config key is renamed from `adminUiSdk`
-> to `adminUi`. Existing apps must migrate to v2. See [Migration from v1](#migration-from-v1) below.
+> **Deprecation notice.** The v1 grid column schema (`commerce/backend-ui/1`, `data.meshId`,
+> `properties`, `columnId`) is deprecated and will be removed from the SDK in a future release.
+> New apps must use `adminUi` and `commerce/backend-ui/2`. Existing apps should migrate —
+> see [Migration from v1](#migration-from-v1) below.
 
 ## Summary
 
-The SDK replaces the v1 Admin UI grid column schema with a unified v2 schema covering order,
-product, and customer grids. Support for `commerce/backend-ui/1` and the mesh-based config
-(`data.meshId`, `properties`, `columnId`, `float` type) is removed. Apps must declare
-`commerce/backend-ui/2` and adopt the new shape: `runtimeAction` (a `workerProcess` operation name
-resolved by App Registry at runtime), `columns` (renamed from `properties`), and `key` (renamed
-from `columnId`). The wire contract between Commerce and the handler is formally standardized for
-the first time.
+The SDK introduces a v2 Admin UI grid column schema under the new `adminUi` config key, covering
+order, product, and customer grids on `commerce/backend-ui/2`. The v1 schema (`adminUiSdk`,
+`commerce/backend-ui/1`, `data.meshId`, `properties`, `columnId`, `float` type) is deprecated and
+will be removed in a future release — it remains functional for now. The v2 shape introduces
+`runtimeAction` (a `workerProcess` operation name resolved by App Registry at runtime), `columns`
+(replacing `properties`), and `key` (replacing `columnId`). The wire contract between Commerce and
+the handler is formally standardized for the first time.
 
 ## Motivation
 
@@ -37,18 +38,19 @@ The v1 grid column design has four concrete problems that compound each other:
 
 **Goals**
 
+- Introduce `adminUi` as the new top-level config key for `commerce/backend-ui/2` registrations.
 - Replace `data.meshId` with `runtimeAction` (a `workerProcess` operation name) in all three grids.
 - Rename `properties` → `columns`, `columnId` → `key` for clarity.
 - Add `label` and `description` to each `gridColumns` block for display during installation.
 - Formally specify the request/response wire contract.
-- Remove `commerce/backend-ui/1` and all v1 schema artifacts from the SDK.
-- Rename the top-level config key from `adminUiSdk` to `adminUi`.
+- Deprecate `adminUiSdk`/`commerce/backend-ui/1` grid columns; keep them functional until removal.
 - Use a single unified column schema under `order.gridColumns`, `product.gridColumns`, and
   `customer.gridColumns`.
 
 **Non-goals**
 
-- Supporting v1 in any compatibility mode or deprecation window.
+- Removing `commerce/backend-ui/1` or `adminUiSdk` in this release — removal is deferred to a future
+  breaking release.
 - Adding grid targets beyond order, product, and customer.
 - Implementing mass action v2 (separate ticket).
 - Wrapping or managing the Commerce API Mesh service.
@@ -61,66 +63,66 @@ The v1 grid column design has four concrete problems that compound each other:
 The config shape is the same across all three grids:
 
 ```ts
-// app-config.ts
+// app.commerce.config.ts
 export default defineConfig({
   adminUi: {
-    registration: {
-      order: {
-        gridColumns: {
-          label: "Order fulfillment data",
-          description:
-            "Adds fulfillment status and risk score to the order grid",
-          runtimeAction: "orders/fetch-order-grid-data",
-          columns: [
-            {
-              key: "fulfillment_status",
-              label: "Fulfillment",
-              type: "string",
-              align: "left",
-            },
-            {
-              key: "risk_score",
-              label: "Risk",
-              type: "integer",
-              align: "right",
-            },
-          ],
-        },
+    order: {
+      gridColumns: {
+        label: "Order fulfillment data",
+        description: "Adds fulfillment status and risk score to the order grid",
+        runtimeAction: "orders/fetch-order-grid-data",
+        columns: [
+          {
+            key: "fulfillment_status",
+            label: "Fulfillment",
+            type: "string",
+            align: "left",
+          },
+          {
+            key: "risk_score",
+            label: "Risk",
+            type: "integer",
+            align: "right",
+          },
+        ],
       },
-      product: {
-        gridColumns: {
-          label: "Product inventory data",
-          description: "Adds inventory status to the product grid",
-          runtimeAction: "products/fetch-product-grid-data",
-          columns: [
-            {
-              key: "inventory_status",
-              label: "Inventory",
-              type: "string",
-              align: "left",
-            },
-          ],
-        },
+    },
+    product: {
+      gridColumns: {
+        label: "Product inventory data",
+        description: "Adds inventory status to the product grid",
+        runtimeAction: "products/fetch-product-grid-data",
+        columns: [
+          {
+            key: "inventory_status",
+            label: "Inventory",
+            type: "string",
+            align: "left",
+          },
+        ],
       },
-      customer: {
-        gridColumns: {
-          label: "Customer loyalty data",
-          description: "Adds loyalty tier to the customer grid",
-          runtimeAction: "customers/fetch-customer-grid-data",
-          columns: [
-            {
-              key: "loyalty_tier",
-              label: "Loyalty Tier",
-              type: "string",
-              align: "left",
-            },
-          ],
-        },
+    },
+    customer: {
+      gridColumns: {
+        label: "Customer loyalty data",
+        description: "Adds loyalty tier to the customer grid",
+        runtimeAction: "customers/fetch-customer-grid-data",
+        columns: [
+          {
+            key: "loyalty_tier",
+            label: "Loyalty Tier",
+            type: "string",
+            align: "left",
+          },
+        ],
       },
     },
   },
 });
 ```
+
+Note: unlike `adminUiSdk`, the `adminUi` key does **not** have a `registration` wrapper. Grid
+column blocks are declared directly under `order`, `product`, and `customer`.
 
 The SDK generates the `workerProcess` operation declarations in `ext.config.yaml` automatically
 from the `runtimeAction` values — developers do not write them by hand. The only thing the
@@ -186,33 +188,39 @@ runtime action URL when Commerce fetches the extension.
 
 | v1                                       | v2                           | Notes                                                         |
 | ---------------------------------------- | ---------------------------- | ------------------------------------------------------------- |
-| `adminUiSdk`                             | `adminUi`                    | Top-level config key rename in `defineConfig()`               |
+| `adminUiSdk.registration.order`          | `adminUi.order`              | No `registration` wrapper in v2                               |
 | `data.meshId`                            | `runtimeAction`              | Operation name declared in `app.config.yaml`, not a Mesh hash |
 | `properties`                             | `columns`                    | Array of column declarations                                  |
 | `properties[].columnId`                  | `columns[].key`              | Doubles as the response data key — make them match            |
 | `properties[].type: "float"`             | `columns[].type: "decimal"`  | Renamed                                                       |
 | _(absent)_                               | `columns[].type: "datetime"` | New type in v2                                                |
 | _(absent)_                               | `label`, `description`       | New block-level metadata for App Management installation UI   |
-| Extension point: `commerce/backend-ui/1` | `commerce/backend-ui/2`      | Required change in `app.config.yaml`                          |
+| Extension point: `commerce/backend-ui/1` | `commerce/backend-ui/2`      | Required change in `app.config.yaml` and `install.yaml`       |
+
+v1 continues to work after migration — both keys can coexist in the same config during transition.
+Once all grid columns have been migrated to `adminUi`, the `adminUiSdk` grid column config can be
+removed. `adminUiSdk` itself (mass actions, menus, view buttons, custom fees) remains functional
+until those extension points are ported to `commerce/backend-ui/2` in a subsequent release.
 
 ## Design
 
-### Config key rename
+### Two config keys, two extension points
 
-The top-level config key changes from `adminUiSdk` to `adminUi`. This is a rename across the SDK:
+`adminUiSdk` and `adminUi` are independent top-level keys in `defineConfig()`. They map to separate
+extension points and separate generated artifacts:
 
-- The config property in `defineConfig()` — `adminUiSdk` → `adminUi`
-- `AdminUiSdkSchema` → `AdminUiSchema`
-- `AdminUiSdkConfiguration` → `AdminUiConfiguration`
-- `AdminUiSdkRegistration` → `AdminUiRegistration`
-- `hasAdminUiSdk()` → `hasAdminUi()`
-- All related exported types and guards in `packages/aio-commerce-lib-app`
+| Config key   | Extension point         | Status                       |
+| ------------ | ----------------------- | ---------------------------- |
+| `adminUiSdk` | `commerce/backend-ui/1` | Deprecated — will be removed |
+| `adminUi`    | `commerce/backend-ui/2` | Current                      |
 
-### Schema changes
+Both keys are optional and can coexist. The SDK generates artifacts for whichever are present.
 
-`packages/aio-commerce-lib-app/source/config/schema/admin-ui-sdk.ts`
+### Schema
 
-Remove `GridColumnPropertySchema` (v1) and `GridColumnsSchema` (v1). Add:
+The v2 schema lives in a dedicated file:
+
+`packages/aio-commerce-lib-app/source/config/schema/admin-ui.ts`
 
 ```ts
 const GridColumnSchema = v.object({
@@ -226,7 +234,7 @@ const GridColumnSchema = v.object({
     "integer",
     "string",
   ]),
-  align: ColumnAlignSchema, // 'left' | 'center' | 'right' — unchanged
+  align: v.picklist(["left", "right", "center"]),
 });
 
 const GridColumnsSchema = v.object({
@@ -238,43 +246,51 @@ const GridColumnsSchema = v.object({
     v.minLength(1, "At least one column is required"),
   ),
 });
+
+export const AdminUiSchema = v.object({
+  order: v.optional(v.object({ gridColumns: v.optional(GridColumnsSchema) })),
+  product: v.optional(v.object({ gridColumns: v.optional(GridColumnsSchema) })),
+  customer: v.optional(
+    v.object({ gridColumns: v.optional(GridColumnsSchema) }),
+  ),
+});
 ```
 
-`OrderExtensionPointsSchema`, `ProductExtensionPointsSchema`, and
-`CustomerExtensionPointsSchema` continue to reference `GridColumnsSchema` by name — the reference
-is unchanged, the schema it points to is replaced.
+The v1 schema in `admin-ui-sdk.ts` is unchanged. Its `GridColumnsSchema` (with `data.meshId` and
+`properties`) and the `gridColumns` field on `OrderExtensionPointsSchema`,
+`ProductExtensionPointsSchema`, and `CustomerExtensionPointsSchema` remain in place. The exported
+v1 type is `AdminUiSdkGridColumns` (marked `@deprecated`).
 
-The exported `GridColumns` type is updated automatically via `v.InferInput<typeof GridColumnsSchema>`.
-
-### Extension point constant
+### Extension point constants
 
 `packages/aio-commerce-lib-app/source/commands/constants.ts`
 
+Both constants coexist:
+
 ```ts
-// before
-export const BACKEND_UI_EXTENSION_POINT_ID = "commerce/backend-ui/1";
-
-// after
-export const BACKEND_UI_EXTENSION_POINT_ID = "commerce/backend-ui/2";
+export const BACKEND_UI_EXTENSION_POINT_ID = "commerce/backend-ui/1"; // v1, deprecated
+export const BACKEND_UI_V2_EXTENSION_POINT_ID = "commerce/backend-ui/2"; // v2
 ```
-
-The constant name is preserved so callsites do not change. Only the value changes.
 
 ### Pre-app-build hook
 
 `packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts`
 
-Remove `"backend-ui/1"` from the `Extension` union and replace with `"backend-ui/2"`. When
-`hasAdminUi` is true, the hook now performs two generation steps:
+The `Extension` union includes both values. Each routes to its own handler:
 
-1. **Registration action** — unchanged from v1: generates the JS file that returns the
-   registration config when Commerce calls the extension.
+- `"backend-ui/1"` → `generateRegistrationActionFile` (v1, unchanged behavior)
+- `"backend-ui/2"` → `updateExtConfig` + `generateGridColumnsRegistrationActionFile` (v2)
 
-2. **`ext.config.yaml` workerProcess declarations** — new in v2: collects all unique
-   `runtimeAction` values across `order`, `product`, and `customer` grid column configs,
-   then writes them as `workerProcess` entries in `ext.config.yaml` for
-   `commerce/backend-ui/2`. Developers do not declare these manually; the SDK derives them
-   from `app.commerce.config.ts` and keeps `ext.config.yaml` in sync on every build.
+When `hasAdminUi` is true, the v2 path performs two generation steps:
+
+1. **Registration action** — generates the JS file that returns the registration config when
+   Commerce calls the extension.
+
+2. **`ext.config.yaml` workerProcess declarations** — collects all unique `runtimeAction` values
+   across `order`, `product`, and `customer` grid column configs, then writes them as `workerProcess`
+   entries in `ext.config.yaml` for `commerce/backend-ui/2`. Developers do not declare these
+   manually; the SDK derives them from `app.commerce.config.ts` and keeps `ext.config.yaml` in sync
+   on every build.
 
 Example generated `ext.config.yaml` fragment for the config above:
 
@@ -306,19 +322,27 @@ do not constitute a semver-major change under the SDK's stability policy.
 ## Drawbacks
 
 - Apps that genuinely need API Mesh federation must wire it inside the handler themselves. The SDK
-  no longer manages the Mesh reference. This is intentional — Mesh is now a handler implementation
-  detail, not a config-level concern.
+  no longer manages the Mesh reference in v2. This is intentional — Mesh is now a handler
+  implementation detail, not a config-level concern.
 - `key` doing double duty (response data key and column identifier) is explicit by design, but
   developers used to v1's separate `columnId` field may find it surprising at first.
-- Dropping v1 requires migration for any existing app using grid columns. There is no deprecation
-  window.
+- Keeping v1 functional alongside v2 means the SDK ships two schemas for the same concept during
+  the deprecation window. This is intentional — removing v1 immediately would be a breaking change
+  for existing apps.
 
 ## Rationale and alternatives
 
-**Keep v1 alongside v2.**
-Rejected. A compatibility shim would preserve exactly the problem being solved: the undocumented
-Mesh coupling and the opaque `meshId`. There is no scenario in which both schemas would be
-simultaneously correct.
+**Keep v1 alongside v2 during a deprecation window (adopted).**
+Removing v1 immediately would be a breaking change for apps that depend on
+`adminUiSdk.registration.order.gridColumns`. The deprecation window lets existing apps migrate at
+their own pace while new apps adopt v2 from the start. v1 will be removed in a future major or
+minor release once the migration path is established and adoption of v2 is confirmed.
+
+**Remove v1 immediately.**
+Considered and rejected for this release. All grid column types under `adminUiSdk` are marked
+`@experimental`, so a removal is not semver-major under the SDK's stability policy — but forcing
+an immediate migration adds friction with no compensating benefit at this stage. Deferral costs
+nothing and preserves optionality.
 
 **Make `meshId` optional in v1.**
 Rejected. This does not solve the multi-environment problem (the ID is still environment-specific),
@@ -344,6 +368,9 @@ Confirm this is correct and no constraint should be added.
 
 ## Future possibilities
 
+- Removal of `adminUiSdk` grid columns and `commerce/backend-ui/1` once migration is complete.
 - Additional grid targets (invoice, shipment grids) following the same unified schema pattern.
+- Porting remaining `adminUiSdk` extension points (mass actions, menus, view buttons, custom fees)
+  to `commerce/backend-ui/2` under `adminUi`.
 - Handler scaffolding: `aio commerce generate handler --type grid-columns` to generate a typed
   handler stub that implements the wire contract.

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -361,14 +361,6 @@ enforce separation.
 Grid columns remain coupled to API Mesh, blocking apps that don't need federation, and the wire
 contract remains undocumented. The multi-environment `meshId` problem has no SDK-level solution.
 
-## Unresolved questions
-
-**Single-operation constraint.**
-Can the same `runtimeAction` value appear in `order.gridColumns` and `customer.gridColumns`? The
-SDK imposes no uniqueness constraint — the same operation name can appear in multiple grid column
-blocks. A single handler would then receive requests for both grid types and branch on `gridType`.
-Confirm this is correct and no constraint should be added.
-
 ## Future possibilities
 
 - Removal of `adminUiSdk` grid columns and `commerce/backend-ui/1` once migration is complete.

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -206,8 +206,7 @@ the `workerProcess` operations.
 
 v1 continues to work after migration — both keys can coexist in the same config during transition.
 Once all grid columns have been migrated to `adminUi`, the `adminUiSdk` grid column config can be
-removed. `adminUiSdk` itself (mass actions, menus, view buttons, custom fees) remains functional
-until those extension points are ported to `commerce/backend-ui/2` in a subsequent release.
+removed.
 
 ## Design
 

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -158,10 +158,6 @@ extensions:
 }
 ```
 
-On failure or timeout: all custom-column cells render empty. A single banner notification is
-surfaced on grid load: _"Could not load custom columns from `<app name>`."_ Defaults via `"*"` are
-not applied — they are for unmatched IDs inside a successful response, not for outages.
-
 ### Column types
 
 | `type` value | Description                          |

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -13,7 +13,7 @@
 The SDK replaces the v1 Admin UI SDK grid column schema with a unified v2 schema covering order,
 product, and customer grids. Support for `commerce/backend-ui/1` and the mesh-based config
 (`data.meshId`, `properties`, `columnId`, `float` type) is removed. Apps must declare
-`commerce/backend-ui/2` and adopt the new shape: `data.backend` (a `workerProcess` operation name
+`commerce/backend-ui/2` and adopt the new shape: `runtimeAction` (a `workerProcess` operation name
 resolved by App Registry at runtime), `columns` (renamed from `properties`), and `key` (renamed
 from `columnId`). The wire contract between Commerce and the handler is formally standardized for
 the first time.
@@ -37,7 +37,7 @@ The v1 grid column design has four concrete problems that compound each other:
 
 **Goals**
 
-- Replace `data.meshId` with `data.backend` (a `workerProcess` operation name) in all three grids.
+- Replace `data.meshId` with `runtimeAction` (a `workerProcess` operation name) in all three grids.
 - Rename `properties` → `columns`, `columnId` → `key` for clarity.
 - Formally specify the request/response wire contract.
 - Remove `commerce/backend-ui/1` and all v1 schema artifacts from the SDK.

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -100,21 +100,11 @@ export default defineConfig({
 });
 ```
 
-`runtimeAction` must match the name of a `workerProcess` operation declared on
-`commerce/backend-ui/2` in `app.config.yaml`. App Registry resolves the name to the deployed
-runtime action URL — developers never write a URL directly.
-
-```yaml
-# app.config.yaml
-extensions:
-  commerce/backend-ui/2:
-    operations:
-      workerProcess:
-        - type: action
-          impl: orders/fetch-order-grid-data
-        - type: action
-          impl: products/fetch-product-grid-data
-```
+The SDK generates the `workerProcess` operation declarations in `ext.config.yaml` automatically
+from the `runtimeAction` values — developers do not write them by hand. The only thing the
+developer needs to provide alongside the config is the handler implementation itself (e.g.
+`orders/fetch-order-grid-data.js`). App Registry resolves the operation name to the deployed
+runtime action URL when Commerce fetches the extension.
 
 ### Wire contract
 
@@ -248,10 +238,31 @@ The constant name is preserved so callsites do not change. Only the value change
 
 `packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts`
 
-Remove `"backend-ui/1"` from the `Extension` union and replace with `"backend-ui/2"`. The hook
-continues to call `generateRegistrationActionFile` when `hasAdminUiSdk` is true — no structural
-change needed. The v2 config shape (with `backend` and `columns`) passes through the existing
-serialization path unchanged.
+Remove `"backend-ui/1"` from the `Extension` union and replace with `"backend-ui/2"`. When
+`hasAdminUi` is true, the hook now performs two generation steps:
+
+1. **Registration action** — unchanged from v1: generates the JS file that returns the
+   registration config when Commerce calls the extension.
+
+2. **`ext.config.yaml` workerProcess declarations** — new in v2: collects all unique
+   `runtimeAction` values across `order`, `product`, and `customer` grid column configs,
+   then writes them as `workerProcess` entries in `ext.config.yaml` for
+   `commerce/backend-ui/2`. Developers do not declare these manually; the SDK derives them
+   from `app.commerce.config.ts` and keeps `ext.config.yaml` in sync on every build.
+
+Example generated `ext.config.yaml` fragment for the config above:
+
+```yaml
+operations:
+  view:
+    - type: web
+      impl: index.html
+  workerProcess:
+    - type: action
+      impl: orders/fetch-order-grid-data
+    - type: action
+      impl: products/fetch-product-grid-data
+```
 
 ### Registration action generation
 

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -255,12 +255,9 @@ serialization path unchanged.
 
 ### Registration action generation
 
-No template change is needed. Before serialization, the SDK transforms the developer-facing config
-into the Commerce-facing registration format: `runtimeAction` is mapped to `data.backend` for each
-grid type that declares `gridColumns`. This transform runs in `generateRegistrationActionFile`
-before the `stringify` call, so the generated registration action contains `data.backend` — the
-shape Commerce expects — while developers write `runtimeAction` in their app config, consistent
-with the rest of the SDK (webhooks, events).
+No template change is needed. The registration action inlines the config as a JS object literal;
+`runtimeAction` is serialized as-is. Commerce reads `runtimeAction` directly from the registration
+JSON — no field mapping is required on either side.
 
 ### Changeset bump
 

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -1,0 +1,303 @@
+# Grid column extensions (v2)
+
+- **Ticket:** [CEXT-6096](https://jira.corp.adobe.com/browse/CEXT-6096)
+- **Created:** 2026-05-29
+- [ ] **Implemented**
+
+> **Breaking change.** The v1 grid column schema (`commerce/backend-ui/1`, `data.meshId`,
+> `properties`, `columnId`) is removed. Existing apps must migrate to v2. See
+> [Migration from v1](#migration-from-v1) below.
+
+## Summary
+
+The SDK replaces the v1 Admin UI SDK grid column schema with a unified v2 schema covering order,
+product, and customer grids. Support for `commerce/backend-ui/1` and the mesh-based config
+(`data.meshId`, `properties`, `columnId`, `float` type) is removed. Apps must declare
+`commerce/backend-ui/2` and adopt the new shape: `data.backend` (a `workerProcess` operation name
+resolved by App Registry at runtime), `columns` (renamed from `properties`), and `key` (renamed
+from `columnId`). The wire contract between Commerce and the handler is formally standardized for
+the first time.
+
+## Motivation
+
+The v1 grid column design has four concrete problems that compound each other:
+
+1. **Mesh is required even for trivial cases.** An app that fetches one extra column from its own
+   database must configure and reference an API Mesh gateway — the SDK offers no direct path.
+2. **`meshId` is opaque and environment-specific.** It is a hash produced by `aio api-mesh:describe`.
+   Each deployment environment (dev, stage, prod) has a different ID; the SDK config has no mechanism
+   to express this, so developers either hard-code one environment's ID or work around the problem
+   entirely outside the SDK.
+3. **The wire contract is undocumented.** Handlers had to parse `?ids=a,b,c` as a comma-joined query
+   string, know that the returned object key was `orderGridColumns` (not `customerGridColumns`, not a
+   generic name), and discover the `"*"` wildcard default behavior from source code. None of this was
+   specified anywhere in the SDK.
+4. **Order, product, and customer grids are architecturally identical but treated as three separate
+   concerns.** Three pages of documentation and three schema branches describe the same pattern.
+
+**Goals**
+
+- Replace `data.meshId` with `data.backend` (a `workerProcess` operation name) in all three grids.
+- Rename `properties` → `columns`, `columnId` → `key` for clarity.
+- Formally specify the request/response wire contract.
+- Remove `commerce/backend-ui/1` and all v1 schema artifacts from the SDK.
+- Use a single unified column schema under `order.gridColumns`, `product.gridColumns`, and
+  `customer.gridColumns`.
+
+**Non-goals**
+
+- Supporting v1 in any compatibility mode or deprecation window.
+- Adding grid targets beyond order, product, and customer.
+- Implementing mass action v2 (separate ticket).
+- Wrapping or managing the Commerce API Mesh service.
+
+## Developer experience
+
+### Defining grid columns
+
+The config shape is the same across all three grids:
+
+```ts
+// app-config.ts
+export default defineConfig({
+  adminUiSdk: {
+    registration: {
+      order: {
+        gridColumns: {
+          data: { backend: "fetch-order-grid-data" },
+          columns: [
+            {
+              key: "fulfillment_status",
+              label: "Fulfillment",
+              type: "string",
+              align: "left",
+            },
+            {
+              key: "risk_score",
+              label: "Risk",
+              type: "integer",
+              align: "right",
+            },
+          ],
+        },
+      },
+      product: {
+        gridColumns: {
+          data: { backend: "fetch-product-grid-data" },
+          columns: [
+            {
+              key: "inventory_status",
+              label: "Inventory",
+              type: "string",
+              align: "left",
+            },
+          ],
+        },
+      },
+    },
+  },
+});
+```
+
+`data.backend` must match the name of a `workerProcess` operation declared on
+`commerce/backend-ui/2` in `app.config.yaml`. App Registry resolves the name to the deployed
+runtime action URL — developers never write a URL directly.
+
+```yaml
+# app.config.yaml
+extensions:
+  commerce/backend-ui/2:
+    operations:
+      workerProcess:
+        - type: action
+          impl: orders/fetch-order-grid-data
+        - type: action
+          impl: products/fetch-product-grid-data
+```
+
+### Wire contract
+
+**Request** (sent by Commerce to the handler):
+
+```json
+{
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "gridType": "order",
+  "ids": ["000000001", "000000002", "000000003"]
+}
+```
+
+- `ids` is a real array. v1 sent `?ids=a,b,c` as a comma-joined query string — this changes.
+- `gridType` is `"customer" | "order" | "product"`. A single handler can serve multiple grids
+  by branching on it, or a developer can write one handler per grid.
+- Commerce chunks to a maximum of 1000 IDs per request. Handlers do not need to implement chunking.
+
+**Success response:**
+
+```json
+{
+  "data": {
+    "000000001": { "fulfillment_status": "shipped", "risk_score": 12 },
+    "000000002": { "fulfillment_status": "pending", "risk_score": 47 },
+    "*": { "fulfillment_status": "unknown", "risk_score": 0 }
+  }
+}
+```
+
+- Each row is keyed by the matching grid ID.
+- The `"*"` key supplies default cell values for IDs absent from the response and for cells whose
+  returned value does not satisfy the declared `type`. It is not a failure fallback.
+- Per-cell type mismatches fall back to `"*"`, then to empty if `"*"` is absent.
+
+**Failure response:**
+
+```json
+{
+  "errorStatus": "INTERNAL_ERROR",
+  "errorMessage": "Could not reach inventory service"
+}
+```
+
+On failure or timeout: all custom-column cells render empty. A single banner notification is
+surfaced on grid load: _"Could not load custom columns from `<app name>`."_ Defaults via `"*"` are
+not applied — they are for unmatched IDs inside a successful response, not for outages.
+
+### Column types
+
+| `type` value | Description                          |
+| ------------ | ------------------------------------ |
+| `boolean`    | Boolean value                        |
+| `date`       | Date (no time component)             |
+| `datetime`   | Date and time                        |
+| `decimal`    | Decimal number (replaces v1 `float`) |
+| `integer`    | Integer                              |
+| `string`     | Text                                 |
+
+### Migration from v1
+
+| v1                                       | v2                           | Notes                                                         |
+| ---------------------------------------- | ---------------------------- | ------------------------------------------------------------- |
+| `data.meshId`                            | `data.backend`               | Operation name declared in `app.config.yaml`, not a Mesh hash |
+| `properties`                             | `columns`                    | Array of column declarations                                  |
+| `properties[].columnId`                  | `columns[].key`              | Doubles as the response data key — make them match            |
+| `properties[].type: "float"`             | `columns[].type: "decimal"`  | Renamed                                                       |
+| _(absent)_                               | `columns[].type: "datetime"` | New type in v2                                                |
+| Extension point: `commerce/backend-ui/1` | `commerce/backend-ui/2`      | Required change in `app.config.yaml`                          |
+
+## Design
+
+### Schema changes
+
+`packages/aio-commerce-lib-app/source/config/schema/admin-ui-sdk.ts`
+
+Remove `GridColumnPropertySchema` (v1) and `GridColumnsSchema` (v1). Add:
+
+```ts
+const GridColumnSchema = v.object({
+  key: nonEmptyStringValueSchema("column key"),
+  label: nonEmptyStringValueSchema("column label"),
+  type: v.picklist([
+    "boolean",
+    "date",
+    "datetime",
+    "decimal",
+    "integer",
+    "string",
+  ]),
+  align: ColumnAlignSchema, // 'left' | 'center' | 'right' — unchanged
+});
+
+const GridColumnsSchema = v.object({
+  data: v.object({ backend: nonEmptyStringValueSchema("backend operation") }),
+  columns: v.pipe(
+    v.array(GridColumnSchema),
+    v.minLength(1, "At least one column is required"),
+  ),
+});
+```
+
+`OrderExtensionPointsSchema`, `ProductExtensionPointsSchema`, and
+`CustomerExtensionPointsSchema` continue to reference `GridColumnsSchema` by name — the reference
+is unchanged, the schema it points to is replaced.
+
+The exported `GridColumns` type is updated automatically via `v.InferInput<typeof GridColumnsSchema>`.
+
+### Extension point constant
+
+`packages/aio-commerce-lib-app/source/commands/constants.ts`
+
+```ts
+// before
+export const BACKEND_UI_EXTENSION_POINT_ID = "commerce/backend-ui/1";
+
+// after
+export const BACKEND_UI_EXTENSION_POINT_ID = "commerce/backend-ui/2";
+```
+
+The constant name is preserved so callsites do not change. Only the value changes.
+
+### Pre-app-build hook
+
+`packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts`
+
+Remove `"backend-ui/1"` from the `Extension` union and replace with `"backend-ui/2"`. The hook
+continues to call `generateRegistrationActionFile` when `hasAdminUiSdk` is true — no structural
+change needed. The v2 config shape (with `backend` and `columns`) passes through the existing
+serialization path unchanged.
+
+### Registration action generation
+
+No template change is needed. The registration action at
+`packages/aio-commerce-lib-app/source/commands/generate/actions/templates/admin-ui-sdk/registration.js.template`
+inlines the config as a JS object literal. The v2 object shape serializes correctly through the
+existing `stringify` call. App Registry resolves `data.backend` to the deployed URL at runtime.
+
+### Changeset bump
+
+This is a `minor` bump. All affected types are marked `@experimental`, so breaking changes to them
+do not constitute a semver-major change under the SDK's stability policy.
+
+## Drawbacks
+
+- Apps that genuinely need API Mesh federation must wire it inside the handler themselves. The SDK
+  no longer manages the Mesh reference. This is intentional — Mesh is now a handler implementation
+  detail, not a config-level concern.
+- `key` doing double duty (response data key and column identifier) is explicit by design, but
+  developers used to v1's separate `columnId` field may find it surprising at first.
+- Dropping v1 requires migration for any existing app using grid columns. There is no deprecation
+  window.
+
+## Rationale and alternatives
+
+**Keep v1 alongside v2.**
+Rejected. A compatibility shim would preserve exactly the problem being solved: the undocumented
+Mesh coupling and the opaque `meshId`. There is no scenario in which both schemas would be
+simultaneously correct.
+
+**Make `meshId` optional in v1.**
+Rejected. This does not solve the multi-environment problem (the ID is still environment-specific),
+and the wire contract remains undocumented. It would also introduce a conditional path where the
+SDK sometimes validates Mesh presence and sometimes does not, increasing complexity with no net gain.
+
+**Per-grid schemas instead of a unified one.**
+Rejected per "one concept, one place." The three grids have identical structure. `gridType` in the
+wire request lets a single handler serve multiple grids if the developer chooses; the SDK need not
+enforce separation.
+
+**Impact of not doing this.**
+Grid columns remain coupled to API Mesh, blocking apps that don't need federation, and the wire
+contract remains undocumented. The multi-environment `meshId` problem has no SDK-level solution.
+
+## Unresolved questions
+
+**Single-operation constraint.**
+Can the same `backend` value appear in `order.gridColumns` and `customer.gridColumns`? The SDK
+imposes no uniqueness constraint — the same operation name can appear in multiple grid column
+blocks. A single handler would then receive requests for both grid types and branch on `gridType`.
+Confirm this is correct and no constraint should be added.
+
+## Future possibilities
+
+- Additional grid targets (invoice, shipment grids) following the same unified schema pattern.
+- Handler scaffolding: `aio commerce generate handler --type grid-columns` to generate a typed
+  handler stub that implements the wire contract.

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -50,6 +50,7 @@ The v1 grid column design has four concrete problems that compound each other:
 - Adding grid targets beyond order, product, and customer.
 - Implementing mass action v2 (separate ticket).
 - Wrapping or managing the Commerce API Mesh service.
+- Creating app-management or app-migration plugin skills for scaffolding or migrating grid column extensions — handled in a separate scope.
 
 ## Developer experience
 

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -61,7 +61,7 @@ The config shape is the same across all three grids:
 ```ts
 // app-config.ts
 export default defineConfig({
-  adminUiSdk: {
+  adminUi: {
     registration: {
       order: {
         gridColumns: {

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -183,6 +183,17 @@ extensions:
 
 ## Design
 
+### Config key rename
+
+The top-level config key changes from `adminUiSdk` to `adminUi`. This is a rename across the SDK:
+
+- The config property in `defineConfig()` — `adminUiSdk` → `adminUi`
+- `AdminUiSdkSchema` → `AdminUiSchema`
+- `AdminUiSdkConfiguration` → `AdminUiConfiguration`
+- `AdminUiSdkRegistration` → `AdminUiRegistration`
+- `hasAdminUiSdk()` → `hasAdminUi()`
+- All related exported types and guards in `packages/aio-commerce-lib-app`
+
 ### Schema changes
 
 `packages/aio-commerce-lib-app/source/config/schema/admin-ui-sdk.ts`

--- a/specs/features/CEXT-6096-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-grid-column-extensions.md
@@ -65,7 +65,7 @@ export default defineConfig({
     registration: {
       order: {
         gridColumns: {
-          data: { backend: "fetch-order-grid-data" },
+          runtimeAction: "fetch-order-grid-data",
           columns: [
             {
               key: "fulfillment_status",
@@ -84,7 +84,7 @@ export default defineConfig({
       },
       product: {
         gridColumns: {
-          data: { backend: "fetch-product-grid-data" },
+          runtimeAction: "fetch-product-grid-data",
           columns: [
             {
               key: "inventory_status",
@@ -100,7 +100,7 @@ export default defineConfig({
 });
 ```
 
-`data.backend` must match the name of a `workerProcess` operation declared on
+`runtimeAction` must match the name of a `workerProcess` operation declared on
 `commerce/backend-ui/2` in `app.config.yaml`. App Registry resolves the name to the deployed
 runtime action URL — developers never write a URL directly.
 
@@ -174,7 +174,7 @@ extensions:
 
 | v1                                       | v2                           | Notes                                                         |
 | ---------------------------------------- | ---------------------------- | ------------------------------------------------------------- |
-| `data.meshId`                            | `data.backend`               | Operation name declared in `app.config.yaml`, not a Mesh hash |
+| `data.meshId`                            | `runtimeAction`              | Operation name declared in `app.config.yaml`, not a Mesh hash |
 | `properties`                             | `columns`                    | Array of column declarations                                  |
 | `properties[].columnId`                  | `columns[].key`              | Doubles as the response data key — make them match            |
 | `properties[].type: "float"`             | `columns[].type: "decimal"`  | Renamed                                                       |
@@ -216,7 +216,7 @@ const GridColumnSchema = v.object({
 });
 
 const GridColumnsSchema = v.object({
-  data: v.object({ backend: nonEmptyStringValueSchema("backend operation") }),
+  runtimeAction: nonEmptyStringValueSchema("runtime action"),
   columns: v.pipe(
     v.array(GridColumnSchema),
     v.minLength(1, "At least one column is required"),
@@ -255,10 +255,12 @@ serialization path unchanged.
 
 ### Registration action generation
 
-No template change is needed. The registration action at
-`packages/aio-commerce-lib-app/source/commands/generate/actions/templates/admin-ui-sdk/registration.js.template`
-inlines the config as a JS object literal. The v2 object shape serializes correctly through the
-existing `stringify` call. App Registry resolves `data.backend` to the deployed URL at runtime.
+No template change is needed. Before serialization, the SDK transforms the developer-facing config
+into the Commerce-facing registration format: `runtimeAction` is mapped to `data.backend` for each
+grid type that declares `gridColumns`. This transform runs in `generateRegistrationActionFile`
+before the `stringify` call, so the generated registration action contains `data.backend` — the
+shape Commerce expects — while developers write `runtimeAction` in their app config, consistent
+with the rest of the SDK (webhooks, events).
 
 ### Changeset bump
 
@@ -299,8 +301,8 @@ contract remains undocumented. The multi-environment `meshId` problem has no SDK
 ## Unresolved questions
 
 **Single-operation constraint.**
-Can the same `backend` value appear in `order.gridColumns` and `customer.gridColumns`? The SDK
-imposes no uniqueness constraint — the same operation name can appear in multiple grid column
+Can the same `runtimeAction` value appear in `order.gridColumns` and `customer.gridColumns`? The
+SDK imposes no uniqueness constraint — the same operation name can appear in multiple grid column
 blocks. A single handler would then receive requests for both grid types and branch on `gridType`.
 Confirm this is correct and no constraint should be added.
 


### PR DESCRIPTION
## Description

Adds a spec for the v2 Admin UI SDK grid column schema, covering order, product, and customer grids.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-6096

## Motivation and Context

The v1 grid column design has three main problems: it requires API Mesh even for trivial cases, `meshId` is opaque and environment-specific, and the wire contract between Commerce and the handler is undocumented. The v2 schema drops Mesh as an SDK-config concept, replaces `data.meshId` with `data.backend` (a `workerProcess` operation name), unifies the three grids under one schema shape, and formally specifies the wire contract.

v1 (`commerce/backend-ui/1`) is removed with no compatibility window. All affected types are `@experimental`, so this is a `minor` bump.

## How Has This Been Tested?

Spec-only change — no code modified.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.