### PR TITLE
CEXT-6313: Restore Admin UI Installation step

### DIFF
--- a/.changeset/bold-guests-report.md
+++ b/.changeset/bold-guests-report.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Apps that include `adminUi` configuration now have a dedicated installation step that registers the extension with Adobe Commerce Admin UI via `commerce/backend-ui/2`.

--- a/.changeset/bold-guests-report.md
+++ b/.changeset/bold-guests-report.md
@@ -1,5 +1,0 @@
----
-"@adobe/aio-commerce-lib-app": minor
----
-
-Apps that include `adminUi` configuration now have a dedicated installation step that registers the extension with Adobe Commerce Admin UI via `commerce/backend-ui/2`.

--- a/packages/aio-commerce-lib-app/source/management/installation/admin-ui/branch.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/admin-ui/branch.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasAdminUi } from "#config/schema/admin-ui";
+import {
+  defineBranchStep,
+  defineLeafStep,
+} from "#management/installation/workflow/step";
+
+import { registerExtension, unregisterExtension } from "./helpers";
+import { createAdminUiStepContext } from "./utils";
+
+import type { InferStepOutput } from "#management/installation/workflow/step";
+import type { AdminUiConfig, AdminUiExecutionContext } from "./utils";
+
+/** Leaf step that registers the extension (POST) on install and unregisters it (DELETE) on uninstall. */
+const registerExtensionStep = defineLeafStep({
+  name: "register-extension",
+  meta: {
+    install: {
+      label: "Register Extension",
+      description: "Registers the Admin UI extension in Adobe Commerce",
+    },
+    uninstall: {
+      label: "Unregister Extension",
+      description: "Removes the Admin UI extension from Adobe Commerce",
+    },
+  },
+
+  install: (_: AdminUiConfig, context: AdminUiExecutionContext) =>
+    registerExtension(context),
+
+  uninstall: (_: AdminUiConfig, context: AdminUiExecutionContext) =>
+    unregisterExtension(context),
+});
+
+/** The output data of the register extension step (auto-inferred). */
+export type RegisterExtensionStepData = InferStepOutput<
+  typeof registerExtensionStep
+>;
+
+/** Branch step for setting up the Admin UI extension registration. */
+export const adminUiStep = defineBranchStep({
+  name: "admin-ui",
+  meta: {
+    install: {
+      label: "Admin UI",
+      description: "Registers the extension with Adobe Commerce Admin UI",
+    },
+    uninstall: {
+      label: "Admin UI",
+      description: "Removes the extension from Adobe Commerce Admin UI",
+    },
+  },
+
+  when: hasAdminUi,
+  context: createAdminUiStepContext,
+  children: [registerExtensionStep],
+});

