### PR TITLE
CEXT-6330: add commerce-app-storage agent skill

### DIFF
--- a/plugins/commerce/app-management/README.md
+++ b/plugins/commerce/app-management/README.md
@@ -27,6 +27,7 @@ A developer creating an app that needs events and webhooks would run `commerce-a
 | [commerce-app-eventing](./skills/commerce-app-eventing/)               | Manage Commerce and external event sources | Available |
 | [commerce-app-webhooks](./skills/commerce-app-webhooks/)               | Manage webhook interception                | Available |
 | [commerce-app-business-config](./skills/commerce-app-business-config/) | Manage custom business configuration       | Available |
+| [commerce-app-storage](./skills/commerce-app-storage/)                 | Integrate App Builder Database Storage     | Available |
 
 ## Installation
 
@@ -50,4 +51,5 @@ npx skills add adobe/aio-commerce-sdk --skill commerce-app-init
 npx skills add adobe/aio-commerce-sdk --skill commerce-app-eventing
 npx skills add adobe/aio-commerce-sdk --skill commerce-app-webhooks
 npx skills add adobe/aio-commerce-sdk --skill commerce-app-business-config
+npx skills add adobe/aio-commerce-sdk --skill commerce-app-storage
 ```

--- a/plugins/commerce/app-management/skills/commerce-app-business-config/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-business-config/SKILL.md
@@ -24,7 +24,11 @@ Other extensibility domains (webhooks, events) are added separately via their ow
 
 ## Prerequisites
 
-Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
+- Verify the app is **scaffolded and initialized**, not merely that the config exists. Require **both**:
+  - `app.commerce.config.ts` present in the project root, **and**
+  - the project initialized — signalled by the generated `src/commerce-extensibility-1/` directory and installed `node_modules` (the `@adobe/aio-commerce-lib-app` dependency).
+- If `app.commerce.config.ts` is **missing**, stop and invoke `commerce-app-init` first (it writes the config, then runs init).
+- If the config is **present but the project is not initialized** (no `src/commerce-extensibility-1/` or `node_modules`), run `npx @adobe/aio-commerce-lib-app init` before continuing. Init is idempotent — it finds the existing config, skips the interactive prompts, installs dependencies, and generates the project files.
 
 ## Step 1 — Understand intent
 

--- a/plugins/commerce/app-management/skills/commerce-app-eventing/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-eventing/SKILL.md
@@ -23,7 +23,11 @@ Extensibility domains other than eventing (webhooks, business config) are added 
 
 ## Prerequisites
 
-- Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
+- Verify the app is **scaffolded and initialized**, not merely that the config exists. Require **both**:
+  - `app.commerce.config.ts` present in the project root, **and**
+  - the project initialized — signalled by the generated `src/commerce-extensibility-1/` directory and installed `node_modules` (the `@adobe/aio-commerce-lib-app` dependency).
+- If `app.commerce.config.ts` is **missing**, stop and invoke `commerce-app-init` first (it writes the config, then runs init).
+- If the config is **present but the project is not initialized** (no `src/commerce-extensibility-1/` or `node_modules`), run `npx @adobe/aio-commerce-lib-app init` before continuing. Init is idempotent — it finds the existing config, skips the interactive prompts, installs dependencies, and generates the project files.
 - Ensure `CloudIntegrationSDK` (I/O Events) and `commerceeventing` (Adobe I/O Events for Adobe Commerce) are subscribed in the Developer Console workspace:
   1. List currently subscribed services:
 

--- a/plugins/commerce/app-management/skills/commerce-app-init/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-init/SKILL.md
@@ -28,7 +28,7 @@ Extensibility domains (events, webhooks, business config) are added separately v
 
 ## Step 1 — Create the config
 
