### PR TITLE
CEXT-6331:  Fix CJS Custom Scripts

### DIFF
--- a/.changeset/grumpy-baboons-turn.md
+++ b/.changeset/grumpy-baboons-turn.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Fix an issue where developers could not define custom installation scripts via `module.exports` when using CJS.

--- a/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
+import { parseOrThrow } from "@aio-commerce-sdk/common-utils/valibot";
 import * as camelcaseModule from "camelcase";
+import * as v from "valibot";
 
 import { hasCustomInstallationSteps } from "#config/schema/installation";
 import { defineLeafStep } from "#management/installation/workflow/step";
@@ -42,15 +44,26 @@ type ScriptModule =
   | CustomInstallationStepDefinition
   | CustomInstallationStepHandler;
 
+const ScriptModuleSchema = v.union([
+  v.function(),
+  v.object({
+    install: v.function(),
+    uninstall: v.optional(v.function()),
+  }),
+]);
+
+/**
+ * Validates that a loaded script export can be executed as a custom installation step.
+ *
+ * @param module - The loaded script export to validate.
+ * @throws If the export is not a function or an object with an `install` function.
+ */
 function assertScriptModule(module: unknown): asserts module is ScriptModule {
-  if (
-    typeof module !== "function" &&
-    (typeof module !== "object" || module === null)
-  ) {
-    throw new Error(
-      "Invalid script module format. Expected a function or an object with an `install` method.",
-    );
-  }
+  parseOrThrow(
+    ScriptModuleSchema,
+    module,
+    "Invalid script module format. Expected a function or an object with an `install` method.",
+  );
 }
 
 /**
@@ -64,7 +77,7 @@ function getScriptModule(
   customScripts: Record<string, unknown>,
   script: string,
 ): ScriptModule {
-  let scriptModule = customScripts[script] as WithDefault<ScriptModule>;
+  let scriptModule = customScripts[script] as WithDefault<unknown>;
 
   if (!scriptModule) {
     throw new Error(
@@ -87,19 +100,31 @@ function getScriptModule(
  * @param scriptModule - The loaded module
  * @param handler - The handler to resolve
  */
