### PR TITLE
CEXT-6338: add scripting dependency helpers

### DIFF
--- a/packages-private/scripting-utils/package.json
+++ b/packages-private/scripting-utils/package.json
@@ -38,8 +38,12 @@
     "@adobe/aio-commerce-lib-core": "workspace:*",
     "@adobe/aio-lib-core-config": "^5.0.1",
     "@adobe/aio-lib-ims": "catalog:",
+    "@npmcli/package-json": "^8.0.0",
+    "@types/semver": "^7.7.1",
     "dotenv": "^17.2.3",
+    "local-pkg": "^1.2.1",
     "package-manager-detector": "^1.6.0",
+    "semver": "^7.8.5",
     "type-fest": "catalog:",
     "yaml": "catalog:"
   },
@@ -48,6 +52,7 @@
     "@aio-commerce-sdk/config-typedoc": "workspace:*",
     "@aio-commerce-sdk/config-typescript": "workspace:*",
     "@aio-commerce-sdk/config-vitest": "workspace:*",
+    "@types/npmcli__package-json": "^4.0.4",
     "typescript": "catalog:"
   },
   "sideEffects": false

--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -19,10 +19,29 @@ import { existsSync } from "node:fs";
 import { access, mkdir, readFile } from "node:fs/promises";
 import { dirname, join, parse } from "node:path";
 
+import NpmPackageJson from "@npmcli/package-json";
+import { getPackageInfo } from "local-pkg";
 import { resolveCommand } from "package-manager-detector";
 import { detect, getUserAgent } from "package-manager-detector/detect";
+import { satisfies as satisfiesSemverRange } from "semver";
 
 import type { PackageJson } from "type-fest";
+
+export type PackageDependency = {
+  /** Package name as it appears in package.json. */
+  name: string;
+
+  /** Version specifier to write or install, compared by exact string equality. */
+  version: string;
+};
+
+export type PackageInstallOptions = {
+  /** Install packages as development dependencies. */
+  dev?: boolean;
+};
+
+type PackageJsonDependencies = NonNullable<PackageJson["dependencies"]>;
+type WritablePackageJsonDependencies = Record<string, string>;
 
 /**
  * Find a file by walking up parent directories
@@ -93,6 +112,120 @@ export async function readPackageJson(
 }
 
 /**
+ * Load the nearest package.json file with npmcli's package.json helper.
+ * @param cwd The current working directory
+ */
+export async function loadPackageJson(cwd = process.cwd()) {
+  const packageJsonPath = await findNearestPackageJson(cwd);
+  if (!packageJsonPath) {
+    return null;
+  }
+
+  return NpmPackageJson.load(dirname(packageJsonPath));
+}
+
+/**
+ * Convert package.json dependencies into a dependency map that can be written back.
+ * @param dependencies - Dependency map read from package.json.
+ */
+function toWritablePackageJsonDependencies(
+  dependencies: PackageJsonDependencies,
+): WritablePackageJsonDependencies {
+  return Object.fromEntries(
+    Object.entries(dependencies).filter((entry): entry is [string, string] =>
+      Boolean(entry[1]),
+    ),
+  );
+}
+
+/**
+ * Resolve the installed package version from a project root.
+ * @param packageName - Package name to resolve.
+ * @param cwd - Project directory to resolve from.
+ */
+export async function getInstalledPackageVersion(
+  packageName: string,
+  cwd = process.cwd(),
+) {
+  const packageInfo = await getPackageInfo(packageName, { paths: [cwd] });
+  return packageInfo?.version ?? null;
+}
+
+type PackageDependencyInstallPlan = {
+  missing: PackageDependency[];
+  incompatible: Array<
+    PackageDependency & {
+      installedVersion: string;
+    }
+  >;
+};
+
+/**
+ * Resolve which dependencies are missing or installed with incompatible versions.
+ *
+ * Installed package versions are compared with `semver.satisfies`. Declared
+ * package.json ranges are not used as compatibility proof because they can
+ * differ from what is actually installed.
+ *
+ * @param requiredDependencies - Dependencies that should exist.
+ * @param cwd - Project directory to resolve installed packages from.
+ */
+export async function getPackageDependencyInstallPlan(
+  requiredDependencies: readonly PackageDependency[],
+  cwd = process.cwd(),
+): Promise<PackageDependencyInstallPlan> {
+  const plan: PackageDependencyInstallPlan = {
+    incompatible: [],
+    missing: [],
+  };
+
+  for (const dependency of requiredDependencies) {
+    const installedVersion = await getInstalledPackageVersion(
+      dependency.name,
+      cwd,
+    );
+
+    if (installedVersion === null) {
+      plan.missing.push(dependency);
+      continue;
+    }
+
+    if (
+      !satisfiesSemverRange(installedVersion, dependency.version, {
+        includePrerelease: true,
+      })
+    ) {
+      plan.incompatible.push({ ...dependency, installedVersion });
+    }
+  }
+
+  return plan;
+}
+
+/**
+ * Merge required dependencies into a package.json dependency map when they are missing.
+ *
+ * @param dependencies - Dependency map to update.
+ * @param requiredDependencies - Dependencies that should exist.
+ * @param dependencyMaps - Package dependency maps to compare against.
+ */
+export function mergePackageJsonDependencies(
+  dependencies: PackageJsonDependencies,
+  requiredDependencies: readonly PackageDependency[],
+  dependencyMaps: readonly PackageJsonDependencies[] = [dependencies],
+) {
+  const nextDependencies = toWritablePackageJsonDependencies(dependencies);
+
+  for (const { name, version } of requiredDependencies) {
+    if (!dependencyMaps.some((dependencies) => name in dependencies)) {
+      nextDependencies[name] = version;
+    }
+  }
+
+  return nextDependencies;
+}
+
+/**
  * Check if the current working directory is an ESM project.
  * @param cwd The current working directory
  */
