### PR TITLE
Cext 6160 commerce system config on association

### DIFF
--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -8,7 +8,6 @@ The `@adobe/aio-commerce-lib-app` library provides:
 - **Business Configuration**: Generate and manage the runtime actions that power the `commerce/configuration/1` extension point.
 - **Installation Management**: Generate and manage the runtime action that powers the app installation flow.
 - **Admin UI Configuration** (`commerce/backend-ui/2`): Generate and manage the runtime action and `workerProcess` declarations for Admin UI extensions on `commerce/backend-ui/2`. Currently supports grid column extensions, mass actions, order view buttons, and menu declarations.
-- **Admin UI SDK Configuration** (`commerce/backend-ui/1`, _deprecated_): Generate and manage the runtime action for the legacy Admin UI SDK extension point. Will be removed from the SDK — use `adminUi` and `commerce/backend-ui/2` for new apps.
 - **Association Helpers**: Retrieve the Commerce instance the app is associated with from any runtime action via `getCommerceClient` and `getCommerceInstance`.
 
 ## Reference


### PR DESCRIPTION
## Description

Removes the accidentally added `Admin UI SDK Configuration` (`commerce/backend-ui/1`) entry from `usage.md`. Support for the v1 extension point was dropped and should not have been re-documented here.

## Motivation and Context

The v1 Admin UI SDK entry was inadvertently added in PR #511 alongside the Association Helpers documentation. It was flagged in review, this removes it.

## How Has This Been Tested?

Doc-only change — no code or tests affected.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