+
+// Overload for `install` (should always return something).
+function resolveCustomScriptHandler(
+  scriptModule: ScriptModule,
+  handler: "install",
+): CustomInstallationStepHandler;
+
+// Overload for `uninstall` (may return null if uninstall is not defined).
+function resolveCustomScriptHandler(
+  scriptModule: ScriptModule,
+  handler: "uninstall",
+): CustomInstallationStepHandler | null;
+
 function resolveCustomScriptHandler(
   scriptModule: ScriptModule,
   handler: "install" | "uninstall",
 ) {
   // For export default / module.exports = defineCustomInstallationStep(() => {})
   if (typeof scriptModule === "function") {
-    // This can only be the install handler, since uninstall requires an object with methods
     return handler === "install" ? scriptModule : null;
   }
 
   // For export default / module.exports = defineCustomInstallationStep({ install, uninstall })
   if (handler in scriptModule && typeof scriptModule[handler] === "function") {
-    return scriptModule[handler] as CustomInstallationStepHandler;
+    return scriptModule[handler];
   }
 
   return null;
@@ -140,12 +165,6 @@ function createCustomScriptStep(scriptConfig: CustomInstallationStep): AnyStep {
 
       const scriptModule = getScriptModule(customScripts, script);
       const install = resolveCustomScriptHandler(scriptModule, "install");
-
-      if (!install) {
-        throw new Error(
-          "Invalid script module format. Expected a function or an object with an `install` method.",
-        );
-      }
 
       const scriptResult = await install(config, context);
       logger.info(`Successfully executed script: ${name}`);

--- a/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/custom-installation/custom-scripts.ts
@@ -37,21 +37,72 @@ const camelcase =
   (camelcaseModule.default as CamelcaseInterop).default ??
   camelcaseModule.default;
 
-function isCustomInstallationStepDefinition(
-  obj: unknown,
-): obj is CustomInstallationStepDefinition {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "install" in obj &&
-    typeof obj.install === "function"
-  );
+type WithDefault<T> = T | { default: T };
+type ScriptModule =
+  | CustomInstallationStepDefinition
+  | CustomInstallationStepHandler;
+
+function assertScriptModule(module: unknown): asserts module is ScriptModule {
+  if (
+    typeof module !== "function" &&
+    (typeof module !== "object" || module === null)
+  ) {
+    throw new Error(
+      "Invalid script module format. Expected a function or an object with an `install` method.",
+    );
+  }
 }
 
-function isCustomInstallationStepHandler(
-  obj: unknown,
-): obj is CustomInstallationStepHandler {
-  return typeof obj === "function";
+/**
+ * Parses and validates a custom script module from the provided customScripts context.
+ * It supports both direct function exports and default exports.
+ *
+ * @param customScripts - The customScripts context containing the loaded modules
+ * @param script - The script path to resolve the module for
+ */
+function getScriptModule(
+  customScripts: Record<string, unknown>,
+  script: string,
+): ScriptModule {
+  let scriptModule = customScripts[script] as WithDefault<ScriptModule>;
+
+  if (!scriptModule) {
+    throw new Error(
+      `Script ${script} not found in customScripts context. Make sure the script is defined in the configuration and the action was generated with custom scripts support.`,
+    );
+  }
+
+  if (typeof scriptModule === "object" && "default" in scriptModule) {
+    scriptModule = scriptModule.default;
+  }
+
+  assertScriptModule(scriptModule);
+  return scriptModule;
+}
+
+/**
+ * Resolves the desired handler function from a custom script module. The module can either export
+ * a single function (for install) or an object with install/uninstall methods.
+ *
+ * @param scriptModule - The loaded module
+ * @param handler - The handler to resolve
+ */
+function resolveCustomScriptHandler(
+  scriptModule: ScriptModule,
+  handler: "install" | "uninstall",
+) {
+  // For export default / module.exports = defineCustomInstallationStep(() => {})
+  if (typeof scriptModule === "function") {
+    // This can only be the install handler, since uninstall requires an object with methods
+    return handler === "install" ? scriptModule : null;
+  }
+
+  // For export default / module.exports = defineCustomInstallationStep({ install, uninstall })
+  if (handler in scriptModule && typeof scriptModule[handler] === "function") {
+    return scriptModule[handler] as CustomInstallationStepHandler;
+  }
+
+  return null;
 }
 
 /** Result of executing a single custom installation script. */
@@ -87,37 +138,16 @@ function createCustomScriptStep(scriptConfig: CustomInstallationStep): AnyStep {
       logger.info(`Executing custom installation script: ${name}`);
       logger.debug(`Script path: ${script}`);
 
-      const scriptModule = customScripts[script];
+      const scriptModule = getScriptModule(customScripts, script);
+      const install = resolveCustomScriptHandler(scriptModule, "install");
 
-      if (!scriptModule) {
+      if (!install) {
         throw new Error(
-          `Script ${script} not found in customScripts context. Make sure the script is defined in the configuration and the action was generated with custom scripts support.`,
+          "Invalid script module format. Expected a function or an object with an `install` method.",
         );
       }
 
-      // Only support default export
-      if (typeof scriptModule !== "object" || !("default" in scriptModule)) {
-        throw new Error(
-          `Script ${script} must export a default function or object. Use defineCustomInstallationStep helper.`,
-        );
-      }
-
-      const defaultExport = scriptModule.default;
-      let runFunction: CustomInstallationStepHandler | null = null;
-
-      if (isCustomInstallationStepHandler(defaultExport)) {
-        runFunction = defaultExport;
-      } else if (isCustomInstallationStepDefinition(defaultExport)) {
-        runFunction = defaultExport.install;
-      }
-
-      if (runFunction === null) {
-        throw new Error(
-          `Script ${script} default export must be a function or an object with an install method. Use defineCustomInstallationStep helper.`,
-        );
-      }
-
-      const scriptResult = await runFunction(config, context);
+      const scriptResult = await install(config, context);
       logger.info(`Successfully executed script: ${name}`);
 
       return {
@@ -132,32 +162,16 @@ function createCustomScriptStep(scriptConfig: CustomInstallationStep): AnyStep {
     ): Promise<void> => {
       const { logger } = context;
       const customScripts = context.customScripts || {};
-
       logger.debug(`Uninstalling custom script: ${name}`);
 
-      const scriptModule = customScripts[script];
-
-      if (!scriptModule) {
-        throw new Error(
-          `Script ${script} not found in customScripts context. Make sure the script is defined in the configuration and the action was generated with custom scripts support.`,
-        );
-      }
-
-      const defaultExport = (scriptModule as Record<string, unknown>).default;
-
-      if (!isCustomInstallationStepDefinition(defaultExport)) {
-        logger.debug(
-          `Script ${script} does not export an uninstall function, skipping uninstall.`,
-        );
-        return;
-      }
-
-      const { uninstall } = defaultExport;
+      const scriptModule = getScriptModule(customScripts, script);
+      const uninstall = resolveCustomScriptHandler(scriptModule, "uninstall");
 
       if (!uninstall) {
         logger.debug(
           `Script ${script} does not export an uninstall function, skipping uninstall.`,
         );
+
         return;
       }
 

--- a/packages/aio-commerce-lib-app/test/integration/management/runner.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/management/runner.test.ts
@@ -240,7 +240,7 @@ describe("runInstallation - custom installation scripts", () => {
     });
 
     expect.assert(isFailedState(result));
-    expect(result.error.message).toContain("default export must be a function");
+    expect(result.error.message).toContain("Invalid script module format");
   });
 });
 

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/custom-installation/custom-scripts.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/custom-installation/custom-scripts.test.ts
@@ -186,6 +186,98 @@ describe("createCustomScriptStep - run function", () => {
   });
 });
 
+describe("createCustomScriptStep - run function (CJS module.exports forms)", () => {
+  test("should execute CJS function form (module.exports = fn) without .default wrapper", async () => {
+    const mockScriptResult = { status: "success", data: "cjs-fn" };
+    const mockScript = vi.fn().mockResolvedValue(mockScriptResult);
+
+    const steps = createCustomScriptSteps(configWithCustomInstallationSteps);
+    const step = steps?.[0] as LeafStep;
+
+    const mockContext = createMockInstallationContext();
+    mockContext.customScripts = {
+      "./demo-success.js": mockScript, // CJS: module.exports = fn
+    };
+
+    const result = await step.install(
+      configWithCustomInstallationSteps,
+      mockContext,
+    );
+
+    expect(mockScript).toHaveBeenCalledWith(
+      configWithCustomInstallationSteps,
+      mockContext,
+    );
+    expect(result).toEqual({
+      script: "./demo-success.js",
+      data: mockScriptResult,
+    });
+  });
+
+  test("should execute CJS object form (module.exports = { install }) without .default wrapper", async () => {
+    const mockInstallResult = { status: "success", data: "cjs-obj" };
+    const mockInstall = vi.fn().mockResolvedValue(mockInstallResult);
+
+    const steps = createCustomScriptSteps(configWithCustomInstallationSteps);
+    const step = steps?.[0] as LeafStep;
+
+    const mockContext = createMockInstallationContext();
+    mockContext.customScripts = {
+      "./demo-success.js": { install: mockInstall }, // CJS: module.exports = { install }
+    };
+
+    const result = await step.install(
+      configWithCustomInstallationSteps,
+      mockContext,
+    );
+
+    expect(mockInstall).toHaveBeenCalledWith(
+      configWithCustomInstallationSteps,
+      mockContext,
+    );
+    expect(result).toEqual({
+      script: "./demo-success.js",
+      data: mockInstallResult,
+    });
+  });
+
+  test("should call uninstall from CJS object form without .default wrapper", async () => {
+    const mockUninstall = vi.fn().mockResolvedValue(undefined);
+    const mockInstall = vi.fn().mockResolvedValue({ status: "success" });
+
+    const steps = createCustomScriptSteps(configWithCustomInstallationSteps);
+    const step = steps?.[0] as LeafStep;
+
+    const mockContext = createMockInstallationContext();
+    mockContext.customScripts = {
+      "./demo-success.js": { install: mockInstall, uninstall: mockUninstall },
+    };
+
+    await step.uninstall?.(configWithCustomInstallationSteps, mockContext);
+
+    expect(mockUninstall).toHaveBeenCalledWith(
+      configWithCustomInstallationSteps,
+      mockContext,
+    );
+  });
+
+  test("should skip uninstall gracefully for CJS function form (no uninstall to call)", async () => {
+    const mockScript = vi.fn().mockResolvedValue({ status: "success" });
+
+    const steps = createCustomScriptSteps(configWithCustomInstallationSteps);
+    const step = steps?.[0] as LeafStep;
+
+    const mockContext = createMockInstallationContext();
+    mockContext.customScripts = {
+      "./demo-success.js": mockScript, // CJS function: no uninstall
+    };
+
+    await expect(
+      step.uninstall?.(configWithCustomInstallationSteps, mockContext),
+    ).resolves.toBeUndefined();
+  });
+});
+
 describe("createCustomScriptStep - run function (object form)", () => {
   test("should execute install handler from object form and return result", async () => {
     const mockInstallResult = { status: "success", data: "object-form" };


### PR DESCRIPTION
## Description

Add support of `module.exports = defineCustomInstallationStep` which doesn't wrap things in a `default` export. 

## Ticket

[CEXT-6331](https://jira.corp.adobe.com/browse/CEXT-6331)