@@ -137,8 +270,13 @@ export async function makeOutputDirFor(fileOrFolder: string) {
   return outputDir;
 }
 
-// App Builder targets Node.js — unsupported detections (e.g. deno) fall back to npm.
 const VALID_PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
+const DEV_DEPENDENCY_INSTALL_FLAGS = {
+  bun: "--dev",
+  npm: "--save-dev",
+  pnpm: "--save-dev",
+  yarn: "--dev",
+} as const satisfies Record<PackageManager, string>;
 
 /** The package manager used to install the package */
 export type PackageManager = (typeof VALID_PACKAGE_MANAGERS)[number];
@@ -198,19 +336,20 @@ export function getExecCommand(packageManager: PackageManager): string {
  * manager (e.g. `pnpm add foo bar`, `npm i foo bar`).
  * @param packageManager - The detected package manager
  * @param packages - Package specifiers to install (e.g. `["foo@^1.0"]`)
+ * @param options - Install command options.
  */
 export function getInstallCommand(
   packageManager: PackageManager,
   packages: string[],
+  options: PackageInstallOptions = {},
 ): { command: string; args: string[] } {
-  const resolved = resolveCommand(packageManager, "add", packages);
-  if (!resolved) {
-    return { command: "npm", args: ["install", ...packages] };
-  }
+  const installArgs = options.dev
+    ? [DEV_DEPENDENCY_INSTALL_FLAGS[packageManager], ...packages]
+    : packages;
 
+  const resolved = resolveCommand(packageManager, "add", installArgs);
   return {
-    // Filter out any empty args via truthyness check.
-    args: resolved.args.filter((a) => Boolean(a)),
-    command: resolved.command,
+    args: resolved?.args.filter(Boolean) ?? ["install", ...installArgs],
+    command: resolved?.command ?? "npm",
   };
 }

--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -353,3 +353,18 @@ export function getInstallCommand(
     command: resolved?.command ?? "npm",
   };
 }
+
+/**
+ * Get the command that installs a project's declared dependencies.
+ * @param packageManager - The detected package manager
+ */
+export function getProjectInstallCommand(packageManager: PackageManager): {
+  command: string;
+  args: string[];
+} {
+  const resolved = resolveCommand(packageManager, "install", []);
+  return {
+    args: resolved?.args.filter(Boolean) ?? ["install"],
+    command: resolved?.command ?? "npm",
+  };
+}

--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -179,15 +179,18 @@ export async function getPackageDependencyInstallPlan(
     missing: [],
   };
 