-Derive values for the following fields from the user's intent, confirm, and write the file to the project root:
+If `app.commerce.config.ts` already exists in the project root, do **not** overwrite it — skip straight to Step 2 (this skill is safe to re-invoke on an app that already has a config). Otherwise, derive values for the following fields from the user's intent, confirm, and write the file to the project root:
 
 ```ts
 // app.commerce.config.ts
@@ -48,13 +48,13 @@ See [assets/app.commerce.config.ts](assets/app.commerce.config.ts) for the full 
 
 ## Step 2 — Initialize the project
 
-Run init — it finds the existing config, validates it, and handles project setup:
+Always run init — it finds the existing config, validates it, and handles project setup:
 
 ```sh
 npx @adobe/aio-commerce-lib-app init
 ```
 
-Since `app.commerce.config.ts` already exists, init skips the interactive prompts.
+Since `app.commerce.config.ts` already exists, init skips the interactive prompts. Re-running is safe: when a config is present it installs dependencies and (re)generates the project files — the `app-management` package is regenerated, while user packages under `src/commerce-extensibility-1/actions/` are preserved (see Project structure below).
 
 ### Project structure
 

--- a/plugins/commerce/app-management/skills/commerce-app-init/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-init/evals/evals.json
@@ -36,6 +36,17 @@
         "Agent suggests using commerce-app-eventing skill for the event source setup",
         "aio app build completes without errors"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "My project already has an app.commerce.config.ts at the root, but it was never initialized — there's no src/commerce-extensibility-1/ directory and no node_modules. Get the project ready to build.",
+      "expected_output": "The agent detects the existing config, does not overwrite it, and runs npx @adobe/aio-commerce-lib-app init to install dependencies and generate the project files. It notes that re-running init is safe because a config is present (it skips the interactive prompts), and confirms with aio app build.",
+      "assertions": [
+        "The existing app.commerce.config.ts is not overwritten",
+        "The agent runs npx @adobe/aio-commerce-lib-app init",
+        "The agent explains init is idempotent / safe to re-run when a config exists",
+        "aio app build completes without errors"
+      ]
     }
   ]
 }

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: commerce-app-storage
+description: >
+  Integrate App Builder Database Storage (@adobe/aio-lib-db) into an Adobe
+  Commerce app and scaffold a runtime action that reads and writes documents.
+  Use when the user wants persistent, queryable storage backing a Commerce app —
+  either from a web action (HTTP-invokable) or from an event/webhook handler.
+  Requires a base app initialized with commerce-app-init.
+license: Apache-2.0
+compatibility: >
+  Requires Node.js 22+, aio CLI, @adobe/aio-commerce-lib-app, and a provisioned
+  workspace database with the App Builder Data Services API subscribed.
+  Requires a base app initialized with commerce-app-init.
+metadata:
+  author: adobe
+  sdk-package: "@adobe/aio-lib-db"
+  version: "0.0.1"
+---
+
+# Add Database Storage to a Commerce App
+
+Integrates App Builder Database Storage into an existing Commerce app and scaffolds a runtime action that uses `@adobe/aio-lib-db` to read and write documents. The library is MongoDB-like: data lives in collections of documents, queried with familiar filters.
+
+The db-access code is identical regardless of action type — what differs is how the action is registered and what its handler returns:
+
+- **Web action** — HTTP-invokable (`web: "yes"`); returns `{ statusCode, body }`.
+- **Event/webhook action** — invoked by a Commerce event or webhook; referenced from `app.commerce.config.ts` via `commerce-app-eventing` (`runtimeActions`) or `commerce-app-webhooks` (`runtimeAction`).
+
+## Prerequisites
+
+- Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
+- The **App Builder Data Services** API must be subscribed in the Developer Console workspace (no special license beyond App Builder). This API authenticates runtime actions to the database service.
+
+## Step 1 — Provision the workspace database
+
+There is a strict one-to-one relationship between an AIO project workspace and a workspace database. Provision it (self-service, no special permissions):
+
+```sh
+aio app db provision --region <amer|apac|emea|aus>
+```
+
+This provisions the database and writes a `database` entry to `app.config.yaml`. **Note the region** — the library must be initialized in the same region the database was provisioned in.
+
+## Step 2 — Install the library
+
+```sh
+npm install @adobe/aio-lib-db
+```
+
+## Step 3 — Understand intent
+
+Gather from the user:
+
+- **Action type**: web action or event/webhook action (see the two shapes above).
+- **Collection name** and the **operations** needed (insert / find / update / delete).
+- **Region**: must match Step 1. Pass it to `init()` or set `AIO_DB_REGION`.
+
+## Step 4 — Register the action
+
+Add the action to a user-defined package in `src/commerce-extensibility-1/ext.config.yaml` (any name except `app-management`, which is reserved). The `include-ims-credentials: true` annotation is **required** — `aio-lib-db` authenticates with the IMS token it injects.
+
+```yaml
+# src/commerce-extensibility-1/ext.config.yaml
+runtimeManifest:
+  packages:
+    app-management:
+      # ... auto-generated — do not edit
+    my-app: # any name except "app-management"
+      actions:
+        store-record:
+          function: actions/store-record/index.js # relative to src/commerce-extensibility-1/
+          runtime: nodejs:24
+          web: "yes" # "yes" for a web action; "no" for an event/webhook action
+          annotations:
+            include-ims-credentials: true # REQUIRED for aio-lib-db auth
+```
+
+| Field                     | Constraint                                                                        |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| Package name              | Lowercase alphanumeric + hyphens; never `app-management` (reserved)               |
+| `function`                | Path relative to `src/commerce-extensibility-1/` — not `src/...` or root-relative |
+| `include-ims-credentials` | Must be `true` — without it `init()` has no IMS token and the connection fails    |
+| `web`                     | `"yes"` for HTTP-invokable web actions; `"no"` for event/webhook handlers         |
+| Collection name           | Non-empty string; created on first write if it doesn't exist                      |
+| Region                    | Must match the provisioned region (`amer` \| `apac` \| `emea` \| `aus`)           |
+
+## Step 5 — Implement the handler
+
+Every handler follows the same lifecycle: generate token → `init` → `connect` → use a collection → **always `close` in `finally`**.
+
+```ts
+// Web action — src/commerce-extensibility-1/actions/store-record/index.ts
+import { Core } from "@adobe/aio-sdk";
+import { init as initDb } from "@adobe/aio-lib-db";
+
+export async function main(params: Record<string, unknown>) {
+  let client;
+  try {
+    const token = await Core.AuthClient.generateAccessToken(params); // IMS token
+    const db = await initDb({ token: token.access_token, region: "emea" }); // region must match provisioning
+    client = await db.connect();
+    const records = client.collection("records");
+
+    const result = await records.insertOne({
+      ...(params.document as object),
+      createdAt: new Date().toISOString(),
+    });
+    return { statusCode: 200, body: { ok: true, result } };
+  } catch (error: any) {
+    return {
+      statusCode: error.statusCode || 500,
+      body: { error: error.message },
+    };
+  } finally {
+    if (client) await client.close(); // always close — avoids connection leaks
+  }
+}
+```
+
+For an **event/webhook action** the only differences are `web: "no"` in registration and that the payload arrives in `params.data`:
+
+```ts
+// Event/webhook handler — same init/connect/close lifecycle
+export async function main(params: Record<string, unknown>) {
+  const data = params.data as Record<string, unknown>;
+  let client;
+  try {
+    const token = await Core.AuthClient.generateAccessToken(params);
+    const db = await initDb({ token: token.access_token, region: "emea" });
+    client = await db.connect();
+    await client
+      .collection("orders")
+      .insertOne({ orderId: data.order_id, receivedAt: new Date() });
+    return { statusCode: 200, body: { processed: true } };
+  } finally {
+    if (client) await client.close();
+  }
+}
+```
+
+See [assets/db-action.ts](assets/db-action.ts) for the full annotated reference covering all CRUD operations and cursor iteration.
+
+## Step 6 — Set up collections and indexes on install
+
+For an App Management app, create collections and indexes with a **custom installation step** — a script that runs once when the app is installed from the Commerce Admin, and can be reversed on uninstall. Prefer this over creating them ad-hoc on the first request.
+
+Author the step with `defineCustomInstallationStep` (an `install` handler plus an optional `uninstall`). Inside it, generate the IMS token from **`context.params`** — _not_ `config` — then follow the same init → connect → `close` lifecycle as Step 5, and call `createIndex` **on the collection object**:
+
+```ts
+// ./scripts/setup-database.ts — referenced from config as ./scripts/setup-database.js
+import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
+import { Core } from "@adobe/aio-sdk";
+import { init as initDb } from "@adobe/aio-lib-db";
+
+export default defineCustomInstallationStep({
+  install: async (config, context) => {
+    let client;
+    try {
+      // context.params carries the injected IMS credentials — NOT config.
+      const token = await Core.AuthClient.generateAccessToken(context.params);
+      const db = await initDb({ token: token.access_token, region: "emea" }); // region must match provisioning
+      client = await db.connect();
+
+      const orders = client.collection("held_orders"); // get the collection object first
+      await orders.createIndex({ order_id: 1 }, { unique: true }); // createIndex on the collection, not a name string
+      return { status: "success" };
+    } finally {
+      if (client) await client.close(); // always close — avoids connection leaks
+    }
+  },
+  uninstall: async (config, context) => {
+    let client;
+    try {
+      const token = await Core.AuthClient.generateAccessToken(context.params);
+      const db = await initDb({ token: token.access_token, region: "emea" });
+      client = await db.connect();
+      await client.collection("held_orders").drop();
+    } finally {
+      if (client) await client.close();
+    }
+  },
+});
+```
+
+Register the step in `app.commerce.config.ts` under `installation.customInstallationSteps`. The `script` path points at the compiled `.js` output:
+
+```ts
+// app.commerce.config.ts
+installation: {
+  customInstallationSteps: [
+    {
+      script: "./scripts/setup-database.js", // compiled output of setup-database.ts
+      name: "Set up held-orders collection",
+      description: "Creates the held_orders collection and a unique index on order_id",
+    },
+  ],
+},
+```
+
+| Field         | Constraint                                                                   |
+| ------------- | ---------------------------------------------------------------------------- |
+| `script`      | Path relative to the project root; must end in `.js` (the compiled step)     |
+| `name`        | Non-empty string, ≤ 255 characters; **unique** across all installation steps |
+| `description` | Non-empty string, ≤ 255 characters                                           |
+
+See [assets/setup-database.ts](assets/setup-database.ts) for the full annotated install/uninstall reference.
+
+## Step 7 — Validate
+
+```sh
+aio app build
+```
+
+A build failure points directly to the offending config field. To exercise the action against the real database, deploy and invoke it (`aio app deploy`).
+
+## Best practices
+
+- **Always close connections** in a `finally` block — leaked connections exhaust resources.
+- **Match the region** between provisioning and `init()`; a mismatch fails the connection silently from the caller's view.
+- **Use projections** (`.project({ field: 1 })`) and **indexes** (`createIndex`) for frequently queried fields; index fields must total ≤ 2048 bytes.
+- **Iterate large result sets with cursors** (`for await (const doc of collection.find(...))`) instead of `toArray()` to bound memory.
+- **Don't hardcode the region or secrets** — prefer `AIO_DB_REGION` and the injected IMS token over inline values.
+- **Set up collections and indexes during installation** with a custom installation step (`defineCustomInstallationStep`, see Step 6) rather than ad-hoc on the first request — it runs once when the app is installed from the Commerce Admin and is reversible on uninstall. A generic App Builder `post-app-deploy` hook is only an alternative when the app is not installed through App Management.
+
+## Common Issues
+
+- **Connection fails despite a valid token**: the action is missing `include-ims-credentials: true`, or the **App Builder Data Services** API is not subscribed in the workspace.
+- **Connection fails after a region change**: the library region doesn't match where the database was provisioned. To move regions you must `aio app db delete`, update the region, then re-provision.
+- **Querying by `_id` from a string returns nothing**: convert it first — `new ObjectId(idString)` from `bson`. A raw string never matches the stored `ObjectId`.
+- **`DbError` vs unexpected error**: errors thrown by the service have `name === "DbError"`; branch on it to separate database failures from application bugs.
+- **Auth fails inside an installation step**: the token must be generated from `context.params` (which carries the injected IMS credentials), not from `config`. `config` is the app configuration and holds no credentials.
+- **`createIndex` errors or has no effect**: it must be called on a collection object (`client.collection("name").createIndex({ field: 1 })`), not with a collection-name string. Get the collection first, then call `createIndex` on it.
+
+## Quality Bar
+
+- `aio app build` completes without errors
+- The action closes the client in a `finally` block and initializes the library in the provisioned region
+
+## Chaining
+
+- **Wire the action to an event** — invoke `commerce-app-eventing` and reference this action in an event's `runtimeActions`.
+- **Wire the action to a webhook** — invoke `commerce-app-webhooks` and reference this action via `runtimeAction`.
+
+## References
+
+- [assets/db-action.ts](assets/db-action.ts) — Full annotated handler: init/connect, CRUD, cursor iteration, and the close lifecycle
+- [assets/setup-database.ts](assets/setup-database.ts) — Full annotated custom installation step: install creates a collection and a unique index, uninstall drops it, with the `context.params` and `createIndex`-on-collection patterns

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -28,7 +28,11 @@ The db-access code is identical regardless of action type — what differs is ho
 
 ## Prerequisites
 
-- Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
+- Verify the app is **scaffolded and initialized**, not merely that the config exists. Require **both**:
+  - `app.commerce.config.ts` present in the project root, **and**
+  - the project initialized — signalled by the generated `src/commerce-extensibility-1/` directory and installed `node_modules` (the `@adobe/aio-commerce-lib-app` dependency).
+- If `app.commerce.config.ts` is **missing**, stop and invoke `commerce-app-init` first (it writes the config, then runs init).
+- If the config is **present but the project is not initialized** (no `src/commerce-extensibility-1/` or `node_modules`), run `npx @adobe/aio-commerce-lib-app init` before continuing. Init is idempotent — it finds the existing config, skips the interactive prompts, installs dependencies, and generates the project files.
 - The **App Builder Data Services** API (API code `AppBuilderDataServicesSDK`) must be **added to the project in the Adobe Developer Console** — in every workspace that uses the database (no special license beyond App Builder). Without it, runtime actions cannot authenticate to the database service.
 
 ## Step 1 — Provision the workspace database

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -43,9 +43,10 @@ application:
       region: emea # amer | apac | emea | aus — the single source of truth for the region
 ```
 
