### PR TITLE
CEXT-6367: leave storage uninstall handler empty by default in commerce-app-storage skill

### DIFF
--- a/plugins/commerce/app-management/.claude-plugin/plugin.json
+++ b/plugins/commerce/app-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commerce-app-management",
   "description": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "Adobe"
   },

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -14,7 +14,7 @@ compatibility: >
 metadata:
   author: adobe
   sdk-package: "@adobe/aio-commerce-lib-app"
-  version: "0.0.2"
+  version: "0.0.3"
 ---
 
 # Add Database Storage to a Commerce App
@@ -211,18 +211,8 @@ export default defineCustomInstallationStep({
     }
   },
   uninstall: async (config, context) => {
-    let client;
-    try {
-      const authProvider = getImsAuthProvider(
-        resolveImsAuthParams(context.params),
-      );
-      const token = await authProvider.getAccessToken();
-      const db = await initDb({ token, region: "emea" });
-      client = await db.connect();
-      await client.collection("held_orders").drop();
-    } finally {
-      if (client) await client.close();
-    }
+    // Tear down your database state here.
+    // Leave empty to preserve data across reinstalls.
   },
 });
 ```

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/setup-database.ts
@@ -3,7 +3,7 @@
 //
 // What it does:
 //   - install:   creates the "held_orders" collection and a UNIQUE index on order_id
-//   - uninstall: drops the collection to reverse the install
+//   - uninstall: tear down your database state here; leave empty to preserve data across reinstalls
 //
 // Why a custom installation step (vs. ad-hoc setup on first request):
 //   It runs exactly once when the app is installed from the Commerce Admin,
@@ -90,23 +90,8 @@ export default defineCustomInstallationStep({
     }
   },
 
-  uninstall: async (config, context) => {
-    const { logger } = context;
-    logger.info(`Removing storage for ${config.metadata.displayName}...`);
-
-    let client: Awaited<ReturnType<typeof openClient>> | undefined;
-    try {
-      client = await openClient(context);
-      await client.collection(COLLECTION).drop();
-      logger.info(`Dropped "${COLLECTION}"`);
-    } finally {
-      if (client) {
-        await client
-          .close()
-          .catch((e: Error) =>
-            logger.warn("Failed to close DB client", e.message),
-          );
-      }
-    }
+  uninstall: async (_config, _context) => {
+    // Tear down your database state here.
+    // Leave empty to preserve data across reinstalls.
   },
 });

--- a/plugins/commerce/app-management/tile.json
+++ b/plugins/commerce/app-management/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe/commerce-app-management",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "summary": "Skills for Adobe Commerce App Management — scaffold and configure Commerce apps using the aio-commerce-sdk.",
   "private": false,
   "skills": {


### PR DESCRIPTION
## Description

Extracted a change originally made in PR #540 that was out of scope there: the `commerce-app-storage` skill's example `uninstall` handler no longer drops the `held_orders` collection automatically. It's left as an empty placeholder with guidance comments, so app data is preserved across reinstalls unless the developer opts in to clearing it.

## Related Issue

N/A

## Motivation and Context

Automatically dropping a collection on uninstall risks destroying production data. Leaving the handler empty by default is safer, and lets developers decide deliberately whether and how to clean up storage.

## How Has This Been Tested?

`pnpm typecheck`, `pnpm lint`, and `pnpm test` all pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.