-  for (const dependency of requiredDependencies) {
-    const installedVersion = await getInstalledPackageVersion(
-      dependency.name,
-      cwd,
-    );
+  const installedVersions = await Promise.all(
+    requiredDependencies.map((dependency) =>
+      getInstalledPackageVersion(dependency.name, cwd),
+    ),
+  );
+
+  requiredDependencies.forEach((dependency, index) => {
+    const installedVersion = installedVersions[index];
 
     if (installedVersion === null) {
       plan.missing.push(dependency);
-      continue;
+      return;
     }
 
     if (
@@ -197,7 +200,7 @@ export async function getPackageDependencyInstallPlan(
     ) {
       plan.incompatible.push({ ...dependency, installedVersion });
     }
-  }
+  });
 
   return plan;
 }

--- a/packages-private/scripting-utils/test/project.test.ts
+++ b/packages-private/scripting-utils/test/project.test.ts
@@ -23,9 +23,12 @@ import {
   findUp,
   getExecCommand,
   getInstallCommand,
+  getInstalledPackageVersion,
+  getPackageDependencyInstallPlan,
   getProjectRootDirectory,
   isESM,
   makeOutputDirFor,
+  mergePackageJsonDependencies,
   readPackageJson,
 } from "#project";
 
@@ -159,6 +162,136 @@ describe("readPackageJson", () => {
       const result = await readPackageJson(tempDir);
       expect(result).toBeNull();
     });
+  });
+});
+
+describe("package.json dependency helpers", () => {
+  test("should resolve an installed package version from a project", async () => {
+    await withTempFiles(
+      {
+        "node_modules/react/package.json": JSON.stringify({
+          name: "react",
+          version: "19.2.7",
+        }),
+        "package.json": JSON.stringify({ name: "test-package" }),
+      },
+      async (tempDir) => {
+        await expect(
+          getInstalledPackageVersion("react", tempDir),
+        ).resolves.toBe("19.2.7");
+      },
+    );
+  });
+
+  test("should return null when an installed package cannot be resolved", async () => {
+    await withTempFiles(
+      {
+        "package.json": JSON.stringify({ name: "test-package" }),
+      },
+      async (tempDir) => {
+        await expect(
+          getInstalledPackageVersion("react", tempDir),
+        ).resolves.toBe(null);
+      },
+    );
+  });
+
+  test("should plan missing dependencies for installation", async () => {
+    await withTempFiles(
+      {
+        "package.json": JSON.stringify({ name: "test-package" }),
+      },
+      async (tempDir) => {
+        await expect(
+          getPackageDependencyInstallPlan(
+            [
+              { name: "react", version: "^19.0.0" },
+              { name: "react-dom", version: "^19.0.0" },
+            ],
+            tempDir,
+          ),
+        ).resolves.toEqual({
+          incompatible: [],
+          missing: [
+            { name: "react", version: "^19.0.0" },
+            { name: "react-dom", version: "^19.0.0" },
+          ],
+        });
+      },
+    );
+  });
+
+  test("should accept semver-compatible installed versions even when declared ranges differ", async () => {
+    await withTempFiles(
+      {
+        "node_modules/react/package.json": JSON.stringify({
+          name: "react",
+          version: "19.2.7",
+        }),
+        "package.json": JSON.stringify({
+          dependencies: { react: "19.2.7" },
+          name: "test-package",
+        }),
+      },
+      async (tempDir) => {
+        await expect(
+          getPackageDependencyInstallPlan(
+            [{ name: "react", version: "^19.0.0" }],
+            tempDir,
+          ),
+        ).resolves.toEqual({ incompatible: [], missing: [] });
+      },
+    );
+  });
+
+  test("should refuse incompatible installed versions", async () => {
+    await withTempFiles(
+      {
+        "node_modules/react/package.json": JSON.stringify({
+          name: "react",
+          version: "18.3.1",
+        }),
+        "package.json": JSON.stringify({ name: "test-package" }),
+      },
+      async (tempDir) => {
+        await expect(
+          getPackageDependencyInstallPlan(
+            [{ name: "react", version: "^19.0.0" }],
+            tempDir,
+          ),
+        ).resolves.toEqual({
+          incompatible: [
+            { installedVersion: "18.3.1", name: "react", version: "^19.0.0" },
+          ],
+          missing: [],
+        });
+      },
+    );
+  });
+
+  test("should merge missing dependencies", () => {
+    expect(
+      mergePackageJsonDependencies(
+        { react: "^18.0.0", typescript: "^5.0.0" },
+        [
+          { name: "react", version: "^19.0.0" },
+          { name: "@types/react", version: "^19.0.0" },
+        ],
+        [{ react: "^18.0.0" }],
+      ),
+    ).toEqual({
+      "@types/react": "^19.0.0",
+      react: "^18.0.0",
+      typescript: "^5.0.0",
+    });
+  });
+
+  test("should preserve declared dependency ranges when the dependency already exists", () => {
+    expect(
+      mergePackageJsonDependencies({ react: "19.2.7" }, [
+        { name: "react", version: "^19.0.0" },
+      ]),
+    ).toEqual({ react: "19.2.7" });
   });
 });
 
