### PR TITLE
revert: CEXT-6338 — remove extensionUrl from registration and adminUiViewUrl from install schema

### DIFF
--- a/.changeset/all-candles-build.md
+++ b/.changeset/all-candles-build.md
@@ -1,5 +1,0 @@
----
-"@adobe/aio-commerce-lib-app": minor
----
-
-Use the provided Admin UI view URL when registering an extension.

--- a/.changeset/light-beans-turn.md
+++ b/.changeset/light-beans-turn.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-admin-ui": minor
+---
+
+Remove `extensionUrl` from extension registration params. The Commerce backend now derives the view URL from the App Registry, so the field has no effect for v2 installed apps.

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -40,7 +40,6 @@ const client = createAdminUiApiClient({
 await client.registerExtension({
   extensionName: "my_namespace",
   extensionTitle: "My App",
-  extensionUrl: "https://my_namespace.adobeio-static.net/index.html",
   extensionWorkspace: "prod-workspace",
 });
 

--- a/packages/aio-commerce-lib-admin-ui/source/api/extensions/schema.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/api/extensions/schema.ts
@@ -16,7 +16,6 @@ import * as v from "valibot";
 export const ExtensionRegistrationParamsSchema = v.object({
   extensionName: v.pipe(v.string(), v.minLength(1)),
   extensionTitle: v.pipe(v.string(), v.minLength(1)),
-  extensionUrl: v.pipe(v.string(), v.url()),
   extensionWorkspace: v.pipe(v.string(), v.minLength(1)),
 });
 

--- a/packages/aio-commerce-lib-admin-ui/test/unit/api/extensions/endpoints.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/api/extensions/endpoints.test.ts
@@ -24,7 +24,6 @@ const UNREGISTER_URL = `${BASE_URL}/rest/all/V1/adminuisdk/extension/prod-worksp
 const PARAMS = {
   extensionName: "my-namespace",
   extensionTitle: "My App",
-  extensionUrl: "https://my-namespace.adobeio-static.net/index.html",
   extensionWorkspace: "prod-workspace",
 };
 
@@ -95,19 +94,6 @@ describe("unregisterExtension", () => {
 });
 
 describe("registerExtension — validation", () => {
-  it("throws when extensionUrl is not a valid URL", async () => {
-    const fetchMock = vi.fn();
-
-    await expect(
-      registerExtension(makeHttpClient(fetchMock as typeof fetch), {
-        ...PARAMS,
-        extensionUrl: "not-a-url",
-      }),
-    ).rejects.toThrow();
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
   it("throws when extensionName is empty", async () => {
     const fetchMock = vi.fn();
 

--- a/packages/aio-commerce-lib-app/docs/openapi.json
+++ b/packages/aio-commerce-lib-app/docs/openapi.json
@@ -2767,11 +2767,6 @@
           "workspaceTitle": {
             "type": "string",
             "minLength": 1
-          },
-          "adminUiViewUrl": {
-            "type": "string",
-            "format": "uri",
-            "minLength": 1
           }
         },
         "required": [

--- a/packages/aio-commerce-lib-app/source/management/installation/admin-ui/helpers.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/admin-ui/helpers.ts
@@ -31,13 +31,9 @@ export async function registerExtension(context: AdminUiExecutionContext) {
 
   logger.info(`Registering Admin UI extension: ${appData.projectName}`);
 
-  const extensionUrl =
-    appData.adminUiViewUrl ??
-    `https://${extensionName}.adobeio-static.net/index.html`;
   const { extensionId } = await adminUiClient
     .registerExtension({
       extensionName,
-      extensionUrl,
       extensionTitle: appData.projectTitle,
       extensionWorkspace: appData.workspaceName,
     })

--- a/packages/aio-commerce-lib-app/source/management/installation/schema.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/schema.ts
@@ -23,12 +23,6 @@ export const AppDataSchema = v.object({
   workspaceId: nonEmptyStringValueSchema("workspaceId"),
   workspaceName: nonEmptyStringValueSchema("workspaceName"),
   workspaceTitle: nonEmptyStringValueSchema("workspaceTitle"),
-  adminUiViewUrl: v.optional(
-    v.pipe(
-      nonEmptyStringValueSchema("adminUiViewUrl"),
-      v.url("Expected a valid URL for adminUiViewUrl"),
-    ),
-  ),
 });
 
 /** Type for Adobe I/O app credentials. */

--- a/packages/aio-commerce-lib-app/test/unit/actions/installation.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/actions/installation.test.ts
@@ -284,28 +284,6 @@ describe("installationRuntimeAction", () => {
       });
     });
 
