### PR TITLE
fix: use npm scripts for changesets version and publish commands

### DIFF
--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -36,8 +36,8 @@ jobs:
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          version: pnpm changeset version && pnpm turbo version && pnpm turbo docs
-          publish: pnpm changeset publish
+          version: pnpm release:version
+          publish: pnpm release:publish
           commit: "ci: release packages"
           title: "[CI] Release Packages"
           createGithubReleases: true

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "pack": "turbo run pack",
     "prepare": "husky",
     "publint": "turbo run publint",
+    "release:publish": "changeset publish",
+    "release:version": "changeset version && turbo version && turbo docs",
     "test": "turbo test",
     "turbo": "turbo",
     "typecheck": "turbo typecheck"


### PR DESCRIPTION
## Description

Moves the compound `version` and `publish` commands used by the changesets release action into dedicated npm scripts (`release:version`, `release:publish`).

## Related Issue

N/A

## Motivation and Context

The `changesets/action` runs the `version` and `publish` fields via `@actions/exec` without shell interpretation, so shell operators like `&&` are passed as literal arguments to pnpm → the changeset CLI → "Too many arguments" error. Because no files were modified, the subsequent PR creation fails with "No commits between release and changeset-release/release".

Moving the commands into npm scripts (`release:version`, `release:publish`) fixes this because pnpm always invokes scripts through a shell, so `&&` is interpreted correctly.

## How Has This Been Tested?

Inspected the failed CI run logs to confirm the root cause. The fix is straightforward — no logic change, only command routing.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.