@@ -390,6 +523,25 @@ describe("getInstallCommand", () => {
     expect(getInstallCommand("bun", pkgs)).toEqual({
       command: "bun",
       args: ["add", "foo", "bar"],
+    });
+  });
+
+  test("should return dev dependency install args", () => {
+    expect(getInstallCommand("npm", pkgs, { dev: true })).toEqual({
+      command: "npm",
+      args: ["i", "--save-dev", "foo", "bar"],
+    });
+    expect(getInstallCommand("pnpm", pkgs, { dev: true })).toEqual({
+      command: "pnpm",
+      args: ["add", "--save-dev", "foo", "bar"],
+    });
+    expect(getInstallCommand("yarn", pkgs, { dev: true })).toEqual({
+      command: "yarn",
+      args: ["add", "--dev", "foo", "bar"],
+    });
+    expect(getInstallCommand("bun", pkgs, { dev: true })).toEqual({
+      command: "bun",
+      args: ["add", "--dev", "foo", "bar"],
     });
   });
 });

--- a/packages-private/scripting-utils/test/project.test.ts
+++ b/packages-private/scripting-utils/test/project.test.ts
@@ -27,6 +27,7 @@ import {
   getPackageDependencyInstallPlan,
   getProjectRootDirectory,
   isESM,
+  loadPackageJson,
   makeOutputDirFor,
   mergePackageJsonDependencies,
   readPackageJson,
@@ -165,6 +166,30 @@ describe("readPackageJson", () => {
   });
 });
 
+describe("loadPackageJson", () => {
+  test("should load package.json with npmcli package-json", async () => {
+    await withTempFiles(
+      {
+        "package.json": JSON.stringify({
+          name: "test-package",
+          version: "1.0.0",
+        }),
+      },
+      async (tempDir) => {
+        const pkg = await loadPackageJson(tempDir);
+        expect(pkg?.content.name).toBe("test-package");
+        expect(pkg?.content.version).toBe("1.0.0");
+      },
+    );
+  });
+
+  test("should return null when package.json is not found", async () => {
+    await withTempFiles({}, async (tempDir) => {
+      await expect(loadPackageJson(tempDir)).resolves.toBeNull();
+    });
+  });
+});
+
 describe("package.json dependency helpers", () => {
   test("should resolve an installed package version from a project", async () => {
     await withTempFiles(
@@ -192,6 +217,23 @@ describe("package.json dependency helpers", () => {
         await expect(
           getInstalledPackageVersion("react", tempDir),
         ).resolves.toBe(null);
+      },
+    );
+  });
+
+  test("should resolve a scoped installed package version from a project", async () => {
+    await withTempFiles(
+      {
+        "node_modules/@scope/package/package.json": JSON.stringify({
+          name: "@scope/package",
+          version: "1.2.3",
+        }),
+        "package.json": JSON.stringify({ name: "test-package" }),
+      },
+      async (tempDir) => {
+        await expect(
+          getInstalledPackageVersion("@scope/package", tempDir),
+        ).resolves.toBe("1.2.3");
       },
     );
   });
@@ -292,6 +334,16 @@ describe("package.json dependency helpers", () => {
         { name: "react", version: "^19.0.0" },
       ]),
     ).toEqual({ react: "19.2.7" });
+  });
+
+  test("should not merge dependencies that exist in another dependency map", () => {
+    expect(
+      mergePackageJsonDependencies(
+        {},
+        [{ name: "@types/react", version: "^19.0.0" }],
+        [{}, { "@types/react": "^18.0.0" }],
+      ),
+    ).toEqual({});
   });
 });
 

