### PR TITLE
CEXT-6324: fix config cache TTL ignored in setCachedConfig

### DIFF
--- a/.changeset/thin-regions-enjoy.md
+++ b/.changeset/thin-regions-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-config": patch
+---
+
+Fix an issue where the configured cache was not being set when caching values in `@adobe/aio-lib-state`

--- a/.changeset/thin-regions-enjoy.md
+++ b/.changeset/thin-regions-enjoy.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-lib-config": patch
 ---
 
-Fix an issue where the configured cache was not being set when caching values in `@adobe/aio-lib-state`
+Fix an issue where the configured cache was not being set when caching values in `@adobe/aio-lib-state`. Also, correct an annotation that was mistakenly affirming that the cache timeout needs to be specified in milliseconds, while it must be in seconds.

--- a/packages/aio-commerce-lib-config/source/modules/configuration/configuration-repository.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/configuration-repository.ts
@@ -43,14 +43,20 @@ export async function getCachedConfig(scopeCode: string) {
  * @param scopeCode - Scope code identifier.
  * @param payload - Configuration payload as JSON string.
  */
-export async function setCachedConfig(scopeCode: string, payload: string) {
+export async function setCachedConfig(
+  scopeCode: string,
+  payload: string,
+  ttlSeconds: number,
+) {
   const logger = getLogger(
     "@adobe/aio-commerce-lib-config:configuration-repository",
   );
   try {
     const state = await getSharedState();
     const key = getConfigStateKey(scopeCode);
-    await state.put(key, stringify({ data: payload }) as string);
+    await state.put(key, stringify({ data: payload }) as string, {
+      ttl: ttlSeconds,
+    });
   } catch (error) {
     logger.debug(
       "Failed to cache configuration:",
@@ -102,7 +108,11 @@ export async function saveConfig(scopeCode: string, payload: string) {
  * @param scopeCode - The scope code to persist configuration for.
  * @param payload - The configuration payload object.
  */
-export async function persistConfig(scopeCode: string, payload: unknown) {
+export async function persistConfig(
+  scopeCode: string,
+  payload: unknown,
+  ttlSeconds: number,
+) {
   const payloadString = stringify(payload) as string;
   const logger = getLogger(
     "@adobe/aio-commerce-lib-config:configuration-repository",
@@ -113,7 +123,7 @@ export async function persistConfig(scopeCode: string, payload: unknown) {
 
   // Try to cache in state for faster reads
   try {
-    await setCachedConfig(scopeCode, payloadString);
+    await setCachedConfig(scopeCode, payloadString, ttlSeconds);
   } catch (e) {
     logger.debug("Failed to cache configuration in state", {
       scopeCode,
@@ -152,7 +162,7 @@ async function loadFromStateCache(scopeCode: string) {
  * @param scopeCode - The scope code to load configuration for.
  * @returns Promise resolving to parsed configuration or null if not found.
  */
-async function loadFromPersistedFiles(scopeCode: string) {
+async function loadFromPersistedFiles(scopeCode: string, ttlSeconds: number) {
   const logger = getLogger(
     "@adobe/aio-commerce-lib-config:configuration-repository",
   );
@@ -164,7 +174,7 @@ async function loadFromPersistedFiles(scopeCode: string) {
 
     // Try to cache the file data for future reads
     try {
-      await setCachedConfig(scopeCode, filePayload);
+      await setCachedConfig(scopeCode, filePayload, ttlSeconds);
     } catch (err) {
       logger.debug("Failed to cache configuration in state", {
         scopeCode,
@@ -194,13 +204,13 @@ async function loadFromPersistedFiles(scopeCode: string) {
  * @param scopeCode - The scope code to load configuration for.
  * @returns Promise resolving to configuration payload or null if not found.
  */
-export async function loadConfig(scopeCode: string) {
+export async function loadConfig(scopeCode: string, ttlSeconds: number) {
   const fromState = await loadFromStateCache(scopeCode);
   if (fromState) {
     return fromState;
   }
 
-  const fromFiles = await loadFromPersistedFiles(scopeCode);
+  const fromFiles = await loadFromPersistedFiles(scopeCode, ttlSeconds);
   if (fromFiles) {
     return fromFiles;
   }

--- a/packages/aio-commerce-lib-config/source/modules/configuration/configuration-repository.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/configuration-repository.ts
@@ -108,6 +108,7 @@ export async function saveConfig(scopeCode: string, payload: string) {
  *
  * @param scopeCode - The scope code to persist configuration for.
  * @param payload - The configuration payload object.
+ * @param ttlSeconds - Time to live for the cached configuration value.
  */
 export async function persistConfig(
   scopeCode: string,
@@ -161,6 +162,8 @@ async function loadFromStateCache(scopeCode: string) {
  * Tries to load configuration from persisted files.
  *
  * @param scopeCode - The scope code to load configuration for.
+ * @param ttlSeconds - Time to live for the cached configuration value.
+
  * @returns Promise resolving to parsed configuration or null if not found.
  */
 async function loadFromPersistedFiles(scopeCode: string, ttlSeconds: number) {
@@ -203,6 +206,8 @@ async function loadFromPersistedFiles(scopeCode: string, ttlSeconds: number) {
  * Loads configuration with smart fallback strategy (state -> files -> cache).
  *
  * @param scopeCode - The scope code to load configuration for.
+ * @param ttlSeconds - Time to live for the cached configuration value.
+
  * @returns Promise resolving to configuration payload or null if not found.
  */
 export async function loadConfig(scopeCode: string, ttlSeconds: number) {

--- a/packages/aio-commerce-lib-config/source/modules/configuration/configuration-repository.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/configuration-repository.ts
@@ -42,6 +42,7 @@ export async function getCachedConfig(scopeCode: string) {
  *
  * @param scopeCode - Scope code identifier.
  * @param payload - Configuration payload as JSON string.
+ * @param ttlSeconds - Time to live for the cached configuration value.
  */
 export async function setCachedConfig(
   scopeCode: string,

--- a/packages/aio-commerce-lib-config/source/modules/configuration/get-config.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/get-config.ts
@@ -47,7 +47,10 @@ export async function fetchRawConfiguration(
     scopeTree,
   );
 
-  let configData = await configRepository.loadConfig(scopeCode);
+  let configData = await configRepository.loadConfig(
+    scopeCode,
+    context.cacheTimeout,
+  );
   if (!configData) {
     const defaults = getSchemaDefaults(schema);
     configData = {
@@ -65,7 +68,8 @@ export async function fetchRawConfiguration(
       scopeLevel,
       scopePath,
 
-      loadScopeConfigFn: (code: string) => configRepository.loadConfig(code),
+      loadScopeConfigFn: (code: string) =>
+        configRepository.loadConfig(code, context.cacheTimeout),
       getSchemaFn: async () => Promise.resolve(schema),
     });
   } catch {

--- a/packages/aio-commerce-lib-config/source/modules/configuration/set-config.ts
+++ b/packages/aio-commerce-lib-config/source/modules/configuration/set-config.ts
@@ -66,7 +66,10 @@ export async function setConfiguration(
     context.encryptionKey,
   );
 
-  const existingPersisted = await configRepository.loadConfig(scopeCode);
+  const existingPersisted = await configRepository.loadConfig(
+    scopeCode,
+    context.cacheTimeout,
+  );
   const existingEntries = Array.isArray(existingPersisted?.config)
     ? (existingPersisted?.config ?? [])
     : [];
@@ -83,7 +86,11 @@ export async function setConfiguration(
     config: mergedScopeConfig,
   };
 
-  await configRepository.persistConfig(scopeCode, payload);
+  await configRepository.persistConfig(
+    scopeCode,
+    payload,
+    context.cacheTimeout,
+  );
 
   return {
     message: "Configuration values updated successfully",

--- a/packages/aio-commerce-lib-config/source/types/index.ts
+++ b/packages/aio-commerce-lib-config/source/types/index.ts
@@ -15,7 +15,7 @@ export * from "./commerce";
 
 /** Options for controlling operations of the configuration library. */
 export type OperationOptions = {
-  /** Optional cache timeout in milliseconds. */
+  /** Optional cache timeout in seconds. */
   cacheTimeout?: number;
 };
 

--- a/packages/aio-commerce-lib-config/test/integration/config-manager.test.ts
+++ b/packages/aio-commerce-lib-config/test/integration/config-manager.test.ts
@@ -128,6 +128,7 @@ describe("config-manager", () => {
           origin: { code: "global", level: "global" },
         },
       ]),
+      300,
     );
 
     const result = await getConfiguration(byCodeAndLevel("global", "global"));

--- a/packages/aio-commerce-lib-config/test/unit/config-manager.test.ts
+++ b/packages/aio-commerce-lib-config/test/unit/config-manager.test.ts
@@ -180,6 +180,49 @@ describe("ConfigManager functions", () => {
     ).toBe("£");
   });
 
+  test("passes default cacheTimeout as TTL when caching on file fallback", async () => {
+    await configRepository.saveConfig(
+      "global",
+      buildPayload("id1", "global", "global", []),
+    );
+
+    await getConfiguration(byCodeAndLevel("global", "global"));
+
+    const putCalls = mockStateInstance.put.mock.calls;
+    expect(putCalls.length).toBeGreaterThan(0);
+    const ttlValues = putCalls.map((call) => call[2]?.ttl);
+    expect(ttlValues.every((ttl) => ttl === 300)).toBe(true);
+  });
+
+  test("passes custom cacheTimeout as TTL when caching on file fallback", async () => {
+    await configRepository.saveConfig(
+      "global",
+      buildPayload("id1", "global", "global", []),
+    );
+
+    await getConfiguration(byCodeAndLevel("global", "global"), {
+      cacheTimeout: 600,
+    });
+
+    const putCalls = mockStateInstance.put.mock.calls;
+    expect(putCalls.length).toBeGreaterThan(0);
+    const ttlValues = putCalls.map((call) => call[2]?.ttl);
+    expect(ttlValues.every((ttl) => ttl === 600)).toBe(true);
+  });
+
+  test("passes cacheTimeout as TTL when persisting via setConfiguration", async () => {
+    await setConfiguration(
+      { config: [{ name: "currency", value: "JPY" }] },
+      byCodeAndLevel("global", "global"),
+      { cacheTimeout: 120 },
+    );
+
+    const putCalls = mockStateInstance.put.mock.calls;
+    expect(putCalls.length).toBeGreaterThan(0);
+    const ttlValues = putCalls.map((call) => call[2]?.ttl);
+    expect(ttlValues.every((ttl) => ttl === 120)).toBe(true);
+  });
+
   test("merges inherited values from parent scopes", async () => {
     // Set up global scope config (top-level parent)
     await configRepository.saveConfig(

--- a/packages/aio-commerce-lib-config/test/unit/config-manager.test.ts
+++ b/packages/aio-commerce-lib-config/test/unit/config-manager.test.ts
@@ -148,6 +148,7 @@ describe("ConfigManager functions", () => {
           origin: { code: "global", level: "global" },
         },
       ]),
+      300,
     );
 
     const result = await getConfiguration(byCodeAndLevel("global", "global"));


### PR DESCRIPTION
## Description

`setCachedConfig` was calling `state.put()` without a TTL, so cache entries used `aio-lib-state`'s default (24 h) regardless of the `cacheTimeout` configured on `ConfigContext`. This fix threads `cacheTimeout` from `ConfigContext` down through `loadConfig`, `persistConfig`, `loadFromPersistedFiles`, and into `setCachedConfig` — matching the pattern `setCachedScopeTree` already used correctly.

## Related Issue

[CEXT-6324](https://jira.corp.adobe.com/browse/CEXT-6324)

## Motivation and Context

With the default `cacheTimeout` of 300 s (~5 min), cache entries were actually persisting for 24 h before expiring and falling back to lib-files — 288× longer than intended.

## How Has This Been Tested?

Existing unit and integration tests updated to pass the required `ttlSeconds` argument; all tests pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.