--- a/packages/aio-commerce-lib-app/source/management/installation/admin-ui/helpers.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/admin-ui/helpers.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { unwrapHttpError } from "@adobe/aio-commerce-lib-api/utils";
+
+import { throwHttpError } from "../utils/http-error";
+
+import type { AdminUiExecutionContext } from "./utils";
+
+/**
+ * Registers the extension with Commerce via POST /V1/adminuisdk/extension.
+ *
+ * @param context - The execution context providing the Admin UI client and logger.
+ */
+export async function registerExtension(context: AdminUiExecutionContext) {
+  const { adminUiClient, appData, logger } = context;
+  const extensionName = process.env.__OW_NAMESPACE;
+
+  if (!extensionName) {
+    throw new Error("__OW_NAMESPACE environment variable is not set");
+  }
+
+  logger.info(`Registering Admin UI extension: ${appData.projectName}`);
+
+  const { extensionId } = await adminUiClient
+    .registerExtension({
+      extensionName,
+      extensionTitle: appData.projectTitle,
+      extensionUrl: `https://${extensionName}.adobeio-static.net/index.html`,
+      extensionWorkspace: appData.workspaceName,
+    })
+    .catch((error: unknown) =>
+      throwHttpError(logger, error, "Failed to register Admin UI extension"),
+    );
+
+  logger.info(`Admin UI extension registered successfully: ${extensionId}`);
+}
+
+/**
+ * Unregisters the extension from Commerce via DELETE /V1/adminuisdk/extension/:workspace_name/:extension_name.
+ * Best-effort: errors are logged as warnings and do not stop the uninstall workflow.
+ *
+ * @param context - The execution context providing the Admin UI client and logger.
+ */
+export async function unregisterExtension(
+  context: AdminUiExecutionContext,
+): Promise<void> {
+  const { adminUiClient, appData, logger } = context;
+  const extensionName = process.env.__OW_NAMESPACE;
+
+  if (!extensionName) {
+    logger.warn(
+      "__OW_NAMESPACE environment variable is not set; skipping Admin UI extension unregistration. Continuing uninstall.",
+    );
+    return;
+  }
+
+  logger.info(
+    `Unregistering Admin UI extension "${extensionName}" from workspace "${appData.workspaceName}"...`,
+  );
+
+  try {
+    await adminUiClient.unregisterExtension({
+      workspaceName: appData.workspaceName,
+      extensionName,
+    });
+    logger.info(
+      `Admin UI extension "${extensionName}" unregistered successfully.`,
+    );
+  } catch (error: unknown) {
+    const msg = await unwrapHttpError(error);
+    logger.warn(
+      `Failed to unregister Admin UI extension "${extensionName}": ${msg}. Continuing uninstall.`,
+    );
+  }
+}

--- a/packages/aio-commerce-lib-app/source/management/installation/admin-ui/index.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/admin-ui/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** biome-ignore-all lint/performance/noBarrelFile: Convenience entrypoint for the admin-ui module */
+
+export { adminUiStep } from "./branch";
+
+export type { RegisterExtensionStepData } from "./branch";
+export type { AdminUiConfig } from "./utils";

--- a/packages/aio-commerce-lib-app/source/management/installation/admin-ui/utils.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/admin-ui/utils.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createAdminUiApiClient } from "@adobe/aio-commerce-lib-admin-ui/api";
+import { resolveCommerceHttpClientParams } from "@adobe/aio-commerce-lib-api";
+
+import type { RuntimeActionParams } from "@adobe/aio-commerce-lib-core/params";
+import type {
+  ExecutionContext,
+  InstallationContext,
+  StepContextFactory,
+} from "#management/installation/workflow/step";
+
+export type { AdminUiConfig } from "#config/schema/admin-ui";
+
+function createAdminUiClient(params: RuntimeActionParams) {
+  const commerceClientParams = resolveCommerceHttpClientParams(params, {
+    tryForwardAuthProvider: true,
+  });
+
+  return createAdminUiApiClient(commerceClientParams);
+}
+
+/** The Admin UI API client used during installation. */
+export type AdminUiApiClient = ReturnType<typeof createAdminUiClient>;
+
+/** Context shared across Admin UI installation steps. */
+export interface AdminUiStepContext extends Record<string, unknown> {
+  get adminUiClient(): AdminUiApiClient;
+}
+
+/** The execution context for Admin UI leaf steps. */
+export type AdminUiExecutionContext = ExecutionContext<AdminUiStepContext>;
+
+/** Creates the Admin UI step context with a lazy-initialized API client. */
+export const createAdminUiStepContext: StepContextFactory<
+  AdminUiStepContext
+> = (installation: InstallationContext) => {
+  const { params } = installation;
+  let adminUiClient: AdminUiApiClient | null = null;
+
+  return {
+    get adminUiClient() {
+      if (adminUiClient === null) {
+        adminUiClient = createAdminUiClient(params);
+      }
+
+      return adminUiClient;
+    },
+  };
+};

--- a/packages/aio-commerce-lib-app/source/management/installation/root.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/root.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { adminUiStep } from "./admin-ui";
 import { createCustomInstallationStep } from "./custom-installation";
 import { eventingStep } from "./events";
 import { webhooksStep } from "./webhooks";