--- a/packages-private/scripting-utils/test/project.test.ts
+++ b/packages-private/scripting-utils/test/project.test.ts
@@ -25,6 +25,7 @@ import {
   getInstallCommand,
   getInstalledPackageVersion,
   getPackageDependencyInstallPlan,
+  getProjectInstallCommand,
   getProjectRootDirectory,
   isESM,
   loadPackageJson,
@@ -594,6 +595,36 @@ describe("getInstallCommand", () => {
     expect(getInstallCommand("bun", pkgs, { dev: true })).toEqual({
       command: "bun",
       args: ["add", "--dev", "foo", "bar"],
+    });
+  });
+});
+
+describe("getProjectInstallCommand", () => {
+  test("should return the project install command for npm", () => {
+    expect(getProjectInstallCommand("npm")).toEqual({
+      command: "npm",
+      args: ["i"],
+    });
+  });
+
+  test("should return the project install command for pnpm", () => {
+    expect(getProjectInstallCommand("pnpm")).toEqual({
+      command: "pnpm",
+      args: ["i"],
+    });
+  });
+
+  test("should return the project install command for yarn", () => {
+    expect(getProjectInstallCommand("yarn")).toEqual({
+      command: "yarn",
+      args: ["install"],
+    });
+  });
+
+  test("should return the project install command for bun", () => {
+    expect(getProjectInstallCommand("bun")).toEqual({
+      command: "bun",
+      args: ["install"],
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,12 +209,24 @@ importers:
       '@adobe/aio-lib-ims':
         specifier: 'catalog:'
         version: 8.1.2
+      '@npmcli/package-json':
+        specifier: ^8.0.0
+        version: 8.0.0
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
+      local-pkg:
+        specifier: ^1.2.1
+        version: 1.2.1
       package-manager-detector:
         specifier: ^1.6.0
         version: 1.6.0
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       type-fest:
         specifier: 'catalog:'
         version: 5.7.0
@@ -234,6 +246,9 @@ importers:
       '@aio-commerce-sdk/config-vitest':
         specifier: workspace:*
         version: link:../../configs/vitest
+      '@types/npmcli__package-json':
+        specifier: ^4.0.4
+        version: 4.0.4
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2099,6 +2114,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
 
@@ -2176,6 +2194,11 @@ packages:
   '@wry/trie@0.5.0':
     resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
     engines: {node: '>=8'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2398,6 +2421,12 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -2580,6 +2609,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -3065,6 +3097,10 @@ packages:
     resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
     engines: {node: '>=22.13.0'}
 
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3177,6 +3213,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3379,6 +3418,12 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -3865,6 +3910,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -5485,6 +5533,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/semver@7.7.1': {}
+
   '@types/set-cookie-parser@2.4.10':
     dependencies:
       '@types/node': 24.13.2
@@ -5589,6 +5639,8 @@ snapshots:
   '@wry/trie@0.5.0':
     dependencies:
       tslib: 2.8.1
+
+  acorn@8.17.0: {}
 
   agent-base@7.1.4: {}
 
@@ -5780,6 +5832,10 @@ snapshots:
 
   commander@15.0.0: {}
 
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
   consola@3.4.2: {}
 
   content-type@2.0.0: {}
@@ -5956,6 +6012,8 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.3.0: {}
+
+  exsolve@1.1.0: {}
 
   extendable-error@0.1.7: {}
 
@@ -6425,6 +6483,12 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 10.0.0
 
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -6532,6 +6596,13 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.17.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   mri@1.2.0: {}
 
@@ -6735,6 +6806,18 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.0
+      pathe: 2.0.3
 
   postcss@8.5.15:
     dependencies:
@@ -7181,6 +7264,8 @@ snapshots:
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
+
+  ufo@1.6.4: {}
 
   uglify-js@3.19.3:
     optional: true


### PR DESCRIPTION
## Description

Adds scripting-utils helpers for dependency management used by generated app scaffolding:

- Load package.json through npmcli's package-json helper.
- Resolve installed package versions with local-pkg.
- Build missing/incompatible dependency install plans using installed versions.
- Merge missing dependency entries into package.json dependency maps.
- Support dev dependency flags in getInstallCommand.

## Related Issue

CEXT-6338

## Motivation and Context

The lib-app Admin UI scaffold needs shared dependency helper behavior before the lib-app-specific changes are split into their own PR.

## How Has This Been Tested?

Not run after the final branch cleanup. Added unit coverage for the new scripting-utils helpers, including installed package resolution, scoped package resolution, dependency install planning, dependency map merging, and dev install command args.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
