### PR TITLE
CEXT-6338: fix mass action worker request field name

### DIFF
--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -177,9 +177,9 @@ Use `parseMassActionRequest` to validate and narrow the incoming body:
 import { parseMassActionRequest } from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
 
 export async function main(params: unknown) {
-  const { requestId, gridType, ids } = parseMassActionRequest(params);
+  const { requestId, gridType, selectedIds } = parseMassActionRequest(params);
   // gridType is "order" | "product" | "customer"
-  // ids is string[] with at least one entry
+  // selectedIds is string[] with at least one entry
 }
 ```
 
@@ -194,7 +194,7 @@ success. Optionally include any fields you need for logging:
 import { okMassActionResponse } from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
 
 return okMassActionResponse();
-return okMassActionResponse({ exported: ids.length });
+return okMassActionResponse({ exported: selectedIds.length });
 ```
 
 #### Building an error response
@@ -432,7 +432,7 @@ export async function main(params: RuntimeActionParams) {
   } catch {
     return massActionErrorResponse(400, "Invalid mass action request");
   }
-  const { gridType, ids } = request;
+  const { gridType, selectedIds } = request;
 
   // 2. Build a Commerce HTTP client and a permission client.
   //    Hoist these to module scope if the action handles more than one request.
@@ -464,8 +464,8 @@ export async function main(params: RuntimeActionParams) {
   }
 
   // 4. Run the work, then return the response envelope Commerce expects.
-  await approveOrders(ids);
-  return okMassActionResponse({ approved: ids.length });
+  await approveOrders(selectedIds);
+  return okMassActionResponse({ approved: selectedIds.length });
 }
 ```
 

--- a/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/presets.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/presets.ts
@@ -35,8 +35,8 @@ import type {
  * import { parseMassActionRequest } from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
  *
  * export async function main(params: unknown) {
- *   const { requestId, gridType, ids } = parseMassActionRequest(params);
- *   // process ids...
+ *   const { requestId, gridType, selectedIds } = parseMassActionRequest(params);
+ *   // process selectedIds...
  * }
  * ```
  */
@@ -57,7 +57,7 @@ export function parseMassActionRequest(input: unknown): MassActionRequest {
  * @example
  * ```ts
  * return okMassActionResponse();
- * return okMassActionResponse({ exported: ids.length });
+ * return okMassActionResponse({ exported: selectedIds.length });
  * ```
  */
 export function okMassActionResponse(

--- a/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/schema.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/mass-actions/worker/schema.ts
@@ -33,8 +33,11 @@ export const MassActionGridTypeSchema = v.picklist([
 export const MassActionRequestSchema = v.object({
   requestId: nonEmptyStringValueSchema("requestId"),
   gridType: MassActionGridTypeSchema,
-  ids: v.pipe(
+  selectedIds: v.pipe(
     v.array(nonEmptyStringValueSchema("id")),
-    v.minLength(1, 'The value of "ids" must contain at least one entry'),
+    v.minLength(
+      1,
+      'The value of "selectedIds" must contain at least one entry',
+    ),
   ),
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/mass-actions/worker.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/mass-actions/worker.test.ts
@@ -24,7 +24,7 @@ import type { MassActionGridType } from "#mass-actions/worker/types";
 const VALID_REQUEST = {
   requestId: "550e8400-e29b-41d4-a716-446655440000",
   gridType: "order",
-  ids: ["000000001", "000000002"],
+  selectedIds: ["000000001", "000000002"],
 };
 
 describe("parseMassActionRequest", () => {
@@ -43,7 +43,7 @@ describe("parseMassActionRequest", () => {
 
   it("throws when requestId is missing", () => {
     expect(() =>
-      parseMassActionRequest({ gridType: "order", ids: ["1"] }),
+      parseMassActionRequest({ gridType: "order", selectedIds: ["1"] }),
     ).toThrow(CommerceSdkValidationError);
   });
 
@@ -53,15 +53,15 @@ describe("parseMassActionRequest", () => {
     ).toThrow(CommerceSdkValidationError);
   });
 
-  it("throws when ids is empty", () => {
-    expect(() => parseMassActionRequest({ ...VALID_REQUEST, ids: [] })).toThrow(
-      CommerceSdkValidationError,
-    );
+  it("throws when selectedIds is empty", () => {
+    expect(() =>
+      parseMassActionRequest({ ...VALID_REQUEST, selectedIds: [] }),
+    ).toThrow(CommerceSdkValidationError);
   });
 
-  it("throws when ids contains an empty string", () => {
+  it("throws when selectedIds contains an empty string", () => {
     expect(() =>
-      parseMassActionRequest({ ...VALID_REQUEST, ids: ["1", ""] }),
+      parseMassActionRequest({ ...VALID_REQUEST, selectedIds: ["1", ""] }),
     ).toThrow(CommerceSdkValidationError);
   });
 

--- a/plugins/commerce/app-management/.claude-plugin/plugin.json
+++ b/plugins/commerce/app-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commerce-app-management",
   "description": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -16,7 +16,7 @@ compatibility: >
 metadata:
   author: adobe
   sdk-package: "@adobe/aio-commerce-sdk"
-  version: "0.0.2"
+  version: "0.0.3"
 ---
 
 # Configure Commerce App Admin UI

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/references/mass-actions.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/references/mass-actions.md
@@ -62,9 +62,9 @@ Available on `order`, `product`, and `customer`.
 
 Import from `@adobe/aio-commerce-sdk/admin-ui/mass-actions`.
 
-Commerce POSTs `{ requestId, gridType, ids }` (`ids` is non-empty). The HTTP status code conveys success vs. failure.
+Commerce POSTs `{ requestId, gridType, selectedIds }` (`selectedIds` is non-empty). The HTTP status code conveys success vs. failure.
 
-- `parseMassActionRequest(params)` → `{ requestId, gridType, ids }`; throws `CommerceSdkValidationError` on malformed input.
+- `parseMassActionRequest(params)` → `{ requestId, gridType, selectedIds }`; throws `CommerceSdkValidationError` on malformed input.
 - `okMassActionResponse(body?)` → HTTP 200; optional body for logging.
 - `massActionErrorResponse(statusCode, message)` → non-2xx; body is `{ message }`. Commerce surfaces `notifications.error`.
 
@@ -77,9 +77,9 @@ import {
 import type { RuntimeActionParams } from "@adobe/aio-commerce-sdk/core/params";
 
 export async function main(params: RuntimeActionParams) {
-  const { gridType, ids } = parseMassActionRequest(params);
+  const { gridType, selectedIds } = parseMassActionRequest(params);
   try {
-    const archived = await archive(gridType, ids);
+    const archived = await archive(gridType, selectedIds);
     return okMassActionResponse({ archived });
   } catch (error) {
     return massActionErrorResponse(

--- a/plugins/commerce/app-management/tile.json
+++ b/plugins/commerce/app-management/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/commerce-app-management",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "summary": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
   "private": false,
   "skills": {


### PR DESCRIPTION
## Description

Renames the `ids` field on the mass action worker request schema to `selectedIds`, and updates the corresponding docs and plugin skill reference to match.

## Related Issue

N/A — pulled out of #548 to keep that PR focused; not tied to its own ticket.

## Motivation and Context

The mass actions wire contract hasn't shipped yet, so this corrects the field name before release rather than after consumers depend on it.

## How Has This Been Tested?

Ran the admin-ui package's unit test suite (updated to cover the renamed field) and typecheck; both pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.