@@ -24,7 +25,12 @@ import type { AnyStep, BranchStep } from "./workflow";
 function createDefaultChildSteps(
   config: CommerceAppConfigOutputModel,
 ): AnyStep[] {
-  return [eventingStep, webhooksStep, createCustomInstallationStep(config)];
+  return [
+    eventingStep,
+    webhooksStep,
+    adminUiStep,
+    createCustomInstallationStep(config),
+  ];
 }
 
 /**

--- a/packages/aio-commerce-lib-app/test/fixtures/admin-ui.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/admin-ui.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { vi } from "vitest";
+
+import { createMockInstallationContext } from "#test/fixtures/installation";
+
+import type { AdminUiExecutionContext } from "#management/installation/admin-ui/utils";
+
+/** Creates a mock AdminUiExecutionContext with Admin UI client methods. */
+export function createMockAdminUiContext(overrides?: {
+  registerExtensionImpl?: () => Promise<{ extensionId: string }>;
+  unregisterExtensionImpl?: () => Promise<unknown>;
+}): AdminUiExecutionContext {
+  const mockInstallation = createMockInstallationContext();
+
+  return {
+    ...mockInstallation,
+    adminUiClient: {
+      registerExtension: vi
+        .fn()
+        .mockImplementation(
+          overrides?.registerExtensionImpl ??
+            (() => Promise.resolve({ extensionId: "ext-123" })),
+        ),
+      unregisterExtension: vi
+        .fn()
+        .mockImplementation(
+          overrides?.unregisterExtensionImpl ?? (() => Promise.resolve()),
+        ),
+    } as unknown as AdminUiExecutionContext["adminUiClient"],
+  };
+}

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/branch.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/branch.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { adminUiStep } from "#management/installation/admin-ui/branch";
+import {
+  isBranchStep,
+  isLeafStep,
+} from "#management/installation/workflow/step";
+import { createMockAdminUiContext } from "#test/fixtures/admin-ui";
+import {
+  configWithAdminUi,
+  configWithWebhooks,
+  minimalValidConfig,
+} from "#test/fixtures/config";
+import { createMockLogger } from "#test/fixtures/installation";
+
+describe("admin-ui installation module", () => {
+  describe("adminUiStep branch step", () => {
+    test("should be a branch step with correct name and meta", () => {
+      expect(isBranchStep(adminUiStep)).toBe(true);
+      expect(adminUiStep.name).toBe("admin-ui");
+      expect(adminUiStep.meta).toEqual({
+        install: {
+          label: "Admin UI",
+          description: "Registers the extension with Adobe Commerce Admin UI",
+        },
+        uninstall: {
+          label: "Admin UI",
+          description: "Removes the extension from Adobe Commerce Admin UI",
+        },
+      });
+    });
+
+    test("should only run if adminUi is defined", () => {
+      expect.assert(adminUiStep.when);
+
+      expect(adminUiStep.when(configWithAdminUi)).toBe(true);
+
+      expect(adminUiStep.when(minimalValidConfig)).toBe(false);
+      expect(adminUiStep.when(configWithWebhooks)).toBe(false);
+    });
+
+    test("should have meta.uninstall defined", () => {
+      expect(adminUiStep.meta.uninstall).toBeDefined();
+    });
+
+    test("should have one leaf child: register-extension", () => {
+      expect(adminUiStep.children).toHaveLength(1);
+      expect(adminUiStep.children[0].name).toBe("register-extension");
+      expect(isLeafStep(adminUiStep.children[0])).toBe(true);
+    });
+  });
+
+  describe("registerExtensionStep uninstall handler", () => {
+    const registerExtensionStep = adminUiStep.children[0];
+
+    beforeEach(() => {
+      vi.stubEnv("__OW_NAMESPACE", "test-namespace");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    test("should have an uninstall handler defined", () => {
+      expect(registerExtensionStep.uninstall).toBeDefined();
+    });
+
+    test("should have meta.uninstall defined", () => {
+      expect(registerExtensionStep.meta.uninstall).toBeDefined();
+    });
+
+    test("should call unregisterExtension with workspaceName and __OW_NAMESPACE", async () => {
+      const context = createMockAdminUiContext();
+
+      await registerExtensionStep.uninstall?.(configWithAdminUi, context);
+
+      expect(context.adminUiClient.unregisterExtension).toHaveBeenCalledWith({
+        workspaceName: context.appData.workspaceName,
+        extensionName: "test-namespace",
+      });
+    });
+
+    test("should not throw when the uninstall call fails (best-effort)", async () => {
+      const context = createMockAdminUiContext({
+        unregisterExtensionImpl: () =>
+          Promise.reject(new Error("Commerce API error")),
+      });
+
+      await expect(
+        registerExtensionStep.uninstall?.(configWithAdminUi, context),
+      ).resolves.toBeUndefined();
+    });
+
+    test("should log a warning when the uninstall call fails", async () => {
+      const logger = createMockLogger();
+      const context = {
+        ...createMockAdminUiContext({
+          unregisterExtensionImpl: () =>
+            Promise.reject(new Error("Commerce API error")),
+        }),
+        logger,
+      };
+
+      await registerExtensionStep.uninstall?.(configWithAdminUi, context);
+
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/helpers.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/helpers.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  registerExtension,
+  unregisterExtension,
+} from "#management/installation/admin-ui/helpers";
+import { createMockAdminUiContext } from "#test/fixtures/admin-ui";
+import { makeHttpError } from "#test/fixtures/http-error";
+import { createMockLogger } from "#test/fixtures/installation";
+
+const REGISTER_EXTENSION_COMBINED_PATTERN =
+  /Failed to register Admin UI extension.*Insufficient permissions/;
+
+describe("registerExtension", () => {
+  beforeEach(() => {
+    vi.stubEnv("__OW_NAMESPACE", "test-ns");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("logs success with extensionId when registerExtension call resolves", async () => {
+    const logger = createMockLogger();
+    const context = {
+      ...createMockAdminUiContext({
+        registerExtensionImpl: () =>
+          Promise.resolve({ extensionId: "ext-123" }),
+      }),
+      logger,
+    };
+
+    await expect(registerExtension(context)).resolves.toBeUndefined();
+
+    expect(context.adminUiClient.registerExtension).toHaveBeenCalledWith({
+      extensionName: "test-ns",
+      extensionTitle: context.appData.projectTitle,
+      extensionUrl: "https://test-ns.adobeio-static.net/index.html",
+      extensionWorkspace: context.appData.workspaceName,
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("registered successfully: ext-123"),
+    );
+  });
+
+  test("throws enriched error when registerExtension call fails", async () => {
+    const httpError = makeHttpError(
+      403,
+      "Forbidden",
+      JSON.stringify({ message: "Insufficient permissions" }),
+    );
+    const context = createMockAdminUiContext({
+      registerExtensionImpl: () => Promise.reject(httpError),
+    });
+
+    await expect(registerExtension(context)).rejects.toThrow(
+      REGISTER_EXTENSION_COMBINED_PATTERN,
+    );
+  });
+
+  test("logs error before throwing", async () => {
+    const logger = createMockLogger();
+    const httpError = makeHttpError(
+      403,
+      "Forbidden",
+      JSON.stringify({ message: "Insufficient permissions" }),
+    );
+    const context = {
+      ...createMockAdminUiContext({
+        registerExtensionImpl: () => Promise.reject(httpError),
+      }),
+      logger,
+    };
+
+    await expect(registerExtension(context)).rejects.toThrow();
+
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(REGISTER_EXTENSION_COMBINED_PATTERN),
+    );
+  });
+});
+
+describe("unregisterExtension", () => {
+  beforeEach(() => {
+    vi.stubEnv("__OW_NAMESPACE", "test-ns");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("warns and returns without calling the client when __OW_NAMESPACE is not set", async () => {
+    vi.unstubAllEnvs();
+    const logger = createMockLogger();
+    const context = { ...createMockAdminUiContext({}), logger };
+
+    await expect(unregisterExtension(context)).resolves.toBeUndefined();
+
+    expect(context.adminUiClient.unregisterExtension).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Continuing uninstall."),
+    );
+  });
+
+  test("warns with enriched error message when unregisterExtension call fails", async () => {
+    const logger = createMockLogger();
+    const httpError = makeHttpError(
+      500,
+      "Internal Server Error",
+      JSON.stringify({ message: "Service unavailable" }),
+    );
+    const context = {
+      ...createMockAdminUiContext({
+        unregisterExtensionImpl: () => Promise.reject(httpError),
+      }),
+      logger,
+    };
+
+    await unregisterExtension(context);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("test-ns"),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Service unavailable"),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Continuing uninstall."),
+    );
+  });
+});

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/root.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/root.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, test } from "vitest";
 
+import { adminUiStep } from "#management/installation/admin-ui/branch";
 import { eventingStep } from "#management/installation/events/branch";
 import {
   createRootInstallationStep,
@@ -31,10 +32,11 @@ describe("createRootInstallationStep", () => {
     expect(result.type).toBe("branch");
     expect(result.name).toBe("installation");
 
-    expect(result.children.length).toBe(3);
+    expect(result.children.length).toBe(4);
     expect(result.children[0]).toBe(eventingStep);
     expect(result.children[1]).toBe(webhooksStep);
-    expect(result.children[2].name).toBe("customInstallationSteps");
+    expect(result.children[2]).toBe(adminUiStep);
+    expect(result.children[3].name).toBe("customInstallationSteps");
   });
 
   test("should create custom installation step with dynamic children when config has custom steps", () => {
@@ -42,8 +44,8 @@ describe("createRootInstallationStep", () => {
       configWithCustomInstallationSteps,
     );
 
-    expect(result.children.length).toBe(3);
-    const customInstallationStep = result.children[2];
+    expect(result.children.length).toBe(4);
+    const customInstallationStep = result.children[3];
     expect(customInstallationStep.name).toBe("customInstallationSteps");
     expect(customInstallationStep.type).toBe("branch");
 
@@ -65,10 +67,11 @@ describe("createRootUninstallationStep", () => {
     expect(result.type).toBe("branch");
     expect(result.name).toBe("uninstallation");
 
-    expect(result.children.length).toBe(3);
+    expect(result.children.length).toBe(4);
     expect(result.children[0]).toBe(eventingStep);
     expect(result.children[1]).toBe(webhooksStep);
-    expect(result.children[2].name).toBe("customInstallationSteps");
+    expect(result.children[2]).toBe(adminUiStep);
+    expect(result.children[3].name).toBe("customInstallationSteps");
   });
 
   test("should have correct meta label for uninstallation", () => {
@@ -87,8 +90,8 @@ describe("createRootUninstallationStep", () => {
       configWithCustomInstallationSteps,
     );
 
-    expect(result.children.length).toBe(3);
-    const customInstallationStep = result.children[2];
+    expect(result.children.length).toBe(4);
+    const customInstallationStep = result.children[3];
     expect(customInstallationStep.name).toBe("customInstallationSteps");
     expect(customInstallationStep.type).toBe("branch");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In https://github.com/adobe/aio-commerce-sdk/pull/512/changes, the Admin UI installation step was removed by mistake, this PR restores it.

<img width="1691" height="667" alt="image" src="https://github.com/user-attachments/assets/eefabdab-044f-4e76-affb-67266414f0cc" />

<img width="847" height="679" alt="image" src="https://github.com/user-attachments/assets/7b1179ee-3b71-47c6-83d6-cc6ebad293d2" />


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
