### PR TITLE
CEXT-6314: reshape Admin UI error responses

### DIFF
--- a/.changeset/admin-ui-error-message-contract.md
+++ b/.changeset/admin-ui-error-message-contract.md
@@ -1,0 +1,6 @@
+---
+"@adobe/aio-commerce-lib-admin-ui": minor
+"@adobe/aio-commerce-sdk": minor
+---
+
+Reshape Admin UI worker error responses to use `message` for better Adobe Commerce compatibility.

--- a/.changeset/admin-ui-error-message-contract.md
+++ b/.changeset/admin-ui-error-message-contract.md
@@ -1,5 +1,0 @@
----
-"@adobe/aio-commerce-lib-admin-ui": minor
----
-
-Reshape Admin UI worker error responses to use `message` for better Adobe Commerce compatibility.

--- a/.changeset/admin-ui-error-message-contract.md
+++ b/.changeset/admin-ui-error-message-contract.md
@@ -1,6 +1,5 @@
 ---
 "@adobe/aio-commerce-lib-admin-ui": minor
-"@adobe/aio-commerce-sdk": minor
 ---
 
 Reshape Admin UI worker error responses to use `message` for better Adobe Commerce compatibility.

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -154,7 +154,7 @@ Commerce renders `notifications.success` from the registration as the toast body
 
 ##### Building an error response
 
-`orderViewButtonErrorResponse` returns an HTTP error response with a `{ error }` body. Commerce uses the HTTP status code to distinguish success from failure.
+`orderViewButtonErrorResponse` returns an HTTP error response with a `{ message }` body. Commerce uses the HTTP status code to distinguish success from failure.
 
 ```typescript
 import { orderViewButtonErrorResponse } from "@adobe/aio-commerce-lib-admin-ui/order-view-buttons";
@@ -199,28 +199,15 @@ return okMassActionResponse({ exported: ids.length });
 
 #### Building an error response
 
-Return one of the typed error builders when the action fails. Commerce treats any
+Return `massActionErrorResponse` when the action fails. Commerce treats any
 non-2xx status as failure and surfaces the `notifications.error` message from the app
-config to the user. The response body is always `{ error: string }`.
-
-| Builder                                 | Status |
-| --------------------------------------- | ------ |
-| `badRequestMassActionResponse`          | 400    |
-| `unauthorizedMassActionResponse`        | 401    |
-| `forbiddenMassActionResponse`           | 403    |
-| `notFoundMassActionResponse`            | 404    |
-| `internalServerErrorMassActionResponse` | 500    |
+config to the user. The response body is always `{ message: string }`.
 
 ```typescript
-import {
-  internalServerErrorMassActionResponse,
-  notFoundMassActionResponse,
-} from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
+import { massActionErrorResponse } from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
 
-return notFoundMassActionResponse("No records matched the given IDs");
-return internalServerErrorMassActionResponse(
-  "Could not reach the export service",
-);
+return massActionErrorResponse(404, "No records matched the given IDs");
+return massActionErrorResponse(500, "Could not reach the export service");
 ```
 
 ### Menu Constants

--- a/packages/aio-commerce-lib-admin-ui/source/mass-actions/index.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/mass-actions/index.ts
@@ -27,14 +27,9 @@
 export { parseMassActionSelection } from "./view/presets";
 export { MassActionSelectionSchema } from "./view/schema";
 export {
-  badRequestMassActionResponse,
-  forbiddenMassActionResponse,
-  internalServerErrorMassActionResponse,
   massActionErrorResponse,
-  notFoundMassActionResponse,
   okMassActionResponse,
   parseMassActionRequest,
-  unauthorizedMassActionResponse,
 } from "./worker/presets";
 export {
   MassActionGridTypeSchema,

--- a/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/presets.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/presets.ts
@@ -19,7 +19,11 @@ import type {
   ErrorResponse,
   SuccessResponse,
 } from "@adobe/aio-commerce-lib-core/responses";
-import type { MassActionRequest, MassActionResponseBody } from "./types";
+import type {
+  MassActionErrorBody,
+  MassActionRequest,
+  MassActionResponseBody,
+} from "./types";
 
 /**
  * Parses and validates the JSON body Commerce POSTs to a worker mass action handler.
@@ -65,11 +69,8 @@ export function okMassActionResponse(
 /**
  * Builds an error response for a worker mass action with the given HTTP status code.
  *
- * Use this when none of the typed helpers (`badRequestMassActionResponse`, etc.) match
- * your use case.
- *
  * @param statusCode - The HTTP status code to return.
- * @param errorMessage - Error message included in the response body as `{ error }`.
+ * @param errorMessage - Error message included in the response body as `{ message }`.
  *
  * @example
  * ```ts
