### PR TITLE
CEXT-6096: align grid column error responses with mass actions and order view buttons

### DIFF
--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -95,12 +95,12 @@ The column keys inside each row must match the `id` values declared in the corre
 
 #### Building an error response
 
-`errorGridResponse` produces the `{ errorStatus, errorMessage }` envelope Commerce recognises as a handler-level failure. The response is returned with HTTP status 200 so the handler can convey a specific error code Commerce can log:
+`errorGridResponse` returns a non-2xx HTTP response. Commerce uses the status code to distinguish success from failure:
 
 ```typescript
 import { errorGridResponse } from "@adobe/aio-commerce-lib-admin-ui/grid-columns";
 
-return errorGridResponse("INTERNAL_ERROR", "Could not reach inventory service");
+return errorGridResponse(500, "Could not reach inventory service");
 ```
 
 ### Order View Button Wire Contract

--- a/packages/aio-commerce-lib-admin-ui/source/grid-columns/responses/presets.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/grid-columns/responses/presets.ts
@@ -10,9 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import { ok } from "@adobe/aio-commerce-lib-core/responses";
+import { buildErrorResponse, ok } from "@adobe/aio-commerce-lib-core/responses";
 
-import type { SuccessResponse } from "@adobe/aio-commerce-lib-core/responses";
+import type {
+  ErrorResponse,
+  SuccessResponse,
+} from "@adobe/aio-commerce-lib-core/responses";
 import type { GridErrorBody, GridRow, GridSuccessBody } from "./types";
 
 /**
@@ -45,25 +48,21 @@ export function okGridResponse(
 }
 
 /**
- * Builds an HTTP 200 response carrying a handler-level failure envelope.
+ * Builds an error response for a grid column handler with the given HTTP status code.
  *
- * Commerce treats any decoded body containing `errorStatus` as a failure
- * regardless of HTTP status, so returning 200 lets the handler convey a
- * specific error code and message that Commerce can log.
+ * Commerce uses the HTTP status code to distinguish success from failure.
+ *
+ * @param statusCode - The HTTP status code to return.
+ * @param errorMessage - Error message included in the response body as `{ message }`.
  *
  * @example
  * ```ts
- * return errorGridResponse("INTERNAL_ERROR", "Could not reach inventory service");
+ * return errorGridResponse(500, "Could not reach inventory service");
  * ```
  */
 export function errorGridResponse(
-  errorStatus: string,
-  errorMessage?: string,
-): SuccessResponse<GridErrorBody> {
-  const body: GridErrorBody =
-    errorMessage === undefined
-      ? { errorStatus }
-      : { errorStatus, errorMessage };
-
-  return ok<GridErrorBody>({ body });
+  statusCode: number,
+  errorMessage: string,
+): ErrorResponse<GridErrorBody> {
+  return buildErrorResponse(statusCode, { body: { message: errorMessage } });
 }

--- a/packages/aio-commerce-lib-admin-ui/source/grid-columns/responses/types.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/grid-columns/responses/types.ts
@@ -25,7 +25,4 @@ export type GridSuccessBody = {
 };
 
 /** Failure body returned to Commerce. */
-export type GridErrorBody = {
-  errorStatus: string;
-  errorMessage?: string;
-};
+export type GridErrorBody = { message: string };

--- a/packages/aio-commerce-lib-admin-ui/test/unit/grid-columns/responses.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/grid-columns/responses.test.ts
@@ -62,28 +62,19 @@ describe("okGridResponse", () => {
 });
 
 describe("errorGridResponse", () => {
-  it("produces a 200 response carrying errorStatus only when no message is given", () => {
-    const result = errorGridResponse("INTERNAL_ERROR");
+  it("returns the given HTTP status code", () => {
+    const result = errorGridResponse(500, "Could not reach inventory service");
     expect(result).toEqual({
-      type: "success",
-      statusCode: 200,
-      body: { errorStatus: "INTERNAL_ERROR" },
+      type: "error",
+      error: {
+        statusCode: 500,
+        body: { message: "Could not reach inventory service" },
+      },
     });
   });
 
-  it("includes errorMessage when provided", () => {
-    const result = errorGridResponse(
-      "INTERNAL_ERROR",
-      "Could not reach inventory service",
-    );
-    expect(result.body).toEqual({
-      errorStatus: "INTERNAL_ERROR",
-      errorMessage: "Could not reach inventory service",
-    });
-  });
-
-  it("preserves an explicit empty errorMessage", () => {
-    const result = errorGridResponse("X", "");
-    expect(result.body).toEqual({ errorStatus: "X", errorMessage: "" });
+  it("wraps the error message in a message field", () => {
+    const result = errorGridResponse(422, "Unprocessable entity");
+    expect(result.error?.body).toEqual({ message: "Unprocessable entity" });
   });
 });


### PR DESCRIPTION
## Description

`errorGridResponse` previously returned HTTP 200 with an `{ errorStatus, errorMessage }` body — a pattern leftover before the error response reshaping done in CEXT-6314. This aligns it with `massActionErrorResponse` and `orderViewButtonErrorResponse`: it now accepts an HTTP status code and returns a proper non-2xx `ErrorResponse` with `{ message }` in the body.

## Related Issue

CEXT-6096

## Motivation and Context

Consistency across all Admin UI wire contracts. Grid columns were the last handler type still using the old error-signalling pattern.

## How Has This Been Tested?

Unit tests updated and passing (`pnpm --filter @adobe/aio-commerce-lib-admin-ui test`). Full typecheck clean (`pnpm typecheck`).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.