### PR TITLE
CEXT-6333: Fix exceptionOperation helper

### DIFF
--- a/.changeset/swift-otters-camp.md
+++ b/.changeset/swift-otters-camp.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-webhooks": patch
+---
+
+Fix the webhook exception operation to emit the exception class under the `type` field instead of `class`, matching the Adobe Commerce webhook response spec. Previously the supplied exception class was ignored by Commerce.

--- a/packages/aio-commerce-lib-webhooks/source/responses/operations/presets.ts
+++ b/packages/aio-commerce-lib-webhooks/source/responses/operations/presets.ts
@@ -52,7 +52,7 @@ export const exceptionOperation = (
 ): ExceptionOperation => ({
   op: "exception",
   ...(message && { message }),
-  ...(exceptionClass && { class: exceptionClass }),
+  ...(exceptionClass && { type: exceptionClass }),
 });
 
 /**

--- a/packages/aio-commerce-lib-webhooks/source/responses/operations/types.ts
+++ b/packages/aio-commerce-lib-webhooks/source/responses/operations/types.ts
@@ -25,7 +25,7 @@ export type SuccessOperation = {
 export type ExceptionOperation = {
   op: "exception";
   /** Specifies the exception class. If not set, \Magento\Framework\Exception\LocalizedException will be thrown. */
-  class?: string;
+  type?: string;
   /** Specifies the exception message. If not set, fallbackErrorMessage or system default will be used. */
   message?: string;
 };

--- a/packages/aio-commerce-lib-webhooks/test/unit/responses/presets.test.ts
+++ b/packages/aio-commerce-lib-webhooks/test/unit/responses/presets.test.ts
@@ -63,7 +63,7 @@ describe("responses/presets", () => {
         body: {
           op: "exception",
           message: "Payment validation failed",
-          class: "Magento\\Payment\\Exception\\PaymentException",
+          type: "Magento\\Payment\\Exception\\PaymentException",
         },
       });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the webhook `exceptionOperation` builder so it emits the exception class under the `type` field instead of `class`, matching the [Adobe Commerce webhook response spec](https://developer.adobe.com/commerce/extensibility/webhooks/responses#exception-operation).

  Per the spec, an exception operation response looks like:

  ```json
  {
    "op": "exception",
    "type": "Path\\To\\Exception\\Class",
    "message": "The product cannot be added to the cart because it is out of stock"
  }
  ```

The SDK was emitting `class` instead of `type`, so Commerce never read the supplied exception class.

https://jira.corp.adobe.com/browse/CEXT-6333

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