-For **local development**, declarative auto-provisioning does **not** run during `aio app run` / `aio app dev`. Provision once up front with the CLI fallback (self-service, no special permissions):
+For **local development**, declarative auto-provisioning does **not** run during `aio app run` / `aio app dev`. Provision once up front with the CLI fallback (self-service, no special permissions). The `aio app db …` commands are only available once the [storage CLI plugin](https://github.com/adobe/aio-cli-plugin-app-storage) is installed:
 
 ```sh
+aio plugins install @adobe/aio-cli-plugin-app-storage
 aio app db provision --region <amer|apac|emea|aus>
 ```
 
@@ -192,6 +193,8 @@ export default defineCustomInstallationStep({
 });
 ```
 
+> **Custom installation scripts must be plain JavaScript for now.** App Management only wires up `.js` step scripts; a `.ts` file works only if you compile it yourself and point `script` at the emitted `.js`. Author the step in JS directly, or treat the `.ts` reference as source and ship its compiled output.
+
 Register the step in `app.commerce.config.ts` under `installation.customInstallationSteps`. The `script` path points at the compiled `.js` output:
 
 ```ts
@@ -207,11 +210,11 @@ installation: {
 },
 ```
 
-| Field         | Constraint                                                                   |
-| ------------- | ---------------------------------------------------------------------------- |
-| `script`      | Path relative to the project root; must end in `.js` (the compiled step)     |
-| `name`        | Non-empty string, ≤ 255 characters; **unique** across all installation steps |
-| `description` | Non-empty string, ≤ 255 characters                                           |
+| Field         | Constraint                                                                                                     |
+| ------------- | -------------------------------------------------------------------------------------------------------------- |
+| `script`      | Path relative to the project root; must be plain JS ending in `.js` (TS only works if you compile it yourself) |
+| `name`        | Non-empty string, ≤ 255 characters; **unique** across all installation steps                                   |
+| `description` | Non-empty string, ≤ 255 characters                                                                             |
 
 See [assets/setup-database.ts](assets/setup-database.ts) for the full annotated install/uninstall reference.
 

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -23,7 +23,7 @@ Integrates App Builder Database Storage into an existing Commerce app and scaffo
 
 The db-access code is identical regardless of action type — what differs is how the action is registered and what its handler returns:
 
-- **Web action** — HTTP-invokable (`web: "yes"`); returns `{ statusCode, body }`.
+- **Web action** — HTTP-invokable (`web: "yes"`); returns a response built with the `responses` helpers from `@adobe/aio-commerce-lib-core`.
 - **Event/webhook action** — invoked by a Commerce event or webhook; referenced from `app.commerce.config.ts` via `commerce-app-eventing` (`runtimeActions`) or `commerce-app-webhooks` (`runtimeAction`).
 
 ## Prerequisites
@@ -100,6 +100,7 @@ Every handler follows the same lifecycle: generate token → `init` → `connect
 
 ```ts
 // Web action — src/commerce-extensibility-1/actions/store-record/index.ts
+import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
 import { Core } from "@adobe/aio-sdk";
 import { init as initDb } from "@adobe/aio-lib-db";
 
@@ -115,12 +116,11 @@ export async function main(params: Record<string, unknown>) {
       ...(params.document as object),
       createdAt: new Date().toISOString(),
     });
-    return { statusCode: 200, body: { ok: true, result } };
+    return ok({ body: { result } });
   } catch (error: any) {
-    return {
-      statusCode: error.statusCode || 500,
-      body: { error: error.message },
-    };
+    return buildErrorResponse(error.statusCode || 500, {
+      body: { message: error.message },
+    });
   } finally {
     if (client) await client.close(); // always close — avoids connection leaks
   }
@@ -141,7 +141,7 @@ export async function main(params: Record<string, unknown>) {
     await client
       .collection("orders")
       .insertOne({ orderId: data.order_id, receivedAt: new Date() });
-    return { statusCode: 200, body: { processed: true } };
+    return ok({ body: { processed: true } });
   } finally {
     if (client) await client.close();
   }

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -43,6 +43,19 @@ application:
       region: emea # amer | apac | emea | aus — the single source of truth for the region
 ```
 
+**Extension-only apps need a workaround.** Declarative auto-provision only runs when the `application` runtime manifest has at least one package with a runtime action. Apps built purely with `extensions` (the recommended layout per the submission guidelines) have no `application` actions, so `aio app deploy` silently skips provisioning. Make the `application` block "real enough" for provisioning to run by adding an empty packages map and a `post-app-build` hook that creates the directory the provisioning step expects:
+
+```yaml
+application:
+  hooks:
+    post-app-build: "mkdir -p dist/application/actions" # provisioning expects this dir to exist
+  runtimeManifest:
+    packages: {} # empty map — required by the config schema so the application block validates with no actions
+    database:
+      auto-provision: true
+      region: emea # single source of truth — see the region callout below
+```
+
 For **local development**, declarative auto-provisioning does **not** run during `aio app run` / `aio app dev`. Provision once up front with the CLI fallback (self-service, no special permissions). The `aio app db …` commands are only available once the [storage CLI plugin](https://github.com/adobe/aio-cli-plugin-app-storage) is installed:
 
 ```sh
@@ -239,6 +252,7 @@ A build failure points directly to the offending config field. To exercise the a
 ## Common Issues
 
 - **Connection fails despite a valid token**: the action is missing `include-ims-credentials: true`, or the **App Builder Data Services** API has not been added to the project in the Adobe Developer Console (see Prerequisites).
+- **DB not provisioned after `aio app deploy` (extension-only app)**: declarative auto-provision is skipped when the `application` runtime manifest has no runtime action. Apply the extension-only workaround from Step 1 — add `packages: {}` and a `post-app-build: "mkdir -p dist/application/actions"` hook under `application` — or provision once with the CLI fallback for local dev.
 - **Connection fails after a region change**: the library region doesn't match the manifest `database.region`. Moving regions is destructive — `aio app db delete`, update `database.region` in the manifest, then re-provision (`aio app deploy`, or the CLI fallback for local dev).
 - **Querying by `_id` from a string returns nothing**: convert it first — `new ObjectId(idString)` from `bson`. A raw string never matches the stored `ObjectId`.
 - **`DbError` vs unexpected error**: errors thrown by the service have `name === "DbError"`; branch on it to separate database failures from application bugs.

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -116,19 +116,24 @@ runtimeManifest:
 
 ## Step 5 — Implement the handler
 
-Every handler follows the same lifecycle: generate token → `init` → `connect` → use a collection → **always `close` in `finally`**.
+Every handler follows the same lifecycle: resolve IMS auth → mint token → `init` → `connect` → use a collection → **always `close` in `finally`**.
 
 ```ts
 // Web action — src/commerce-extensibility-1/actions/store-record/index.ts
 import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
-import { generateAccessToken } from "@adobe/aio-lib-core-auth";
+import {
+  getImsAuthProvider,
+  resolveImsAuthParams,
+} from "@adobe/aio-commerce-lib-auth";
 import { init as initDb } from "@adobe/aio-lib-db";
 
 export async function main(params: Record<string, unknown>) {
   let client;
   try {
-    const token = await generateAccessToken(params); // IMS token
-    const db = await initDb({ token: token.access_token, region: "emea" }); // must match the manifest database.region
+    // Resolve the injected AIO_COMMERCE_AUTH_IMS_* params, then mint a raw token string.
+    const authProvider = getImsAuthProvider(resolveImsAuthParams(params));
+    const token = await authProvider.getAccessToken();
+    const db = await initDb({ token, region: "emea" }); // must match the manifest database.region
     client = await db.connect();
     const records = client.collection("records");
 
@@ -155,8 +160,9 @@ export async function main(params: Record<string, unknown>) {
   const data = params.data as Record<string, unknown>;
   let client;
   try {
-    const token = await generateAccessToken(params);
-    const db = await initDb({ token: token.access_token, region: "emea" });
+    const authProvider = getImsAuthProvider(resolveImsAuthParams(params));
+    const token = await authProvider.getAccessToken();
+    const db = await initDb({ token, region: "emea" });
     client = await db.connect();
     await client
       .collection("orders")
@@ -174,12 +180,15 @@ See [assets/db-action.ts](assets/db-action.ts) for the full annotated reference 
 
 For an App Management app, create collections and indexes with a **custom installation step** — a script that runs once when the app is installed from the Commerce Admin, and can be reversed on uninstall. Prefer this over creating them ad-hoc on the first request.
 
-Author the step with `defineCustomInstallationStep` (an `install` handler plus an optional `uninstall`). Inside it, generate the IMS token from **`context.params`** — _not_ `config` — then follow the same init → connect → `close` lifecycle as Step 5, and call `createIndex` **on the collection object**:
+Author the step with `defineCustomInstallationStep` (an `install` handler plus an optional `uninstall`). Inside it, resolve the IMS auth params from **`context.params`** — _not_ `config` — then follow the same init → connect → `close` lifecycle as Step 5, and call `createIndex` **on the collection object**:
 
 ```ts
 // ./scripts/setup-database.ts — referenced from config as ./scripts/setup-database.js
 import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
-import { generateAccessToken } from "@adobe/aio-lib-core-auth";
+import {
+  getImsAuthProvider,
+  resolveImsAuthParams,
+} from "@adobe/aio-commerce-lib-auth";
 import { init as initDb } from "@adobe/aio-lib-db";
 
 export default defineCustomInstallationStep({
@@ -187,8 +196,11 @@ export default defineCustomInstallationStep({
     let client;
     try {
       // context.params carries the injected IMS credentials — NOT config.
-      const token = await generateAccessToken(context.params);
-      const db = await initDb({ token: token.access_token, region: "emea" }); // must match the manifest database.region
+      const authProvider = getImsAuthProvider(
+        resolveImsAuthParams(context.params),
+      );
+      const token = await authProvider.getAccessToken();
+      const db = await initDb({ token, region: "emea" }); // must match the manifest database.region
       client = await db.connect();
 
       const orders = client.collection("held_orders"); // get the collection object first
@@ -201,8 +213,11 @@ export default defineCustomInstallationStep({
   uninstall: async (config, context) => {
     let client;
     try {
-      const token = await generateAccessToken(context.params);
-      const db = await initDb({ token: token.access_token, region: "emea" });
+      const authProvider = getImsAuthProvider(
+        resolveImsAuthParams(context.params),
+      );
+      const token = await authProvider.getAccessToken();
+      const db = await initDb({ token, region: "emea" });
       client = await db.connect();
       await client.collection("held_orders").drop();
     } finally {
@@ -212,7 +227,7 @@ export default defineCustomInstallationStep({
 });
 ```
 
-> **Custom installation scripts must be plain JavaScript for now.** App Management only wires up `.js` step scripts; a `.ts` file works only if you compile it yourself and point `script` at the emitted `.js`. Author the step in JS directly, or treat the `.ts` reference as source and ship its compiled output.
+> **Author the install script as an ES module with `export default` — never `module.exports`.** The installation action loads each step via `import * as step from "<script>"` and reads `step.default`, so the script must default-export the `defineCustomInstallationStep(...)` result. CommonJS breaks this: `module.exports.default` surfaces as `step.default.default` and validation fails. The `script` path must end in `.js`; if you author in TypeScript, compile it and keep the emitted `.js` an ES module.
 
 Register the step in `app.commerce.config.ts` under `installation.customInstallationSteps`. The `script` path points at the compiled `.js` output:
 
@@ -229,11 +244,11 @@ installation: {
 },
 ```
 
-| Field         | Constraint                                                                                                     |
-| ------------- | -------------------------------------------------------------------------------------------------------------- |
-| `script`      | Path relative to the project root; must be plain JS ending in `.js` (TS only works if you compile it yourself) |
-| `name`        | Non-empty string, ≤ 255 characters; **unique** across all installation steps                                   |
-| `description` | Non-empty string, ≤ 255 characters                                                                             |
+| Field         | Constraint                                                                                                                             |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `script`      | Path relative to the project root; must be an ES module (`export default`) ending in `.js` (compile from TS if you author it that way) |
+| `name`        | Non-empty string, ≤ 255 characters; **unique** across all installation steps                                                           |
+| `description` | Non-empty string, ≤ 255 characters                                                                                                     |
 
 See [assets/setup-database.ts](assets/setup-database.ts) for the full annotated install/uninstall reference.
 
@@ -252,7 +267,7 @@ A build failure points directly to the offending config field. To exercise the a
 - **Use projections** (`.project({ field: 1 })`) and **indexes** (`createIndex`) for frequently queried fields; index fields must total ≤ 2048 bytes.
 - **Iterate large result sets with cursors** (`for await (const doc of collection.find(...))`) instead of `toArray()` to bound memory.
 - **Don't hardcode the region or secrets** — prefer `AIO_DB_REGION` and the injected IMS token over inline values.
-- **Prefer the most specific Adobe I/O library** in runtime actions over the `@adobe/aio-sdk` umbrella — e.g. `@adobe/aio-lib-core-auth` for `generateAccessToken` and `@adobe/aio-lib-core-logging` for the logger — to keep action bundles small.
+- **Prefer the most specific Adobe I/O library** in runtime actions over the `@adobe/aio-sdk` umbrella — e.g. `@adobe/aio-commerce-lib-auth` for IMS auth and `@adobe/aio-lib-core-logging` for the logger — to keep action bundles small.
 - **Set up collections and indexes during installation** with a custom installation step (`defineCustomInstallationStep`, see Step 6) rather than ad-hoc on the first request — it runs once when the app is installed from the Commerce Admin and is reversible on uninstall. A generic App Builder `post-app-deploy` hook is only an alternative when the app is not installed through App Management.
 
 ## Common Issues
@@ -262,7 +277,8 @@ A build failure points directly to the offending config field. To exercise the a
 - **Connection fails after a region change**: the library region doesn't match the manifest `database.region`. Moving regions is destructive — `aio app db delete`, update `database.region` in the manifest, then re-provision (`aio app deploy`, or the CLI fallback for local dev).
 - **Querying by `_id` from a string returns nothing**: convert it first — `new ObjectId(idString)` from `bson`. A raw string never matches the stored `ObjectId`.
 - **`DbError` vs unexpected error**: errors thrown by the service have `name === "DbError"`; branch on it to separate database failures from application bugs.
-- **Auth fails inside an installation step**: the token must be generated from `context.params` (which carries the injected IMS credentials), not from `config`. `config` is the app configuration and holds no credentials.
+- **Auth fails inside an installation step**: resolve the IMS auth params from `context.params` (`resolveImsAuthParams(context.params)`) — which carries the injected `AIO_COMMERCE_AUTH_IMS_*` credentials — not from `config`, which holds no credentials. Use `@adobe/aio-commerce-lib-auth`, not `@adobe/aio-lib-core-auth`: the latter's `generateAccessToken` expects `clientId`/`clientSecret` directly and cannot consume the injected params.
+- **Installation step fails to load (`must export a default function or object`)**: the script was authored as CommonJS. Author it as an ES module with `export default`; `module.exports` (or `module.exports.default`) surfaces through the framework's `import * as` loader as `.default.default` and fails validation.
 - **`createIndex` errors or has no effect**: it must be called on a collection object (`client.collection("name").createIndex({ field: 1 })`), not with a collection-name string. Get the collection first, then call `createIndex` on it.
 
 ## Quality Bar

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -9,8 +9,8 @@ description: >
 license: Apache-2.0
 compatibility: >
   Requires Node.js 22+, aio CLI, @adobe/aio-commerce-lib-app, and a provisioned
-  workspace database with the App Builder Data Services API subscribed.
-  Requires a base app initialized with commerce-app-init.
+  workspace database with the App Builder Data Services API added to the project
+  in the Adobe Developer Console. Requires a base app initialized with commerce-app-init.
 metadata:
   author: adobe
   sdk-package: "@adobe/aio-lib-db"
@@ -29,17 +29,27 @@ The db-access code is identical regardless of action type — what differs is ho
 ## Prerequisites
 
 - Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
-- The **App Builder Data Services** API must be subscribed in the Developer Console workspace (no special license beyond App Builder). This API authenticates runtime actions to the database service.
+- The **App Builder Data Services** API must be **added to the project in the Adobe Developer Console** — in every workspace that uses the database (no special license beyond App Builder). Without it, runtime actions cannot authenticate to the database service.
 
 ## Step 1 — Provision the workspace database
 
-There is a strict one-to-one relationship between an AIO project workspace and a workspace database. Provision it (self-service, no special permissions):
+There is a strict one-to-one relationship between an AIO project workspace and a workspace database. The recommended way to provision it is **declaratively** in `app.config.yaml` — the database is provisioned (if not already present) on `aio app deploy`:
+
+```yaml
+application:
+  runtimeManifest:
+    database:
+      auto-provision: true
+      region: emea # amer | apac | emea | aus — the single source of truth for the region
+```
+
+For **local development**, declarative auto-provisioning does **not** run during `aio app run` / `aio app dev`. Provision once up front with the CLI fallback (self-service, no special permissions):
 
 ```sh
 aio app db provision --region <amer|apac|emea|aus>
 ```
 
-This provisions the database and writes a `database` entry to `app.config.yaml`. **Note the region** — the library must be initialized in the same region the database was provisioned in.
+> **Region is a single source of truth.** The `region` in the manifest `database` block must match the `region` passed to every `initDb({ region })` call (or `AIO_DB_REGION`) — in every action **and** in the install step (Step 6). A mismatch fails the connection. Changing region is destructive: `aio app db delete`, update `database.region` in the manifest, then re-provision.
 
 ## Step 2 — Install the library
 
@@ -53,7 +63,7 @@ Gather from the user:
 
 - **Action type**: web action or event/webhook action (see the two shapes above).
 - **Collection name** and the **operations** needed (insert / find / update / delete).
-- **Region**: must match Step 1. Pass it to `init()` or set `AIO_DB_REGION`.
+- **Region**: must match the manifest `database.region` (see the region callout in Step 1). Pass it to `init()` or set `AIO_DB_REGION`.
 
 ## Step 4 — Register the action
 
@@ -82,7 +92,7 @@ runtimeManifest:
 | `include-ims-credentials` | Must be `true` — without it `init()` has no IMS token and the connection fails    |
 | `web`                     | `"yes"` for HTTP-invokable web actions; `"no"` for event/webhook handlers         |
 | Collection name           | Non-empty string; created on first write if it doesn't exist                      |
-| Region                    | Must match the provisioned region (`amer` \| `apac` \| `emea` \| `aus`)           |
+| Region                    | Must match the manifest `database.region` (`amer` \| `apac` \| `emea` \| `aus`)   |
 
 ## Step 5 — Implement the handler
 
@@ -97,7 +107,7 @@ export async function main(params: Record<string, unknown>) {
   let client;
   try {
     const token = await Core.AuthClient.generateAccessToken(params); // IMS token
-    const db = await initDb({ token: token.access_token, region: "emea" }); // region must match provisioning
+    const db = await initDb({ token: token.access_token, region: "emea" }); // must match the manifest database.region
     client = await db.connect();
     const records = client.collection("records");
 
@@ -158,7 +168,7 @@ export default defineCustomInstallationStep({
     try {
       // context.params carries the injected IMS credentials — NOT config.
       const token = await Core.AuthClient.generateAccessToken(context.params);
-      const db = await initDb({ token: token.access_token, region: "emea" }); // region must match provisioning
+      const db = await initDb({ token: token.access_token, region: "emea" }); // must match the manifest database.region
       client = await db.connect();
 
       const orders = client.collection("held_orders"); // get the collection object first
@@ -216,7 +226,7 @@ A build failure points directly to the offending config field. To exercise the a
 ## Best practices
 
 - **Always close connections** in a `finally` block — leaked connections exhaust resources.
-- **Match the region** between provisioning and `init()`; a mismatch fails the connection silently from the caller's view.
+- **Match the region** — the manifest `database.region` is the single source of truth; every `init()` call and the install step must use it (see the region callout in Step 1). A mismatch fails the connection silently from the caller's view.
 - **Use projections** (`.project({ field: 1 })`) and **indexes** (`createIndex`) for frequently queried fields; index fields must total ≤ 2048 bytes.
 - **Iterate large result sets with cursors** (`for await (const doc of collection.find(...))`) instead of `toArray()` to bound memory.
 - **Don't hardcode the region or secrets** — prefer `AIO_DB_REGION` and the injected IMS token over inline values.
@@ -224,8 +234,8 @@ A build failure points directly to the offending config field. To exercise the a
 
 ## Common Issues
 
-- **Connection fails despite a valid token**: the action is missing `include-ims-credentials: true`, or the **App Builder Data Services** API is not subscribed in the workspace.
-- **Connection fails after a region change**: the library region doesn't match where the database was provisioned. To move regions you must `aio app db delete`, update the region, then re-provision.
+- **Connection fails despite a valid token**: the action is missing `include-ims-credentials: true`, or the **App Builder Data Services** API has not been added to the project in the Adobe Developer Console (see Prerequisites).
+- **Connection fails after a region change**: the library region doesn't match the manifest `database.region`. Moving regions is destructive — `aio app db delete`, update `database.region` in the manifest, then re-provision (`aio app deploy`, or the CLI fallback for local dev).
 - **Querying by `_id` from a string returns nothing**: convert it first — `new ObjectId(idString)` from `bson`. A raw string never matches the stored `ObjectId`.
 - **`DbError` vs unexpected error**: errors thrown by the service have `name === "DbError"`; branch on it to separate database failures from application bugs.
 - **Auth fails inside an installation step**: the token must be generated from `context.params` (which carries the injected IMS credentials), not from `config`. `config` is the app configuration and holds no credentials.
@@ -234,7 +244,7 @@ A build failure points directly to the offending config field. To exercise the a
 ## Quality Bar
 
 - `aio app build` completes without errors
-- The action closes the client in a `finally` block and initializes the library in the provisioned region
+- The action closes the client in a `finally` block and initializes the library in the region declared in the manifest `database` block
 
 ## Chaining
 

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -29,7 +29,7 @@ The db-access code is identical regardless of action type — what differs is ho
 ## Prerequisites
 
 - Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
-- The **App Builder Data Services** API must be **added to the project in the Adobe Developer Console** — in every workspace that uses the database (no special license beyond App Builder). Without it, runtime actions cannot authenticate to the database service.
+- The **App Builder Data Services** API (API code `AppBuilderDataServicesSDK`) must be **added to the project in the Adobe Developer Console** — in every workspace that uses the database (no special license beyond App Builder). Without it, runtime actions cannot authenticate to the database service.
 
 ## Step 1 — Provision the workspace database
 

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -101,13 +101,13 @@ Every handler follows the same lifecycle: generate token → `init` → `connect
 ```ts
 // Web action — src/commerce-extensibility-1/actions/store-record/index.ts
 import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
-import { Core } from "@adobe/aio-sdk";
+import { generateAccessToken } from "@adobe/aio-lib-core-auth";
 import { init as initDb } from "@adobe/aio-lib-db";
 
 export async function main(params: Record<string, unknown>) {
   let client;
   try {
-    const token = await Core.AuthClient.generateAccessToken(params); // IMS token
+    const token = await generateAccessToken(params); // IMS token
     const db = await initDb({ token: token.access_token, region: "emea" }); // must match the manifest database.region
     client = await db.connect();
     const records = client.collection("records");
@@ -135,7 +135,7 @@ export async function main(params: Record<string, unknown>) {
   const data = params.data as Record<string, unknown>;
   let client;
   try {
-    const token = await Core.AuthClient.generateAccessToken(params);
+    const token = await generateAccessToken(params);
     const db = await initDb({ token: token.access_token, region: "emea" });
     client = await db.connect();
     await client
@@ -159,7 +159,7 @@ Author the step with `defineCustomInstallationStep` (an `install` handler plus a
 ```ts
 // ./scripts/setup-database.ts — referenced from config as ./scripts/setup-database.js
 import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
-import { Core } from "@adobe/aio-sdk";
+import { generateAccessToken } from "@adobe/aio-lib-core-auth";
 import { init as initDb } from "@adobe/aio-lib-db";
 
 export default defineCustomInstallationStep({
@@ -167,7 +167,7 @@ export default defineCustomInstallationStep({
     let client;
     try {
       // context.params carries the injected IMS credentials — NOT config.
-      const token = await Core.AuthClient.generateAccessToken(context.params);
+      const token = await generateAccessToken(context.params);
       const db = await initDb({ token: token.access_token, region: "emea" }); // must match the manifest database.region
       client = await db.connect();
 
@@ -181,7 +181,7 @@ export default defineCustomInstallationStep({
   uninstall: async (config, context) => {
     let client;
     try {
-      const token = await Core.AuthClient.generateAccessToken(context.params);
+      const token = await generateAccessToken(context.params);
       const db = await initDb({ token: token.access_token, region: "emea" });
       client = await db.connect();
       await client.collection("held_orders").drop();
@@ -230,6 +230,7 @@ A build failure points directly to the offending config field. To exercise the a
 - **Use projections** (`.project({ field: 1 })`) and **indexes** (`createIndex`) for frequently queried fields; index fields must total ≤ 2048 bytes.
 - **Iterate large result sets with cursors** (`for await (const doc of collection.find(...))`) instead of `toArray()` to bound memory.
 - **Don't hardcode the region or secrets** — prefer `AIO_DB_REGION` and the injected IMS token over inline values.
+- **Prefer the most specific Adobe I/O library** in runtime actions over the `@adobe/aio-sdk` umbrella — e.g. `@adobe/aio-lib-core-auth` for `generateAccessToken` and `@adobe/aio-lib-core-logging` for the logger — to keep action bundles small.
 - **Set up collections and indexes during installation** with a custom installation step (`defineCustomInstallationStep`, see Step 6) rather than ad-hoc on the first request — it runs once when the app is installed from the Commerce Admin and is reversible on uninstall. A generic App Builder `post-app-deploy` hook is only an alternative when the app is not installed through App Management.
 
 ## Common Issues

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -13,7 +13,7 @@ compatibility: >
   in the Adobe Developer Console. Requires a base app initialized with commerce-app-init.
 metadata:
   author: adobe
-  sdk-package: "@adobe/aio-lib-db"
+  sdk-package: "@adobe/aio-commerce-lib-app"
   version: "0.0.1"
 ---
 
@@ -47,7 +47,7 @@ application:
       region: emea # amer | apac | emea | aus — the single source of truth for the region
 ```
 
-**Extension-only apps need a workaround.** Declarative auto-provision only runs when the `application` runtime manifest has at least one package with a runtime action. Apps built purely with `extensions` (the recommended layout per the submission guidelines) have no `application` actions, so `aio app deploy` silently skips provisioning. Make the `application` block "real enough" for provisioning to run by adding an empty packages map and a `post-app-build` hook that creates the directory the provisioning step expects:
+**Extension-only apps need a workaround.** Due to a bug in the `aio app` CLI plugin (not `aio-lib-db`), `aio app deploy` only runs declarative auto-provision when the `application` runtime manifest has at least one package with a runtime action. Apps built purely with `extensions` (the recommended layout per the submission guidelines) have no `application` actions, so deploy silently skips provisioning. Make the `application` block "real enough" for provisioning to run by adding an empty packages map and a `post-app-build` hook that creates the directory the provisioning step expects:
 
 ```yaml
 application:
@@ -85,7 +85,9 @@ Gather from the user:
 
 ## Step 4 — Register the action
 
-Add the action to a user-defined package in `src/commerce-extensibility-1/ext.config.yaml` (any name except `app-management`, which is reserved). The `include-ims-credentials: true` annotation is **required** — `aio-lib-db` authenticates with the IMS token it injects.
+Add the action to a user-defined package in `src/commerce-extensibility-1/ext.config.yaml` (any name except `app-management`, which is reserved).
+
+> **`include-ims-credentials: true` is required on every DB action.** Without it, `aio-lib-db` has no IMS token to authenticate with and the connection fails at runtime (and the app installation fails if the action runs during install). Do not omit this annotation.
 
 ```yaml
 # src/commerce-extensibility-1/ext.config.yaml
@@ -256,7 +258,7 @@ A build failure points directly to the offending config field. To exercise the a
 ## Common Issues
 
 - **Connection fails despite a valid token**: the action is missing `include-ims-credentials: true`, or the **App Builder Data Services** API has not been added to the project in the Adobe Developer Console (see Prerequisites).
-- **DB not provisioned after `aio app deploy` (extension-only app)**: declarative auto-provision is skipped when the `application` runtime manifest has no runtime action. Apply the extension-only workaround from Step 1 — add `packages: {}` and a `post-app-build: "mkdir -p dist/application/actions"` hook under `application` — or provision once with the CLI fallback for local dev.
+- **DB not provisioned after `aio app deploy` (extension-only app)**: a bug in the `aio app` CLI plugin (not `aio-lib-db`) skips declarative auto-provision when the `application` runtime manifest has no runtime action. Apply the extension-only workaround from Step 1 — add `packages: {}` and a `post-app-build: "mkdir -p dist/application/actions"` hook under `application` — or provision once with the CLI fallback for local dev.
 - **Connection fails after a region change**: the library region doesn't match the manifest `database.region`. Moving regions is destructive — `aio app db delete`, update `database.region` in the manifest, then re-provision (`aio app deploy`, or the CLI fallback for local dev).
 - **Querying by `_id` from a string returns nothing**: convert it first — `new ObjectId(idString)` from `bson`. A raw string never matches the stored `ObjectId`.
 - **`DbError` vs unexpected error**: errors thrown by the service have `name === "DbError"`; branch on it to separate database failures from application bugs.
@@ -266,6 +268,7 @@ A build failure points directly to the offending config field. To exercise the a
 ## Quality Bar
 
 - `aio app build` completes without errors
+- Every user-authored DB action declares `include-ims-credentials: true` in its annotations
 - The action closes the client in a `finally` block and initializes the library in the region declared in the manifest `database` block
 
 ## Chaining

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
@@ -1,0 +1,124 @@
+// Full annotated reference for a Commerce app runtime action backed by
+// App Builder Database Storage (@adobe/aio-lib-db).
+//
+// Lifecycle (identical for web actions and event/webhook handlers):
+//   generateAccessToken -> init -> connect -> use collection -> ALWAYS close.
+//
+// Registration requirements (in src/commerce-extensibility-1/ext.config.yaml):
+//   - include-ims-credentials: true   (REQUIRED — provides the IMS token below)
+//   - web: "yes" for an HTTP-invokable web action; "no" for an event/webhook handler
+//   - the "App Builder Data Services" API must be subscribed in the workspace
+//   - the workspace database must be provisioned (aio app db provision --region <r>)
+
+import { init as initDb } from "@adobe/aio-lib-db";
+import { Core } from "@adobe/aio-sdk";
+
+// The connected client returned by db.connect().
+type DbClient = Awaited<
+  ReturnType<Awaited<ReturnType<typeof initDb>>["connect"]>
+>;
+
+// Web actions return an HTTP-shaped response.
+function jsonResponse(statusCode: number, body: unknown) {
+  return { statusCode, headers: { "Content-Type": "application/json" }, body };
+}
+
+export async function main(params: Record<string, unknown>) {
+  const logger = Core.Logger("commerce-app-storage", {
+    level: (params.LOG_LEVEL as string) || "info",
+  });
+
+  // Web actions receive input directly on params; event/webhook handlers
+  // receive the payload on params.data instead:
+  //   const data = params.data as Record<string, unknown>;
+  let client: DbClient | undefined;
+
+  try {
+    // 1. IMS token — injected because include-ims-credentials is true.
+    const token = await Core.AuthClient.generateAccessToken(params);
+
+    // 2. Initialize. region MUST match the provisioned region.
+    //    Omit it to use AIO_DB_REGION or the "amer" default.
+    const db = await initDb({
+      token: token.access_token,
+      region: (params.DB_REGION as string) || "amer", // "amer" | "apac" | "emea" | "aus"
+    });
+
+    // 3. Connect — opens a session that must be closed (see finally).
+    client = await db.connect();
+
+    // 4. Select a collection (created on first write if absent).
+    const records = client.collection("records");
+
+    // --- CRUD reference ---------------------------------------------------
+
+    // Insert one
+    const inserted = await records.insertOne({
+      name: "Jane Smith",
+      createdAt: new Date().toISOString(),
+    });
+
+    // Insert many
+    await records.insertMany([{ name: "Alice" }, { name: "Bob" }]);
+
+    // Find one
+    const one = await records.findOne({ name: "Jane Smith" });
+
+    // Find many — returns a cursor. Iterate to bound memory.
+    for await (const doc of records
+      .find({ active: true })
+      .project({ name: 1, _id: 0 })) {
+      logger.info("record", doc);
+    }
+    // ...or load all at once (only for small result sets):
+    // const all = await records.find({}).toArray();
+
+    // Update one (use $set / other operators)
+    await records.updateOne({ name: "Jane Smith" }, { $set: { active: true } });
+
+    // Update many
+    await records.updateMany(
+      { active: { $exists: false } },
+      { $set: { active: false } },
+    );
+
+    // Find and update, returning the updated document
+    await records.findOneAndUpdate(
+      { name: "Jane Smith" },
+      { $set: { lastSeen: new Date() } },
+      { returnDocument: "after" },
+    );
+
+    // Delete one / many
+    await records.deleteOne({ name: "Bob" });
+    await records.deleteMany({ active: false });
+
+    // Look up a document by its _id supplied as a string:
+    //   import { ObjectId } from "bson";
+    //   await records.findOne({ _id: new ObjectId(idString) });
+
+    return jsonResponse(200, { ok: true, inserted, one });
+  } catch (error) {
+    // Database errors surface with name === "DbError".
+    const dbError = error as {
+      name?: string;
+      message?: string;
+      statusCode?: number;
+    };
+    if (dbError.name === "DbError") {
+      logger.error("Database error", dbError.message);
+    } else {
+      logger.error("Unexpected error", error);
+    }
+    return jsonResponse(dbError.statusCode ?? 500, { error: dbError.message });
+  } finally {
+    // 5. ALWAYS close — leaked connections exhaust resources.
+    if (client) {
+      await client
+        .close()
+        .catch((e: Error) =>
+          logger.warn("Failed to close DB client", e.message),
+        );
+    }
+  }
+}

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
@@ -14,8 +14,9 @@
 //     provision --region <r>` is the local-dev fallback)
 
 import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
+import { generateAccessToken } from "@adobe/aio-lib-core-auth";
+import AioLogger from "@adobe/aio-lib-core-logging";
 import { init as initDb } from "@adobe/aio-lib-db";
-import { Core } from "@adobe/aio-sdk";
 
 // The connected client returned by db.connect().
 type DbClient = Awaited<
@@ -23,7 +24,7 @@ type DbClient = Awaited<
 >;
 
 export async function main(params: Record<string, unknown>) {
-  const logger = Core.Logger("commerce-app-storage", {
+  const logger = AioLogger("commerce-app-storage", {
     level: (params.LOG_LEVEL as string) || "info",
   });
 
@@ -34,7 +35,7 @@ export async function main(params: Record<string, unknown>) {
 
   try {
     // 1. IMS token — injected because include-ims-credentials is true.
-    const token = await Core.AuthClient.generateAccessToken(params);
+    const token = await generateAccessToken(params);
 
     // 2. Initialize. region MUST match the manifest database.region.
     //    Omit it to use AIO_DB_REGION or the "amer" default.

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
@@ -2,7 +2,7 @@
 // App Builder Database Storage (@adobe/aio-lib-db).
 //
 // Lifecycle (identical for web actions and event/webhook handlers):
-//   generateAccessToken -> init -> connect -> use collection -> ALWAYS close.
+//   resolveImsAuthParams -> getAccessToken -> init -> connect -> use collection -> ALWAYS close.
 //
 // Registration requirements (in src/commerce-extensibility-1/ext.config.yaml):
 //   - include-ims-credentials: true   (REQUIRED — provides the IMS token below)
@@ -13,8 +13,11 @@
 //     app.config.yaml database block on `aio app deploy` (CLI `aio app db
 //     provision --region <r>` is the local-dev fallback)
 
+import {
+  getImsAuthProvider,
+  resolveImsAuthParams,
+} from "@adobe/aio-commerce-lib-auth";
 import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
-import { generateAccessToken } from "@adobe/aio-lib-core-auth";
 import AioLogger from "@adobe/aio-lib-core-logging";
 import { init as initDb } from "@adobe/aio-lib-db";
 
@@ -34,13 +37,15 @@ export async function main(params: Record<string, unknown>) {
   let client: DbClient | undefined;
 
   try {
-    // 1. IMS token — injected because include-ims-credentials is true.
-    const token = await generateAccessToken(params);
+    // 1. Resolve the AIO_COMMERCE_AUTH_IMS_* params injected because
+    //    include-ims-credentials is true, then mint a raw access token string.
+    const authProvider = getImsAuthProvider(resolveImsAuthParams(params));
+    const token = await authProvider.getAccessToken();
 
     // 2. Initialize. region MUST match the manifest database.region.
     //    Omit it to use AIO_DB_REGION or the "amer" default.
     const db = await initDb({
-      token: token.access_token,
+      token,
       region: (params.DB_REGION as string) || "amer", // "amer" | "apac" | "emea" | "aus"
     });
 

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
@@ -13,6 +13,7 @@
 //     app.config.yaml database block on `aio app deploy` (CLI `aio app db
 //     provision --region <r>` is the local-dev fallback)
 
+import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
 import { init as initDb } from "@adobe/aio-lib-db";
 import { Core } from "@adobe/aio-sdk";
 
@@ -20,11 +21,6 @@ import { Core } from "@adobe/aio-sdk";
 type DbClient = Awaited<
   ReturnType<Awaited<ReturnType<typeof initDb>>["connect"]>
 >;
-
-// Web actions return an HTTP-shaped response.
-function jsonResponse(statusCode: number, body: unknown) {
-  return { statusCode, headers: { "Content-Type": "application/json" }, body };
-}
 
 export async function main(params: Record<string, unknown>) {
   const logger = Core.Logger("commerce-app-storage", {
@@ -100,7 +96,7 @@ export async function main(params: Record<string, unknown>) {
     //   import { ObjectId } from "bson";
     //   await records.findOne({ _id: new ObjectId(idString) });
 
-    return jsonResponse(200, { ok: true, inserted, one });
+    return ok({ body: { inserted, one } });
   } catch (error) {
     // Database errors surface with name === "DbError".
     const dbError = error as {
@@ -113,7 +109,9 @@ export async function main(params: Record<string, unknown>) {
     } else {
       logger.error("Unexpected error", error);
     }
-    return jsonResponse(dbError.statusCode ?? 500, { error: dbError.message });
+    return buildErrorResponse(dbError.statusCode ?? 500, {
+      body: { message: dbError.message ?? "Unexpected error" },
+    });
   } finally {
     // 5. ALWAYS close — leaked connections exhaust resources.
     if (client) {

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
@@ -7,8 +7,11 @@
 // Registration requirements (in src/commerce-extensibility-1/ext.config.yaml):
 //   - include-ims-credentials: true   (REQUIRED — provides the IMS token below)
 //   - web: "yes" for an HTTP-invokable web action; "no" for an event/webhook handler
-//   - the "App Builder Data Services" API must be subscribed in the workspace
-//   - the workspace database must be provisioned (aio app db provision --region <r>)
+//   - the "App Builder Data Services" API must be added to the project in the
+//     Adobe Developer Console (every workspace that uses the database)
+//   - the workspace database must be provisioned: declaratively via the
+//     app.config.yaml database block on `aio app deploy` (CLI `aio app db
+//     provision --region <r>` is the local-dev fallback)
 
 import { init as initDb } from "@adobe/aio-lib-db";
 import { Core } from "@adobe/aio-sdk";
@@ -37,7 +40,7 @@ export async function main(params: Record<string, unknown>) {
     // 1. IMS token — injected because include-ims-credentials is true.
     const token = await Core.AuthClient.generateAccessToken(params);
 
-    // 2. Initialize. region MUST match the provisioned region.
+    // 2. Initialize. region MUST match the manifest database.region.
     //    Omit it to use AIO_DB_REGION or the "amer" default.
     const db = await initDb({
       token: token.access_token,

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
@@ -39,7 +39,7 @@ async function openClient(context: { params: Record<string, unknown> }) {
   const token = await Core.AuthClient.generateAccessToken(context.params);
   const db = await initDb({
     token: token.access_token,
-    // region MUST match the provisioned region. Omit to use AIO_DB_REGION.
+    // region MUST match the manifest database.region. Omit to use AIO_DB_REGION.
     region: (context.params.DB_REGION as string) || "amer", // "amer" | "apac" | "emea" | "aus"
   });
   return db.connect();

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
@@ -1,0 +1,99 @@
+// Full annotated custom installation step for a Commerce App Management app,
+// backed by App Builder Database Storage (@adobe/aio-lib-db).
+//
+// What it does:
+//   - install:   creates the "held_orders" collection and a UNIQUE index on order_id
+//   - uninstall: drops the collection to reverse the install
+//
+// Why a custom installation step (vs. ad-hoc setup on first request):
+//   It runs exactly once when the app is installed from the Commerce Admin,
+//   and the uninstall handler lets the app clean up after itself.
+//
+// Wiring (in app.commerce.config.ts) — the script path is the COMPILED .js:
+//   installation: {
+//     customInstallationSteps: [
+//       {
+//         script: "./scripts/setup-database.js",
+//         name: "Set up held-orders collection",
+//         description: "Creates the held_orders collection and a unique index on order_id",
+//       },
+//     ],
+//   }
+//
+// Two easy mistakes this file avoids:
+//   1. Generate the IMS token from context.params — NOT config. config is the app
+//      configuration and carries no credentials; context.params carries the injected
+//      IMS credentials (AIO_COMMERCE_AUTH_IMS_*).
+//   2. createIndex is called ON A COLLECTION OBJECT, not with a collection-name string.
+
+import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
+import { init as initDb } from "@adobe/aio-lib-db";
+import { Core } from "@adobe/aio-sdk";
+
+const COLLECTION = "held_orders";
+
+// Open a DB client using the credentials on context.params. The caller is
+// responsible for closing it (see the finally blocks below).
+async function openClient(context: { params: Record<string, unknown> }) {
+  // include-ims-credentials makes these credentials available on context.params.
+  const token = await Core.AuthClient.generateAccessToken(context.params);
+  const db = await initDb({
+    token: token.access_token,
+    // region MUST match the provisioned region. Omit to use AIO_DB_REGION.
+    region: (context.params.DB_REGION as string) || "amer", // "amer" | "apac" | "emea" | "aus"
+  });
+  return db.connect();
+}
+
+export default defineCustomInstallationStep({
+  install: async (config, context) => {
+    const { logger } = context;
+    logger.info(`Setting up storage for ${config.metadata.displayName}...`);
+
+    let client: Awaited<ReturnType<typeof openClient>> | undefined;
+    try {
+      client = await openClient(context);
+
+      // Get the collection OBJECT first (created on first write if absent),
+      // then create the index on it — never pass a collection-name string.
+      const orders = client.collection(COLLECTION);
+      await orders.createIndex({ order_id: 1 }, { unique: true });
+
+      logger.info(`Created "${COLLECTION}" with a unique index on order_id`);
+      return { status: "success", collection: COLLECTION };
+    } catch (error) {
+      if (error instanceof Error && error.name === "DbError") {
+        logger.error("Database error during install", error.message);
+      }
+      throw error; // re-throw so the installation step fails loudly
+    } finally {
+      if (client) {
+        await client
+          .close()
+          .catch((e: Error) =>
+            logger.warn("Failed to close DB client", e.message),
+          );
+      }
+    }
+  },
+
+  uninstall: async (config, context) => {
+    const { logger } = context;
+    logger.info(`Removing storage for ${config.metadata.displayName}...`);
+
+    let client: Awaited<ReturnType<typeof openClient>> | undefined;
+    try {
+      client = await openClient(context);
+      await client.collection(COLLECTION).drop();
+      logger.info(`Dropped "${COLLECTION}"`);
+    } finally {
+      if (client) {
+        await client
+          .close()
+          .catch((e: Error) =>
+            logger.warn("Failed to close DB client", e.message),
+          );
+      }
+    }
+  },
+});

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
@@ -9,9 +9,12 @@
 //   It runs exactly once when the app is installed from the Commerce Admin,
 //   and the uninstall handler lets the app clean up after itself.
 //
-// Custom installation scripts must be plain JS for now: App Management only wires
-// up .js step scripts. This .ts file works only if you compile it yourself and
-// point `script` at the emitted .js — otherwise author the step directly in JS.
+// Author the install script as an ES module with `export default` — never
+// `module.exports`. The installation action loads each step via
+// `import * as step from "<script>"` and reads `step.default`, so the script
+// must default-export the defineCustomInstallationStep(...) result. The `script`
+// path must end in .js; if you author in TypeScript, compile it and keep the
+// emitted .js an ES module.
 //
 // Wiring (in app.commerce.config.ts) — the script path is the COMPILED .js:
 //   installation: {
@@ -25,13 +28,17 @@
 //   }
 //
 // Two easy mistakes this file avoids:
-//   1. Generate the IMS token from context.params — NOT config. config is the app
-//      configuration and carries no credentials; context.params carries the injected
-//      IMS credentials (AIO_COMMERCE_AUTH_IMS_*).
+//   1. Resolve the IMS auth params from context.params — NOT config. config is the
+//      app configuration and carries no credentials; context.params carries the
+//      injected IMS credentials (AIO_COMMERCE_AUTH_IMS_*) read by
+//      @adobe/aio-commerce-lib-auth.
 //   2. createIndex is called ON A COLLECTION OBJECT, not with a collection-name string.
 
 import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
-import { generateAccessToken } from "@adobe/aio-lib-core-auth";
+import {
+  getImsAuthProvider,
+  resolveImsAuthParams,
+} from "@adobe/aio-commerce-lib-auth";
 import { init as initDb } from "@adobe/aio-lib-db";
 
 const COLLECTION = "held_orders";
@@ -39,10 +46,12 @@ const COLLECTION = "held_orders";
 // Open a DB client using the credentials on context.params. The caller is
 // responsible for closing it (see the finally blocks below).
 async function openClient(context: { params: Record<string, unknown> }) {
-  // include-ims-credentials makes these credentials available on context.params.
-  const token = await generateAccessToken(context.params);
+  // include-ims-credentials makes the AIO_COMMERCE_AUTH_IMS_* credentials available
+  // on context.params; resolve them and mint a raw access token string.
+  const authProvider = getImsAuthProvider(resolveImsAuthParams(context.params));
+  const token = await authProvider.getAccessToken();
   const db = await initDb({
-    token: token.access_token,
+    token,
     // region MUST match the manifest database.region. Omit to use AIO_DB_REGION.
     region: (context.params.DB_REGION as string) || "amer", // "amer" | "apac" | "emea" | "aus"
   });

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
@@ -9,6 +9,10 @@
 //   It runs exactly once when the app is installed from the Commerce Admin,
 //   and the uninstall handler lets the app clean up after itself.
 //
+// Custom installation scripts must be plain JS for now: App Management only wires
+// up .js step scripts. This .ts file works only if you compile it yourself and
+// point `script` at the emitted .js — otherwise author the step directly in JS.
+//
 // Wiring (in app.commerce.config.ts) — the script path is the COMPILED .js:
 //   installation: {
 //     customInstallationSteps: [

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
@@ -27,8 +27,8 @@
 //   2. createIndex is called ON A COLLECTION OBJECT, not with a collection-name string.
 
 import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
+import { generateAccessToken } from "@adobe/aio-lib-core-auth";
 import { init as initDb } from "@adobe/aio-lib-db";
-import { Core } from "@adobe/aio-sdk";
 
 const COLLECTION = "held_orders";
 
@@ -36,7 +36,7 @@ const COLLECTION = "held_orders";
 // responsible for closing it (see the finally blocks below).
 async function openClient(context: { params: Record<string, unknown> }) {
   // include-ims-credentials makes these credentials available on context.params.
-  const token = await Core.AuthClient.generateAccessToken(context.params);
+  const token = await generateAccessToken(context.params);
   const db = await initDb({
     token: token.access_token,
     // region MUST match the manifest database.region. Omit to use AIO_DB_REGION.

--- a/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "I want to persist customer feedback in my Commerce app. Add a web runtime action that stores a feedback document in App Builder Database Storage and returns the result.",
-      "expected_output": "The agent installs @adobe/aio-lib-db, registers a web action (web: \"yes\") under a user package (not app-management) in src/commerce-extensibility-1/ext.config.yaml with include-ims-credentials: true, and creates a handler that generates an IMS token, calls init then connect, inserts into a collection, and closes the client in a finally block. It notes the workspace database must be provisioned and the App Builder Data Services API subscribed.",
+      "expected_output": "The agent installs @adobe/aio-lib-db, registers a web action (web: \"yes\") under a user package (not app-management) in src/commerce-extensibility-1/ext.config.yaml with include-ims-credentials: true, and creates a handler that generates an IMS token, calls init then connect, inserts into a collection, and closes the client in a finally block. It notes the workspace database must be provisioned (declaratively via the app.config.yaml database block on deploy, with the aio app db provision CLI as a local-dev fallback) and that the App Builder Data Services API must be added to the project in the Adobe Developer Console.",
       "assertions": [
         "The action is registered with include-ims-credentials: true",
         "The action package name is not 'app-management'",
@@ -12,7 +12,7 @@
         "The handler closes the client in a finally block",
         "An IMS access token is generated via generateAccessToken and passed to init()",
         "The action is registered with web: \"yes\"",
-        "Provisioning (aio app db provision) and the App Builder Data Services API are mentioned"
+        "Provisioning (declarative auto-provision in app.config.yaml as primary, aio app db provision CLI as local-dev fallback) and the App Builder Data Services API are mentioned"
       ]
     },
     {

--- a/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
@@ -50,6 +50,18 @@
         "The client is closed in a finally block",
         "The step is registered under installation.customInstallationSteps in app.commerce.config.ts with a .js script path, a name, and a description"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "My Commerce app is extension-only (no application runtime actions) and uses App Builder Database Storage. After aio app deploy the workspace database isn't provisioned. Configure it so the database is auto-provisioned on deploy.",
+      "expected_output": "The agent explains that declarative auto-provision is skipped for extension-only apps because the application runtime manifest has no runtime action, and applies the workaround in app.config.yaml: an empty packages map (packages: {}) under application.runtimeManifest plus a post-app-build hook running mkdir -p dist/application/actions, alongside the database auto-provision block with a region. It may also mention the aio app db provision CLI as a local-dev fallback.",
+      "assertions": [
+        "Identifies that auto-provision is skipped because the app has no application runtime action",
+        "Adds packages: {} under application.runtimeManifest",
+        "Adds a post-app-build hook running mkdir -p dist/application/actions",
+        "Keeps the database auto-provision block with a region",
+        "References the aio app db provision CLI as a local-dev fallback"
+      ]
     }
   ]
 }

--- a/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
@@ -4,13 +4,13 @@
     {
       "id": 1,
       "prompt": "I want to persist customer feedback in my Commerce app. Add a web runtime action that stores a feedback document in App Builder Database Storage and returns the result.",
-      "expected_output": "The agent installs @adobe/aio-lib-db, registers a web action (web: \"yes\") under a user package (not app-management) in src/commerce-extensibility-1/ext.config.yaml with include-ims-credentials: true, and creates a handler that generates an IMS token, calls init then connect, inserts into a collection, and closes the client in a finally block. It notes the workspace database must be provisioned (declaratively via the app.config.yaml database block on deploy, with the aio app db provision CLI as a local-dev fallback) and that the App Builder Data Services API must be added to the project in the Adobe Developer Console.",
+      "expected_output": "The agent installs @adobe/aio-lib-db, registers a web action (web: \"yes\") under a user package (not app-management) in src/commerce-extensibility-1/ext.config.yaml with include-ims-credentials: true, and creates a handler that resolves the injected IMS auth params with @adobe/aio-commerce-lib-auth, mints a raw access token string, calls init then connect, inserts into a collection, and closes the client in a finally block. It notes the workspace database must be provisioned (declaratively via the app.config.yaml database block on deploy, with the aio app db provision CLI as a local-dev fallback) and that the App Builder Data Services API must be added to the project in the Adobe Developer Console.",
       "assertions": [
         "The action is registered with include-ims-credentials: true",
         "The action package name is not 'app-management'",
         "The handler calls init() then connect() and obtains a collection",
         "The handler closes the client in a finally block",
-        "An IMS access token is generated via generateAccessToken and passed to init()",
+        "An IMS access token is obtained via getImsAuthProvider(resolveImsAuthParams(params)).getAccessToken() from @adobe/aio-commerce-lib-auth and passed to init() as a raw string (not generateAccessToken, not token.access_token)",
         "The action is registered with web: \"yes\"",
         "Provisioning (declarative auto-provision in app.config.yaml as primary, aio app db provision CLI as local-dev fallback) and the App Builder Data Services API are mentioned"
       ]
@@ -42,13 +42,14 @@
     {
       "id": 4,
       "prompt": "When my Commerce app installs, create a 'held_orders' collection with a unique index on order_id so duplicate holds are rejected. Set it up as part of the app installation, not on first request.",
-      "expected_output": "The agent authors a custom installation step with defineCustomInstallationStep (install handler, ideally with an uninstall that drops the collection), generates the IMS token from context.params (not config), connects, gets the collection object and calls createIndex({ order_id: 1 }, { unique: true }) on it, and closes the client in a finally block. It wires the script into app.commerce.config.ts under installation.customInstallationSteps with a .js script path, a unique name, and a description.",
+      "expected_output": "The agent authors a custom installation step with defineCustomInstallationStep (install handler, ideally with an uninstall that drops the collection), exported as an ES module default export (export default, not module.exports), resolves the IMS auth params from context.params via @adobe/aio-commerce-lib-auth and mints a raw access token string, connects, gets the collection object and calls createIndex({ order_id: 1 }, { unique: true }) on it, and closes the client in a finally block. It wires the script into app.commerce.config.ts under installation.customInstallationSteps with a .js script path, a unique name, and a description.",
       "assertions": [
         "The step is defined with defineCustomInstallationStep from @adobe/aio-commerce-lib-app/management",
-        "The IMS token is generated from context.params, not from config",
+        "The IMS token is obtained via getImsAuthProvider(resolveImsAuthParams(context.params)).getAccessToken() from @adobe/aio-commerce-lib-auth (from context.params, not config; not generateAccessToken)",
         "createIndex is called on a collection object with { order_id: 1 } and { unique: true }",
         "The client is closed in a finally block",
-        "The step is registered under installation.customInstallationSteps in app.commerce.config.ts with a .js script path, a name, and a description"
+        "The step is registered under installation.customInstallationSteps in app.commerce.config.ts with a .js script path, a name, and a description",
+        "The install script is authored as an ES module using export default (not module.exports / CommonJS)"
       ]
     },
     {

--- a/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
@@ -1,0 +1,55 @@
+{
+  "skill_name": "commerce-app-storage",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want to persist customer feedback in my Commerce app. Add a web runtime action that stores a feedback document in App Builder Database Storage and returns the result.",
+      "expected_output": "The agent installs @adobe/aio-lib-db, registers a web action (web: \"yes\") under a user package (not app-management) in src/commerce-extensibility-1/ext.config.yaml with include-ims-credentials: true, and creates a handler that generates an IMS token, calls init then connect, inserts into a collection, and closes the client in a finally block. It notes the workspace database must be provisioned and the App Builder Data Services API subscribed.",
+      "assertions": [
+        "The action is registered with include-ims-credentials: true",
+        "The action package name is not 'app-management'",
+        "The handler calls init() then connect() and obtains a collection",
+        "The handler closes the client in a finally block",
+        "An IMS access token is generated via generateAccessToken and passed to init()",
+        "The action is registered with web: \"yes\"",
+        "Provisioning (aio app db provision) and the App Builder Data Services API are mentioned"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "When an order is placed in Commerce, I want to record it in our database. The order event handler already needs to be created. Scaffold the event action and have it write the order to a collection.",
+      "expected_output": "The agent scaffolds an event/webhook action (web: \"no\") registered with include-ims-credentials: true, reading the payload from params.data, and writing to a collection using the init/connect/close lifecycle. After build passes it suggests commerce-app-eventing to wire the action to the order event via runtimeActions.",
+      "assertions": [
+        "The action is registered with include-ims-credentials: true",
+        "The handler reads the event payload from params.data",
+        "The handler uses init() -> connect() -> collection write -> close() in finally",
+        "The action is registered with web: \"no\"",
+        "Agent mentions commerce-app-eventing (or runtimeActions) to wire the action to the event"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Our workspace database is in emea. Add a runtime action that looks up a product by SKU from a 'products' collection, and make sure queries are efficient.",
+      "expected_output": "The agent creates a handler that initializes the library with region 'emea' (matching provisioning), connects, queries the products collection by sku, and closes the client. It promotes best practices: creating an index on the queried field, using projections, and iterating cursors for large result sets.",
+      "assertions": [
+        "init() is called with region: \"emea\"",
+        "The handler queries the products collection filtering by sku",
+        "The client is closed in a finally block",
+        "The agent recommends an index on the queried field and/or projections for efficiency",
+        "aio app build completes without errors"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "When my Commerce app installs, create a 'held_orders' collection with a unique index on order_id so duplicate holds are rejected. Set it up as part of the app installation, not on first request.",
+      "expected_output": "The agent authors a custom installation step with defineCustomInstallationStep (install handler, ideally with an uninstall that drops the collection), generates the IMS token from context.params (not config), connects, gets the collection object and calls createIndex({ order_id: 1 }, { unique: true }) on it, and closes the client in a finally block. It wires the script into app.commerce.config.ts under installation.customInstallationSteps with a .js script path, a unique name, and a description.",
+      "assertions": [
+        "The step is defined with defineCustomInstallationStep from @adobe/aio-commerce-lib-app/management",
+        "The IMS token is generated from context.params, not from config",
+        "createIndex is called on a collection object with { order_id: 1 } and { unique: true }",
+        "The client is closed in a finally block",
+        "The step is registered under installation.customInstallationSteps in app.commerce.config.ts with a .js script path, a name, and a description"
+      ]
+    }
+  ]
+}

--- a/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
@@ -62,6 +62,17 @@
         "Keeps the database auto-provision block with a region",
         "References the aio app db provision CLI as a local-dev fallback"
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "Add a web action that stores records in App Builder Database Storage. My repo has an app.commerce.config.ts at the root, but I haven't initialized the project yet — there's no src/commerce-extensibility-1/ directory and no node_modules.",
+      "expected_output": "The agent recognizes that although the config exists, the project is not initialized (no src/commerce-extensibility-1/ or node_modules), so it runs npx @adobe/aio-commerce-lib-app init before proceeding — without overwriting the existing config. Only after the project is initialized does it install @adobe/aio-lib-db and scaffold the storage web action.",
+      "assertions": [
+        "The agent detects the project is not initialized despite the config being present",
+        "The agent runs npx @adobe/aio-commerce-lib-app init before doing storage work",
+        "The existing app.commerce.config.ts is not overwritten",
+        "Storage work (installing @adobe/aio-lib-db, scaffolding the action) proceeds only after initialization"
+      ]
     }
   ]
 }

--- a/plugins/commerce/app-management/skills/commerce-app-webhooks/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-webhooks/SKILL.md
@@ -23,7 +23,11 @@ Other extensibility domains (events, business config) are added separately via t
 
 ## Prerequisites
 
-Verify `app.commerce.config.ts` exists in the project root. If it doesn't, stop and invoke `commerce-app-init` first.
+- Verify the app is **scaffolded and initialized**, not merely that the config exists. Require **both**:
+  - `app.commerce.config.ts` present in the project root, **and**
+  - the project initialized — signalled by the generated `src/commerce-extensibility-1/` directory and installed `node_modules` (the `@adobe/aio-commerce-lib-app` dependency).
+- If `app.commerce.config.ts` is **missing**, stop and invoke `commerce-app-init` first (it writes the config, then runs init).
+- If the config is **present but the project is not initialized** (no `src/commerce-extensibility-1/` or `node_modules`), run `npx @adobe/aio-commerce-lib-app init` before continuing. Init is idempotent — it finds the existing config, skips the interactive prompts, installs dependencies, and generates the project files.
 
 ## Step 1 — Understand intent
 

--- a/plugins/commerce/app-management/tile.json
+++ b/plugins/commerce/app-management/tile.json
@@ -15,6 +15,9 @@
     },
     "commerce-app-business-config": {
       "path": "skills/commerce-app-business-config/SKILL.md"
+    },
+    "commerce-app-storage": {
+      "path": "skills/commerce-app-storage/SKILL.md"
     }
   }
 }


### PR DESCRIPTION
## Description

Adds a new agentic skill, `commerce-app-storage`, to the Commerce App Management plugin. The skill guides a developer to add App Builder Database Storage to an Adobe Commerce app: scaffolding a runtime action (web or event/webhook) that reads and writes data, and preparing the app's collections and indexes as part of the installation experience rather than ad-hoc on first use.

Includes the skill definition, annotated reference assets, eval cases, and the plugin registration (README and tile) entries.

## Related Issue

- Story: CEXT-6330
- Epic: CEXT-6092 — [M4] Improve Installation Experience (Admin UI)

## Motivation and Context

Supports the M4 "Improve Installation Experience" goal. Apps that need storage today copy boilerplate into every project and have no standard way to prepare their data layer when the app is installed from the Commerce Admin. Centralizing the recommended end-to-end pattern in one reviewed skill makes it reusable, surfaces common pitfalls (provisioning, region consistency, the required Developer Console API), and lets lab/workbook prompts drop the embedded boilerplate.

## How Has This Been Tested?

- Skill review (tessl) passes with 0 errors / 0 warnings and a review score of 94%.
- Repository `pnpm typecheck` and `pnpm test` pass. No published-package source is changed; the diff is plugin/skill content only.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
