### PR TITLE
CEXT-6314: use float for Admin UI grid column type

### DIFF
--- a/packages/aio-commerce-lib-app/docs/openapi.json
+++ b/packages/aio-commerce-lib-app/docs/openapi.json
@@ -3376,7 +3376,7 @@
                     "boolean",
                     "date",
                     "datetime",
-                    "decimal",
+                    "float",
                     "integer",
                     "string"
                   ]

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -539,7 +539,7 @@ export default defineConfig({
 - **columns**: Required array (at least one entry); each column requires:
   - **id**: non-empty string — stable column identifier, also used as the response data key
   - **label**: non-empty string — column header displayed in the grid
-  - **type**: one of `"boolean"`, `"date"`, `"datetime"`, `"decimal"`, `"integer"`, `"string"`
+  - **type**: one of `"boolean"`, `"date"`, `"datetime"`, `"float"`, `"integer"`, `"string"`
   - **align**: one of `"left"`, `"center"`, `"right"`
 
 Each of `order`, `product`, and `customer` is optional — configure only the grids your application extends.

--- a/packages/aio-commerce-lib-app/source/config/schema/admin-ui.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/admin-ui.ts
@@ -60,7 +60,7 @@ const ColumnTypeSchema = v.picklist([
   "boolean",
   "date",
   "datetime",
-  "decimal",
+  "float",
   "integer",
   "string",
 ]);

--- a/packages/aio-commerce-lib-app/test/unit/config/schema/admin-ui.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/schema/admin-ui.test.ts
@@ -54,7 +54,7 @@ describe("AdminUiSchema", () => {
         "boolean",
         "date",
         "datetime",
-        "decimal",
+        "float",
         "integer",
         "string",
       ] as const) {
@@ -381,7 +381,7 @@ describe("AdminUiSchema", () => {
   });
 
   describe("invalid cases", () => {
-    test("float type is rejected", () => {
+    test("decimal type is rejected", () => {
       const result = v.safeParse(AdminUiSchema, {
         order: {
           gridColumns: {
@@ -389,7 +389,7 @@ describe("AdminUiSchema", () => {
             description: "Adds a column",
             runtimeAction: "orders/fetch",
             columns: [
-              { id: "col", label: "Col", type: "float", align: "left" },
+              { id: "col", label: "Col", type: "decimal", align: "left" },
             ],
           },
         },

--- a/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
+++ b/specs/features/CEXT-6096-admin-ui-grid-column-extensions.md
@@ -188,14 +188,14 @@ handling across multiple installed apps is Commerce's responsibility.
 
 ### Column types
 
-| `type` value | Description                          |
-| ------------ | ------------------------------------ |
-| `boolean`    | Boolean value                        |
-| `date`       | Date (no time component)             |
-| `datetime`   | Date and time                        |
-| `decimal`    | Decimal number (replaces v1 `float`) |
-| `integer`    | Integer                              |
-| `string`     | Text                                 |
+| `type` value | Description              |
+| ------------ | ------------------------ |
+| `boolean`    | Boolean value            |
+| `date`       | Date (no time component) |
+| `datetime`   | Date and time            |
+| `float`      | Floating-point number    |
+| `integer`    | Integer                  |
+| `string`     | Text                     |
 
 ### Migration from v1
 
@@ -205,7 +205,7 @@ handling across multiple installed apps is Commerce's responsibility.
 | `data.meshId`                            | `runtimeAction`              | Operation name declared in `app.config.yaml`, not a Mesh hash |
 | `properties`                             | `columns`                    | Array of column declarations                                  |
 | `properties[].columnId`                  | `columns[].id`               | Renamed                                                       |
-| `properties[].type: "float"`             | `columns[].type: "decimal"`  | Renamed                                                       |
+| `properties[].type: "float"`             | `columns[].type: "float"`    | Same type name                                                |
 | _(absent)_                               | `columns[].type: "datetime"` | New type in v2                                                |
 | _(absent)_                               | `label`, `description`       | New block-level metadata for App Management installation UI   |
 | Extension point: `commerce/backend-ui/1` | `commerce/backend-ui/2`      | Required change in `app.config.yaml` and `install.yaml`       |
@@ -244,7 +244,7 @@ const GridColumnSchema = v.object({
     "boolean",
     "date",
     "datetime",
-    "decimal",
+    "float",
     "integer",
     "string",
   ]),


### PR DESCRIPTION
## Description

- Replace the Admin UI grid column numeric type from `decimal` to the v1-compatible `float` value.
- Update the app config schema, committed OpenAPI contract, usage docs, and CEXT-6096 feature spec.
- Update schema tests so `float` is valid and `decimal` is rejected.

## Related Issue

CEXT-6314

## Motivation and Context

Commerce expects the grid column type to use the v1-compatible `float` value. This keeps the v2 `adminUi.*.gridColumns.columns[].type` contract aligned with the existing Admin UI SDK type name.

## How Has This Been Tested?

- `pnpm --filter @adobe/aio-commerce-lib-app test`
- `pnpm --filter @adobe/aio-commerce-lib-app typecheck`
- `pnpm --filter @adobe/aio-commerce-lib-app check:ci`

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.