### PR TITLE
docs: document PaaS admin user requirement for IMS auth

### DIFF
--- a/packages/aio-commerce-lib-api/docs/usage.md
+++ b/packages/aio-commerce-lib-api/docs/usage.md
@@ -67,6 +67,11 @@ const commerceClient = new AdobeCommerceHttpClient({
 
 **With IMS Auth:**
 
+> [!IMPORTANT]
+> Using IMS authentication with PaaS requires a one-time manual setup in the Commerce Admin. The S2S token issued for your technical account is treated as a user token, so the technical account must exist as an admin user with the appropriate permissions.
+>
+> To set this up, follow the [Admin User Creation Guide](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/user-accounts/permissions-users-all#create-a-user) and use the technical account email from your OAuth S2S credentials in the Adobe Developer Console workspace (format: `<technical-account>@techacct.adobe.com`) in the Email field — this must match the value of `AIO_COMMERCE_AUTH_IMS_TECHNICAL_ACCOUNT_EMAIL` exactly. On the User Role tab, assign the **Integrations** role.
+
 ```typescript
 const commerceClient = new AdobeCommerceHttpClient({
   config: {


### PR DESCRIPTION
## Description

Documents that using IMS authentication with a PaaS Commerce instance requires a one-time manual setup: the technical account must be added as an admin user in the Commerce Admin with the Integrations role, and the email must match the value from the OAuth S2S credentials in the Adobe Developer Console workspace.

## Related Issue

N/A

## Motivation and Context

IMS S2S tokens are treated as user tokens by the PaaS Admin REST API. Without the technical account being registered as an admin user, requests will fail. This was undocumented and easy to miss.

## How Has This Been Tested?

Documentation-only change.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.