-    test("returns 400 when adminUiViewUrl is not a valid URL", async () => {
-      const handler = installationRuntimeAction({
-        appConfig: minimalValidConfig,
-      });
-
-      const result = await handler(
-        createRuntimeActionParams({
-          method: "post",
-          body: {
-            ...requestBody,
-            appData: { ...appData, adminUiViewUrl: "not-a-url" },
-          },
-          ...DEFAULT_INSTALLATION_PARAMS,
-        }),
-      );
-
-      expect(result).toMatchObject({
-        type: "error",
-        error: { statusCode: 400 },
-      });
-    });
-
     test("returns 500 when installation starts without an app config", async () => {
       const handler = installationRuntimeAction({
         // @ts-expect-error - intentionally missing app config
@@ -369,39 +347,6 @@ describe("installationRuntimeAction", () => {
           name: "app-management/installation",
           blocking: false,
           result: false,
-        }),
-      );
-    });
-
-    test("passes adminUiViewUrl to the installation execution", async () => {
-      const initialState = createMockInProgressState({ id: "installation-1" });
-      createInitialInstallationStateMock.mockReturnValue(initialState);
-
-      const handler = installationRuntimeAction({
-        appConfig: minimalValidConfig,
-      });
-
-      await handler(
-        createRuntimeActionParams({
-          method: "post",
-          body: {
-            ...requestBody,
-            appData: {
-              ...appData,
-              adminUiViewUrl: "https://example.com/admin-ui/index.html",
-            },
-          },
-          ...DEFAULT_INSTALLATION_PARAMS,
-        }),
-      );
-
-      expect(invokeMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          params: expect.objectContaining({
-            appData: expect.objectContaining({
-              adminUiViewUrl: "https://example.com/admin-ui/index.html",
-            }),
-          }),
         }),
       );
     });

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/branch.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/branch.test.ts
@@ -81,18 +81,13 @@ describe("admin-ui installation module", () => {
       expect(registerExtensionStep.meta.uninstall).toBeDefined();
     });
 
-    test("should call registerExtension with the provided adminUiViewUrl", async () => {
-      const context = createMockAdminUiContext({
-        appData: {
-          adminUiViewUrl: "https://example.com/admin-ui/index.html",
-        },
-      });
+    test("should call registerExtension with extensionName, title, and workspace", async () => {
+      const context = createMockAdminUiContext();
 
       await registerExtensionStep.install(configWithFullAdminUiV2, context);
       expect(context.adminUiClient.registerExtension).toHaveBeenCalledWith({
         extensionName: "test-namespace",
         extensionTitle: context.appData.projectTitle,
-        extensionUrl: "https://example.com/admin-ui/index.html",
         extensionWorkspace: context.appData.workspaceName,
       });
     });

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/helpers.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/admin-ui/helpers.test.ts
@@ -36,9 +36,6 @@ describe("registerExtension", () => {
     const logger = createMockLogger();
     const context = createMockAdminUiContext({
       registerExtensionImpl: () => Promise.resolve({ extensionId: "ext-123" }),
-      appData: {
-        adminUiViewUrl: "https://example.com/admin-ui/index.html",
-      },
       logger,
     });
 
@@ -47,7 +44,6 @@ describe("registerExtension", () => {
     expect(context.adminUiClient.registerExtension).toHaveBeenCalledWith({
       extensionName: "test-ns",
       extensionTitle: context.appData.projectTitle,
-      extensionUrl: "https://example.com/admin-ui/index.html",
       extensionWorkspace: context.appData.workspaceName,
     });
     expect(logger.info).toHaveBeenCalledWith(
@@ -63,9 +59,6 @@ describe("registerExtension", () => {
     );
     const context = createMockAdminUiContext({
       registerExtensionImpl: () => Promise.reject(httpError),
-      appData: {
-        adminUiViewUrl: "https://example.com/admin-ui/index.html",
-      },
     });
 
     await expect(registerExtension(context)).rejects.toThrow(
@@ -82,9 +75,6 @@ describe("registerExtension", () => {
     );
     const context = createMockAdminUiContext({
       registerExtensionImpl: () => Promise.reject(httpError),
-      appData: {
-        adminUiViewUrl: "https://example.com/admin-ui/index.html",
-      },
       logger,
     });
 
@@ -94,18 +84,6 @@ describe("registerExtension", () => {
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringMatching(REGISTER_EXTENSION_COMBINED_PATTERN),
     );
-  });
-
-  test("falls back to the static extension url when no adminUiViewUrl is provided", async () => {
-    const context = createMockAdminUiContext();
-
-    await expect(registerExtension(context)).resolves.toBeUndefined();
-    expect(context.adminUiClient.registerExtension).toHaveBeenCalledWith({
-      extensionName: "test-ns",
-      extensionTitle: context.appData.projectTitle,
-      extensionUrl: "https://test-ns.adobeio-static.net/index.html",
-      extensionWorkspace: context.appData.workspaceName,
-    });
   });
 });
 


### PR DESCRIPTION
## Description

Reverts #541 and removes the companion `extensionUrl` field from the Admin UI client registration params.

Backend PR [adobe-commerce-backend-uix#361](https://github.com/magento-commerce/adobe-commerce-backend-uix/pull/361) makes `extension_url` optional for v2 installed apps and derives the correct URL from the App Registry automatically. Caller-supplied values are silently ignored, so the SDK no longer needs to accept or forward `adminUiViewUrl`.

The `lib-admin-ui` change drops the now-redundant `extensionUrl` field from `registerExtension` params — the backend ignores it for v2 apps regardless.

## Related Issue

N/A (cleanup driven by backend-uix#361)

## How Has This Been Tested?

- `pnpm --filter @adobe/aio-commerce-lib-app typecheck` ✅
- `pnpm --filter @adobe/aio-commerce-lib-app test` — 915 tests passing ✅
- `pnpm --filter @adobe/aio-commerce-lib-admin-ui test` — 112 tests passing ✅

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)