### PR TITLE
CEXT-6418: skip empty runtime manifest in generated ext.config.yaml

### DIFF
--- a/.changeset/empty-runtime-manifest.md
+++ b/.changeset/empty-runtime-manifest.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Avoid generating empty runtime manifests for view-only Admin UI extensions.

--- a/.changeset/empty-runtime-manifest.md
+++ b/.changeset/empty-runtime-manifest.md
@@ -1,5 +1,0 @@
----
-"@adobe/aio-commerce-lib-app": patch
----
-
-Avoid generating empty runtime manifests for view-only Admin UI extensions.

--- a/packages-private/scripting-utils/source/yaml/codegen.ts
+++ b/packages-private/scripting-utils/source/yaml/codegen.ts
@@ -48,13 +48,14 @@ export async function createOrUpdateExtConfig(
   }
 
   config.hooks ??= {};
-  config.runtimeManifest ??= { packages: {} };
 
   await buildHooks(extConfigDoc, config.hooks);
   if (config.operations !== undefined) {
     buildOperations(extConfigDoc, config.operations);
   }
-  buildRuntimeManifest(extConfigDoc, config.runtimeManifest);
+  if (config.runtimeManifest !== undefined) {
+    buildRuntimeManifest(extConfigDoc, config.runtimeManifest);
+  }
 
   await writeExtConfig(path, extConfigDoc);
   return extConfigDoc;
@@ -205,13 +206,17 @@ function buildOperations(extConfig: Document, operations: Operations) {
  * @param packages - The packages to build
  */
 function buildRuntimeManifest(extConfig: Document, manifest: RuntimeManifest) {
+  const packages = manifest.packages ?? {};
+  if (Object.keys(packages).length === 0) {
+    return;
+  }
+
   getOrCreateMap(extConfig, ["runtimeManifest"], {
     onBeforeCreate: (pair) => {
       pair.key.spaceBefore = true;
     },
   });
 
-  const packages = manifest.packages ?? {};
   getOrCreateMap(extConfig, ["runtimeManifest", "packages"]);
 
   for (const [name, pkg] of Object.entries(packages)) {

--- a/packages-private/scripting-utils/test/yaml/codegen.test.ts
+++ b/packages-private/scripting-utils/test/yaml/codegen.test.ts
@@ -126,10 +126,32 @@ runtimeManifest:
         new Document({}),
       );
 
-      // Should have default empty structures
+      // Should have default empty hooks but no action manifest.
       expect(doc.has("hooks")).toBe(true);
       expect(doc.has("operations")).toBe(false);
-      expect(doc.has("runtimeManifest")).toBe(true);
+      expect(doc.has("runtimeManifest")).toBe(false);
+    });
+  });
+
+  test("should not create runtime manifest when packages are empty", async () => {
+    await withTempFiles({}, async (tempDir) => {
+      const configPath = join(tempDir, "ext.config.yaml");
+      const config = {
+        runtimeManifest: {
+          packages: {},
+        },
+      };
+
+      const doc = await createOrUpdateExtConfig(
+        configPath,
+        config,
+        new Document({}),
+      );
+      const fileContent = await readFile(configPath, "utf-8");
+
+      expect(doc.has("runtimeManifest")).toBe(false);
+      expect(fileContent).not.toContain("runtimeManifest");
+      expect(fileContent).not.toContain("packages: {}");
     });
   });
 
@@ -178,7 +200,7 @@ runtimeManifest:
       const configPath = join(tempDir, "ext.config.yaml");
       const config = {
         runtimeManifest: {
-          // No packages - tests line 148 (manifest.packages ?? {})
+          // No packages should not create an action manifest.
         },
       };
 
@@ -188,7 +210,10 @@ runtimeManifest:
         new Document({}),
       );
 
-      expect(doc.has("runtimeManifest")).toBe(true);
+      const fileContent = await readFile(configPath, "utf-8");
+
+      expect(doc.has("runtimeManifest")).toBe(false);
+      expect(fileContent).not.toContain("runtimeManifest");
     });
   });
 
@@ -731,6 +756,26 @@ runtimeManifest:
         const fileContent = await readFile(configPath, "utf-8");
 
         expect(fileContent).toContain("web: web-src");
+      });
+    });
+
+    test("does not write runtime manifest for web-only extensions", async () => {
+      await withTempFiles({}, async (tempDir) => {
+        const configPath = join(tempDir, "ext.config.yaml");
+        const config = {
+          operations: {
+            view: [{ type: "web" as const, impl: "index.html" }],
+          },
+          web: "web-src",
+        };
+
+        await createOrUpdateExtConfig(configPath, config, new Document({}));
+        const fileContent = await readFile(configPath, "utf-8");
+
+        expect(fileContent).toContain("web: web-src");
+        expect(fileContent).toContain("view:");
+        expect(fileContent).not.toContain("runtimeManifest");
+        expect(fileContent).not.toContain("packages: {}");
       });
     });
 

--- a/packages/aio-commerce-lib-app/test/unit/commands/generate/actions/config.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/commands/generate/actions/config.test.ts
@@ -300,7 +300,13 @@ describe("buildAdminUiV2ExtConfig", () => {
 
   test("workerProcess is omitted when adminUi has only menu (no grids or worker mass actions)", () => {
     const config = buildAdminUiV2ExtConfig(configWithAdminUiMenu);
+
+    expect(config.operations.view).toEqual([
+      { type: "web", impl: "index.html" },
+    ]);
     expect(config.operations?.workerProcess).toBeUndefined();
+    expect(config.web).toBe("web-src");
+    expect("runtimeManifest" in config).toBe(false);
   });
 
   test("includes view and web when view mass actions are configured", () => {


### PR DESCRIPTION
## Description

`createOrUpdateExtConfig` no longer defaults `runtimeManifest` to `{ packages: {} }`, and `buildRuntimeManifest` now skips writing the `runtimeManifest` section entirely when there are no packages to declare.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-6418

## Motivation and Context

For Admin UI extensions that only configure a menu (no worker actions), `generate all` was emitting an empty `runtimeManifest: packages: {}` block in `ext.config.yaml`. The `aio` CLI then unconditionally checks for a built actions directory for any extension declaring a runtime manifest, so `aio app deploy` failed with `missing files in dist/commerce-backend-ui-2/actions` even though the extension has no actions to deploy.

## How Has This Been Tested?

Added/updated unit tests in `packages-private/scripting-utils` covering `createOrUpdateExtConfig`/`buildRuntimeManifest` with no `runtimeManifest`, an explicit empty `packages` map, and a web-only extension, plus a test in `aio-commerce-lib-app` covering `buildAdminUiV2ExtConfig` for a menu-only config. Ran the full test suite, typecheck, and lint locally.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.