### PR TITLE
chore: commit repo-level Scout config

### DIFF
--- a/.scout/scout.config.yaml
+++ b/.scout/scout.config.yaml
@@ -1,0 +1,16 @@
+# Scout per-repo config template.
+#
+# Seeded into `<repo>/.scout/scout.config.yaml` by `scout attach` when the
+# repo has no config yet.  Templates here only carry the repo-specific
+# ignore / dampen / boost / tune overrides; defaults for
+# repository/markdown/ranking/index/projects are filled in at load time.
+ignore:
+  - '**/CHANGELOG.md'
+  - '**/CHANGELOG*'
+  - '**/CHANGES.md'
+  - '**/HISTORY.md'
+
+dampen:
+  - factor: 0.3
+    patterns:
+      - '**/package.json'


### PR DESCRIPTION
## Description

Checks in the repo-root `.scout/scout.config.yaml` instead of leaving it untracked.

## Related Issue

N/A

## Motivation and Context

The repo-root `.scout/` holds per-repo Scout configuration (search ignore/dampen/boost rules), distinct from the per-user local index/model data Scout keeps under the home directory. It's meant to be shared across the team rather than gitignored.

## How Has This Been Tested?

N/A — config-only change, no code affected.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.