### PR TITLE
CEXT-6316: add order-view-buttons wire contract to lib-admin-ui and sdk

### DIFF
--- a/.changeset/chilly-vans-change.md
+++ b/.changeset/chilly-vans-change.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-admin-ui": minor
+---
+
+Add `order-view-buttons` entrypoint with request parsing and response builders for `commerce/backend-ui/2` order view button handlers.

--- a/.changeset/sunny-years-hear.md
+++ b/.changeset/sunny-years-hear.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-sdk": minor
+---
+
+Re-export `order-view-buttons` from the `admin-ui/order-view-buttons` entrypoint.

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -128,7 +128,9 @@ Commerce POSTs a body of the shape `{ requestId, id, orderId }` to the handler. 
 ```typescript
 import { parseOrderViewButtonRequest } from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";
 
-export async function main(params: unknown) {
+import type { RuntimeActionParams } from "@adobe/aio-commerce-lib-core/params";
+
+export async function main(params: RuntimeActionParams) {
   const { requestId, id, orderId } = parseOrderViewButtonRequest(params);
   // id identifies which button was clicked — useful when one handler serves multiple buttons
   // orderId is the order currently being viewed

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -5,11 +5,12 @@
 
 ## Overview
 
-This package provides utilities for interacting with the Admin UI SDK API and the Admin UI grid column extension points:
+This package provides utilities for interacting with the Admin UI SDK API and the Admin UI `commerce/backend-ui/2` extension points:
 
 - **[API Client](#api-client)**: Create typed HTTP clients for the Admin UI SDK API
 - **[Grid Column Wire Contract](#grid-column-wire-contract)**: Request and response builders for runtime actions handling `commerce/backend-ui/2` grid column extensions
 - **[Menu Constants](#menu-constants)**: Named constants and type guards for Commerce Admin menu IDs
+- **[Order View Button Wire Contract](#order-view-button-wire-contract)**: Runtime model for `commerce/backend-ui/2` order view buttons — iframe navigation contract for `type: "view"` and request/response builders for `type: "worker"` handlers
 
 ## API Reference
 
@@ -100,6 +101,63 @@ The column keys inside each row must match the `id` values declared in the corre
 import { errorGridResponse } from "@adobe/aio-commerce-lib-admin-ui/grid-columns";
 
 return errorGridResponse("INTERNAL_ERROR", "Could not reach inventory service");
+```
+
+### Order View Button Wire Contract
+
+`adminUi.order.viewButtons` supports two variants with different runtime models. The registration side (declaring buttons and their configuration) is handled through `@adobe/aio-commerce-lib-app`.
+
+#### type: "view" — iframe buttons
+
+Commerce does not call a server-side handler. Instead, it opens an iframe pointing at the app's web entry with the button `path` appended and `orderId` as a query parameter:
+
+```
+https://<extension-host>/index.html<path>?orderId=<orderId>
+```
+
+The app signals completion to Commerce through the UIX Host connection — calling `close()` to indicate success or `onError()` to indicate failure. Commerce then redirects back to the order view page and renders the appropriate banner notification from the registration. No SDK builders are needed for this variant.
+
+#### type: "worker" — runtime action buttons
+
+Apps that declare `type: "worker"` entries expose a runtime action that Commerce POSTs to when the button is clicked. This package provides typed builders for that JSON wire contract.
+
+##### Parsing the incoming request
+
+Commerce POSTs a body of the shape `{ requestId, id, orderId }` to the handler. Use `parseOrderViewButtonRequest` to validate and narrow it:
+
+```typescript
+import { parseOrderViewButtonRequest } from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";
+
+export async function main(params: unknown) {
+  const { requestId, id, orderId } = parseOrderViewButtonRequest(params);
+  // id identifies which button was clicked — useful when one handler serves multiple buttons
+  // orderId is the order currently being viewed
+  // ...
+}
+```
+
+`parseOrderViewButtonRequest` throws a `CommerceSdkValidationError` when the input is malformed.
+
+##### Building a success response
+
+`okOrderViewButtonResponse` returns the empty-object body Commerce expects on success:
+
+```typescript
+import { okOrderViewButtonResponse } from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";
+
+return okOrderViewButtonResponse();
+```
+
+Commerce renders `notifications.success` from the registration as the toast body when present, and a default success toast otherwise.
+
+##### Building an error response
+
+`orderViewButtonErrorResponse` returns an HTTP error response with a `{ error }` body. Commerce uses the HTTP status code to distinguish success from failure.
+
+```typescript
+import { orderViewButtonErrorResponse } from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";
+
+return orderViewButtonErrorResponse(500, "Could not reach inventory service");
 ```
 
 ### Mass Action Worker Contract

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -10,7 +10,7 @@ This package provides utilities for interacting with the Admin UI SDK API and th
 - **[API Client](#api-client)**: Create typed HTTP clients for the Admin UI SDK API
 - **[Grid Column Wire Contract](#grid-column-wire-contract)**: Request and response builders for runtime actions handling `commerce/backend-ui/2` grid column extensions
 - **[Menu Constants](#menu-constants)**: Named constants and type guards for Commerce Admin menu IDs
-- **[Order View Button Wire Contract](#order-view-button-wire-contract)**: Runtime model for `commerce/backend-ui/2` order view buttons — iframe navigation contract for `type: "view"` and request/response builders for `type: "worker"` handlers
+- **[Order View Button Wire Contract](#order-view-button-wire-contract)**: Request and response builders for runtime actions handling `commerce/backend-ui/2` order view button extensions
 
 ## API Reference
 
@@ -105,9 +105,9 @@ return errorGridResponse("INTERNAL_ERROR", "Could not reach inventory service");
 
 ### Order View Button Wire Contract
 
-`adminUi.order.viewButtons` supports two variants with different runtime models. The registration side (declaring buttons and their configuration) is handled through `@adobe/aio-commerce-lib-app`.
+Apps that expose a runtime action handler for `commerce/backend-ui/2` order view buttons receive a POST from Commerce when the button is clicked. This package provides typed builders for that JSON wire contract.
 
-#### type: "view" — iframe buttons
+#### Iframe buttons
 
 Commerce does not call a server-side handler. Instead, it opens an iframe pointing at the app's web entry with the button `path` appended and `orderId` as a query parameter:
 
@@ -117,9 +117,9 @@ https://<extension-host>/index.html<path>?orderId=<orderId>
 
 The app signals completion to Commerce through the UIX Host connection — calling `close()` to indicate success or `onError()` to indicate failure. Commerce then redirects back to the order view page and renders the appropriate banner notification from the registration. No SDK builders are needed for this variant.
 
-#### type: "worker" — runtime action buttons
+#### Runtime action buttons
 
-Apps that declare `type: "worker"` entries expose a runtime action that Commerce POSTs to when the button is clicked. This package provides typed builders for that JSON wire contract.
+When Commerce POSTs to the app's runtime action handler, this package provides typed builders for that JSON wire contract.
 
 ##### Parsing the incoming request
 

--- a/packages/aio-commerce-lib-admin-ui/package.json
+++ b/packages/aio-commerce-lib-admin-ui/package.json
@@ -71,6 +71,16 @@
           "default": "./dist/cjs/menu/index.cjs"
         }
       },
+      "./order-view-buttons": {
+        "import": {
+          "types": "./dist/es/order-view-buttons/index.d.mts",
+          "default": "./dist/es/order-view-buttons/index.mjs"
+        },
+        "require": {
+          "types": "./dist/cjs/order-view-buttons/index.d.cts",
+          "default": "./dist/cjs/order-view-buttons/index.cjs"
+        }
+      },
       "./package.json": "./package.json"
     }
   },
@@ -79,6 +89,7 @@
     "./grid-columns": "./source/grid-columns/index.ts",
     "./mass-actions": "./source/mass-actions/index.ts",
     "./menu": "./source/menu/index.ts",
+    "./order-view-buttons": "./source/order-view-buttons/index.ts",
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/index.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** biome-ignore-all lint/performance/noBarrelFile: This is the public API for the order-view-buttons entrypoint. */
+
+/**
+ * Builders for the `commerce/backend-ui/2` order view button wire contract.
+ *
+ * Provides request parsing and response envelope construction for runtime
+ * actions registered under `adminUi.order.viewButtons[].runtimeAction`.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  okOrderViewButtonResponse,
+  orderViewButtonErrorResponse,
+  parseOrderViewButtonRequest,
+} from "./presets";
+export { OrderViewButtonRequestSchema } from "./schema";
+
+export type {
+  OrderViewButtonErrorBody,
+  OrderViewButtonRequest,
+  OrderViewButtonSuccessBody,
+} from "./types";

--- a/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/presets.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/presets.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
+import { parseOrThrow } from "@aio-commerce-sdk/common-utils/valibot";
+
+import { OrderViewButtonRequestSchema } from "./schema";
+
+import type {
+  ErrorResponse,
+  SuccessResponse,
+} from "@adobe/aio-commerce-lib-core/responses";
+import type {
+  OrderViewButtonRequest,
+  OrderViewButtonSuccessBody,
+} from "./types";
+
+/**
+ * Parses and validates the JSON body Commerce POSTs to an order view button handler.
+ *
+ * Throws a `CommerceSdkValidationError` if the input is malformed.
+ *
+ * @example
+ * ```ts
+ * import { parseOrderViewButtonRequest } from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";
+ *
+ * export async function main(params: unknown) {
+ *   const { requestId, id, orderId } = parseOrderViewButtonRequest(params);
+ *   // id identifies which button was clicked
+ *   // orderId is the order currently being viewed
+ *   // ...
+ * }
+ * ```
+ */
+export function parseOrderViewButtonRequest(
+  input: unknown,
+): OrderViewButtonRequest {
+  return parseOrThrow(
+    OrderViewButtonRequestSchema,
+    input,
+    "Invalid order view button request",
+  );
+}
+
+/**
+ * Builds an HTTP 200 success response for an order view button handler.
+ *
+ * Commerce renders `notifications.success` from the registration as the
+ * toast body when present, and a default success toast otherwise.
+ *
+ * @example
+ * ```ts
+ * return okOrderViewButtonResponse();
+ * ```
+ */
+export function okOrderViewButtonResponse(): SuccessResponse<OrderViewButtonSuccessBody> {
+  return ok<OrderViewButtonSuccessBody>({ body: {} });
+}
+
+/**
+ * Builds an error response for a worker order view button handler with the given HTTP status code.
+ *
+ * Commerce uses the HTTP status code to distinguish success from failure.
+ *
+ * @param statusCode - The HTTP status code to return.
+ * @param errorMessage - Error message included in the response body as `{ error }`.
+ *
+ * @example
+ * ```ts
+ * return orderViewButtonErrorResponse(500, "Could not reach inventory service");
+ * ```
+ */
+export function orderViewButtonErrorResponse(
+  statusCode: number,
+  errorMessage: string,
+): ErrorResponse {
+  // @ts-expect-error — Commerce's wire contract uses `{ error }` only; lib-core requires `message`, which is not part of this format.
+  return buildErrorResponse(statusCode, { body: { error: errorMessage } });
+}

--- a/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/schema.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/schema.ts
@@ -10,15 +10,18 @@
  * governing permissions and limitations under the License.
  */
 
-import { baseConfig } from "@aio-commerce-sdk/config-tsdown/tsdown.config.base";
-import { mergeConfig } from "tsdown";
+import { nonEmptyStringValueSchema } from "@aio-commerce-sdk/common-utils/valibot";
+import * as v from "valibot";
 
-export default mergeConfig(baseConfig, {
-  entry: [
-    "./source/api/index.ts",
-    "./source/grid-columns/index.ts",
-    "./source/mass-actions/index.ts",
-    "./source/menu/index.ts",
-    "./source/order-view-buttons/index.ts",
-  ],
+/**
+ * Schema for the JSON body Commerce POSTs to an order view button handler.
+ *
+ * `id` identifies the specific button that was clicked, letting a single
+ * handler serve multiple buttons by branching on it. `orderId` is the
+ * single order currently being viewed.
+ */
+export const OrderViewButtonRequestSchema = v.object({
+  requestId: nonEmptyStringValueSchema("requestId"),
+  id: nonEmptyStringValueSchema("id"),
+  orderId: nonEmptyStringValueSchema("orderId"),
 });

--- a/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/types.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/types.ts
@@ -10,15 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import { baseConfig } from "@aio-commerce-sdk/config-tsdown/tsdown.config.base";
-import { mergeConfig } from "tsdown";
+import type * as v from "valibot";
+import type { OrderViewButtonRequestSchema } from "./schema";
 
-export default mergeConfig(baseConfig, {
-  entry: [
-    "./source/api/index.ts",
-    "./source/grid-columns/index.ts",
-    "./source/mass-actions/index.ts",
-    "./source/menu/index.ts",
-    "./source/order-view-buttons/index.ts",
-  ],
-});
+/** Parsed request body sent by Commerce to an order view button handler. */
+export type OrderViewButtonRequest = v.InferOutput<
+  typeof OrderViewButtonRequestSchema
+>;
+
+/** Success body returned to Commerce — an empty object signals success. */
+export type OrderViewButtonSuccessBody = Record<string, never>;
+
+/** Failure body returned to Commerce when a worker order view button handler fails. */
+export type OrderViewButtonErrorBody = { error: string };

--- a/packages/aio-commerce-lib-admin-ui/test/unit/order-view-buttons/presets.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/order-view-buttons/presets.test.ts
@@ -17,7 +17,7 @@ import {
   okOrderViewButtonResponse,
   orderViewButtonErrorResponse,
   parseOrderViewButtonRequest,
-} from "#order-view-buttons/presets";
+} from "../../../source/order-view-buttons/presets";
 
 const VALID_REQUEST = {
   requestId: "550e8400-e29b-41d4-a716-446655440000",

--- a/packages/aio-commerce-lib-admin-ui/test/unit/order-view-buttons/presets.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/order-view-buttons/presets.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
+import { describe, expect, it } from "vitest";
+
+import {
+  okOrderViewButtonResponse,
+  orderViewButtonErrorResponse,
+  parseOrderViewButtonRequest,
+} from "#order-view-buttons/presets";
+
+const VALID_REQUEST = {
+  requestId: "550e8400-e29b-41d4-a716-446655440000",
+  id: "sync-inventory",
+  orderId: "000000001",
+};
+
+describe("parseOrderViewButtonRequest", () => {
+  it("returns the parsed request when input is valid", () => {
+    expect(parseOrderViewButtonRequest(VALID_REQUEST)).toEqual(VALID_REQUEST);
+  });
+
+  it("throws when requestId is missing", () => {
+    const { requestId: _, ...input } = VALID_REQUEST;
+    expect(() => parseOrderViewButtonRequest(input)).toThrow(
+      CommerceSdkValidationError,
+    );
+  });
+
+  it("throws when requestId is empty", () => {
+    expect(() =>
+      parseOrderViewButtonRequest({ ...VALID_REQUEST, requestId: "" }),
+    ).toThrow(CommerceSdkValidationError);
+  });
+
+  it("throws when id is missing", () => {
+    const { id: _, ...input } = VALID_REQUEST;
+    expect(() => parseOrderViewButtonRequest(input)).toThrow(
+      CommerceSdkValidationError,
+    );
+  });
+
+  it("throws when id is empty", () => {
+    expect(() =>
+      parseOrderViewButtonRequest({ ...VALID_REQUEST, id: "" }),
+    ).toThrow(CommerceSdkValidationError);
+  });
+
+  it("throws when orderId is missing", () => {
+    const { orderId: _, ...input } = VALID_REQUEST;
+    expect(() => parseOrderViewButtonRequest(input)).toThrow(
+      CommerceSdkValidationError,
+    );
+  });
+
+  it("throws when orderId is empty", () => {
+    expect(() =>
+      parseOrderViewButtonRequest({ ...VALID_REQUEST, orderId: "" }),
+    ).toThrow(CommerceSdkValidationError);
+  });
+
+  it("throws when the input is not an object", () => {
+    expect(() => parseOrderViewButtonRequest("nope")).toThrow(
+      CommerceSdkValidationError,
+    );
+  });
+});
+
+describe("okOrderViewButtonResponse", () => {
+  it("returns a 200 success response with an empty body", () => {
+    expect(okOrderViewButtonResponse()).toEqual({
+      type: "success",
+      statusCode: 200,
+      body: {},
+    });
+  });
+});
+
+describe("orderViewButtonErrorResponse", () => {
+  it("returns an error response with the given status code", () => {
+    const response = orderViewButtonErrorResponse(
+      500,
+      "Could not reach inventory service",
+    );
+    expect(response.type).toBe("error");
+    expect(response.error.statusCode).toBe(500);
+  });
+
+  it("puts the error message in the error field of the body", () => {
+    const response = orderViewButtonErrorResponse(
+      500,
+      "Could not reach inventory service",
+    );
+    expect(response.error.body).toMatchObject({
+      error: "Could not reach inventory service",
+    });
+  });
+
+  it("forwards the status code unchanged", () => {
+    const response = orderViewButtonErrorResponse(400, "Bad input");
+    expect(response.error.statusCode).toBe(400);
+  });
+});

--- a/packages/aio-commerce-sdk/source/admin-ui/order-view-buttons.ts
+++ b/packages/aio-commerce-sdk/source/admin-ui/order-view-buttons.ts
@@ -10,15 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import { baseConfig } from "@aio-commerce-sdk/config-tsdown/tsdown.config.base";
-import { mergeConfig } from "tsdown";
+/** biome-ignore-all lint/performance/noBarrelFile: Public API for the admin-ui/order-view-buttons entrypoint */
 
-export default mergeConfig(baseConfig, {
-  entry: [
-    "./source/api/index.ts",
-    "./source/grid-columns/index.ts",
-    "./source/mass-actions/index.ts",
-    "./source/menu/index.ts",
-    "./source/order-view-buttons/index.ts",
-  ],
-});
+export * from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";


### PR DESCRIPTION
## Description

Adds the `order-view-buttons` entrypoint to `@adobe/aio-commerce-lib-admin-ui` with typed builders for the `commerce/backend-ui/2` order view button wire contract, and re-exports it from `@adobe/aio-commerce-sdk`.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-6316

## Motivation and Context

Apps declaring `adminUi.order.viewButtons` with `type: "worker"` need typed helpers to parse the incoming request and build success/error responses that match what Commerce expects on the wire.

## How Has This Been Tested?

Unit tests cover request parsing (validation errors on missing/empty fields) and response builders (success and error shapes).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.