@@ -79,87 +80,6 @@ export function okMassActionResponse(
 export function massActionErrorResponse(
   statusCode: number,
   errorMessage: string,
-): ErrorResponse {
-  // @ts-expect-error — Commerce's wire contract uses `{ error }` only; lib-core requires `message`, which is not part of this format.
-  return buildErrorResponse(statusCode, { body: { error: errorMessage } });
-}
-
-/**
- * Builds an HTTP 400 Bad Request error response for a worker mass action.
- *
- * @param errorMessage - Error message included in the response body as `{ error }`.
- *
- * @example
- * ```ts
- * return badRequestMassActionResponse("Missing required field: orderId");
- * ```
- */
-export function badRequestMassActionResponse(
-  errorMessage: string,
-): ErrorResponse {
-  return massActionErrorResponse(400, errorMessage);
-}
-
-/**
- * Builds an HTTP 401 Unauthorized error response for a worker mass action.
- *
- * @param errorMessage - Error message included in the response body as `{ error }`.
- *
- * @example
- * ```ts
- * return unauthorizedMassActionResponse("Invalid or expired token");
- * ```
- */
-export function unauthorizedMassActionResponse(
-  errorMessage: string,
-): ErrorResponse {
-  return massActionErrorResponse(401, errorMessage);
-}
-
-/**
- * Builds an HTTP 403 Forbidden error response for a worker mass action.
- *
- * @param errorMessage - Error message included in the response body as `{ error }`.
- *
- * @example
- * ```ts
- * return forbiddenMassActionResponse("Insufficient permissions to export orders");
- * ```
- */
-export function forbiddenMassActionResponse(
-  errorMessage: string,
-): ErrorResponse {
-  return massActionErrorResponse(403, errorMessage);
-}
-
-/**
- * Builds an HTTP 404 Not Found error response for a worker mass action.
- *
- * @param errorMessage - Error message included in the response body as `{ error }`.
- *
- * @example
- * ```ts
- * return notFoundMassActionResponse("No matching records found for the given IDs");
- * ```
- */
-export function notFoundMassActionResponse(
-  errorMessage: string,
-): ErrorResponse {
-  return massActionErrorResponse(404, errorMessage);
-}
-
-/**
- * Builds an HTTP 500 Internal Server Error response for a worker mass action.
- *
- * @param errorMessage - Error message included in the response body as `{ error }`.
- *
- * @example
- * ```ts
- * return internalServerErrorMassActionResponse("Could not reach the export service");
- * ```
- */
-export function internalServerErrorMassActionResponse(
-  errorMessage: string,
-): ErrorResponse {
-  return massActionErrorResponse(500, errorMessage);
+): ErrorResponse<MassActionErrorBody> {
+  return buildErrorResponse(statusCode, { body: { message: errorMessage } });
 }

--- a/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/types.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/types.ts
@@ -26,4 +26,4 @@ export type MassActionRequest = v.InferOutput<typeof MassActionRequestSchema>;
 export type MassActionResponseBody = Record<string, unknown>;
 
 /** Error body returned to Commerce when a worker mass action fails. */
-export type MassActionErrorBody = { error: string };
+export type MassActionErrorBody = { message: string };

--- a/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/presets.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/presets.ts
@@ -20,6 +20,7 @@ import type {
   SuccessResponse,
 } from "@adobe/aio-commerce-lib-core/responses";
 import type {
+  OrderViewButtonErrorBody,
   OrderViewButtonRequest,
   OrderViewButtonSuccessBody,
 } from "./types";
@@ -72,7 +73,7 @@ export function okOrderViewButtonResponse(): SuccessResponse<OrderViewButtonSucc
  * Commerce uses the HTTP status code to distinguish success from failure.
  *
  * @param statusCode - The HTTP status code to return.
- * @param errorMessage - Error message included in the response body as `{ error }`.
+ * @param errorMessage - Error message included in the response body as `{ message }`.
  *
  * @example
  * ```ts
@@ -82,7 +83,6 @@ export function okOrderViewButtonResponse(): SuccessResponse<OrderViewButtonSucc
 export function orderViewButtonErrorResponse(
   statusCode: number,
   errorMessage: string,
-): ErrorResponse {
-  // @ts-expect-error — Commerce's wire contract uses `{ error }` only; lib-core requires `message`, which is not part of this format.
-  return buildErrorResponse(statusCode, { body: { error: errorMessage } });
+): ErrorResponse<OrderViewButtonErrorBody> {
+  return buildErrorResponse(statusCode, { body: { message: errorMessage } });
 }

--- a/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/types.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/order-view-buttons/types.ts
@@ -22,4 +22,4 @@ export type OrderViewButtonRequest = v.InferOutput<
 export type OrderViewButtonSuccessBody = Record<string, never>;
 
 /** Failure body returned to Commerce when a worker order view button handler fails. */
-export type OrderViewButtonErrorBody = { error: string };
+export type OrderViewButtonErrorBody = { message: string };

--- a/packages/aio-commerce-lib-admin-ui/test/unit/mass-actions/worker.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/mass-actions/worker.test.ts
@@ -14,13 +14,9 @@ import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import { describe, expect, it } from "vitest";
 
 import {
-  badRequestMassActionResponse,
-  forbiddenMassActionResponse,
-  internalServerErrorMassActionResponse,
-  notFoundMassActionResponse,
+  massActionErrorResponse,
   okMassActionResponse,
   parseMassActionRequest,
-  unauthorizedMassActionResponse,
 } from "#mass-actions/worker/presets";
 
 import type { MassActionGridType } from "#mass-actions/worker/types";
@@ -96,23 +92,17 @@ describe("okMassActionResponse", () => {
   });
 });
 
-describe.each([
-  { fn: badRequestMassActionResponse, statusCode: 400 },
-  { fn: unauthorizedMassActionResponse, statusCode: 401 },
-  { fn: forbiddenMassActionResponse, statusCode: 403 },
-  { fn: notFoundMassActionResponse, statusCode: 404 },
-  { fn: internalServerErrorMassActionResponse, statusCode: 500 },
-])("$fn.name", ({ fn, statusCode }) => {
-  it(`returns an error response with status ${statusCode}`, () => {
-    const response = fn("something went wrong");
+describe("massActionErrorResponse", () => {
+  it("returns an error response with the given status code", () => {
+    const response = massActionErrorResponse(422, "something went wrong");
     expect(response.type).toBe("error");
-    expect(response.error.statusCode).toBe(statusCode);
+    expect(response.error.statusCode).toBe(422);
   });
 
-  it("puts the errorMessage in the error field of the body", () => {
-    const response = fn("could not reach service");
+  it("puts the errorMessage in the message field of the body", () => {
+    const response = massActionErrorResponse(500, "could not reach service");
     expect(response.error.body).toMatchObject({
-      error: "could not reach service",
+      message: "could not reach service",
     });
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/order-view-buttons/presets.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/order-view-buttons/presets.test.ts
@@ -96,13 +96,13 @@ describe("orderViewButtonErrorResponse", () => {
     expect(response.error.statusCode).toBe(500);
   });
 
-  it("puts the error message in the error field of the body", () => {
+  it("puts the error message in the message field of the body", () => {
     const response = orderViewButtonErrorResponse(
       500,
       "Could not reach inventory service",
     );
     expect(response.error.body).toMatchObject({
-      error: "Could not reach inventory service",
+      message: "Could not reach inventory service",
     });
   });
 


### PR DESCRIPTION
## Description

- Reshape Admin UI worker error responses to use `message` instead of `error` in mass action and order view button response bodies.
- Type the builders as `ErrorResponse<MassActionErrorBody>` and `ErrorResponse<OrderViewButtonErrorBody>` without suppression comments.
- Remove status-specific mass action error response helpers and keep `massActionErrorResponse` as the single mass action error builder.
- Update usage docs and unit tests for Adobe Commerce compatibility.

## Related Issue

CEXT-6314

## Motivation and Context

Adobe Commerce compatibility expects worker error response bodies to expose a standard message field. This aligns the Admin UI worker contracts with the SDK's standard `ErrorResponse<T>` body constraint and removes the previous type mismatch.

## How Has This Been Tested?

- `pnpm --filter @adobe/aio-commerce-lib-admin-ui test`
- `pnpm --filter @adobe/aio-commerce-lib-admin-ui typecheck`
- `pnpm --filter @adobe/aio-commerce-lib-admin-ui check:ci`
- `pnpm test`

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.