### PR TITLE
add .npmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ web_modules/
 # Optional npm cache directory
 .npm
 
+# npm/pnpm auth config — may contain registry tokens
+.npmrc
+
 # Optional eslint cache
 .eslintcache
 


### PR DESCRIPTION
## Description

Adds `.npmrc` to `.gitignore`.

## Motivation and Context

`.npmrc` was not listed in `.gitignore`, which was a contributing factor to the token leak described in the [RCA](https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3901740898). The primary fix (PR #474) already eliminates the vector by replacing manual token-writing with `setup-node` auth, but ignoring `.npmrc` ensures any future workspace-level `.npmrc` — however created — cannot be accidentally staged by `git add .`.

## How Has This Been Tested?

No automated tests needed — `.gitignore` change only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] All new and existing tests passed.