### PR TITLE
CEXT-6338: add admin-ui React browser-mode test suite

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,7 +55,7 @@ jobs:
         # The Chromium binary itself is fetched by pnpm (playwright is in allowBuilds),
         # but Linux still needs Chromium's system libraries for the browser-mode tests.
       - name: Install Playwright system deps (Linux)
-        run: pnpm exec playwright install-deps chromium
+        run: pnpx playwright install-deps chromium
 
         # See: https://turborepo.com/docs/reference/run#--affected
       - name: Run Turbo tasks on affected packages

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -52,10 +52,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-        # The Chromium binary itself is fetched by pnpm (playwright is in allowBuilds),
-        # but Linux still needs Chromium's system libraries for the browser-mode tests.
-      - name: Install Playwright system deps (Linux)
-        run: pnpx playwright install-deps chromium
+        # Cache the downloaded browser binary; system libs (--with-deps) install too fast to cache.
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+        # Browser-mode tests need the Chromium binary plus its system libraries on Linux.
+      - name: Install Playwright Chromium
+        run: pnpx playwright install --with-deps chromium
 
         # See: https://turborepo.com/docs/reference/run#--affected
       - name: Run Turbo tasks on affected packages

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,7 +63,7 @@ jobs:
 
         # Browser-mode tests need the Chromium binary plus its system libraries on Linux.
       - name: Install Playwright Chromium
-        run: pnpx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
         # See: https://turborepo.com/docs/reference/run#--affected
       - name: Run Turbo tasks on affected packages

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+        # The Chromium binary itself is fetched by pnpm (playwright is in allowBuilds),
+        # but Linux still needs Chromium's system libraries for the browser-mode tests.
+      - name: Install Playwright system deps (Linux)
+        run: pnpm exec playwright install-deps chromium
+
         # See: https://turborepo.com/docs/reference/run#--affected
       - name: Run Turbo tasks on affected packages
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,10 @@ out
 # Turbo
 .turbo
 
+# Vitest browser-mode failure screenshots
+**/__screenshots__/
+**/.vitest-attachments/
+
 .vscode/*
 !.vscode/settings.json
 !.vscode/extensions.json

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@redocly/cli": "^2.31.4",
     "@turbo/gen": "^2.8.17",
     "@types/node": "^24.12.0",
+    "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/browser-playwright": "^4.1.9",
     "@vitest/coverage-v8": "^4.1.0",
     "@vitest/ui": "^4.1.0",
     "husky": "^9.1.7",
@@ -51,7 +53,8 @@
     "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "catalog:",
     "ultracite": "7.8.4",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "vitest-browser-react": "^2.2.0"
   },
   "lint-staged": {
     "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vitest/ui": "^4.1.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.0",
+    "playwright": "1.61.1",
     "prettier": "catalog:",
     "publint": "^0.3.18",
     "tsdown": "^0.22.0",

--- a/packages/aio-commerce-lib-admin-ui/package.json
+++ b/packages/aio-commerce-lib-admin-ui/package.json
@@ -173,11 +173,8 @@
     "@aio-commerce-sdk/scripting-utils": "workspace:*",
     "@aio-commerce-sdk/scripts": "workspace:*",
     "@react-spectrum/s2": "catalog:react",
-    "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.2",
     "@types/react": "catalog:react",
     "@types/react-dom": "catalog:react",
-    "jsdom": "^29.1.1",
     "react": "catalog:react",
     "react-dom": "catalog:react",
     "typescript": "catalog:"

--- a/packages/aio-commerce-lib-admin-ui/package.json
+++ b/packages/aio-commerce-lib-admin-ui/package.json
@@ -109,7 +109,8 @@
   "imports": {
     "#*": "./source/*.ts",
     "#*.tsx": "./source/*.tsx",
-    "#test/*": "./test/*.ts"
+    "#test/*": "./test/*.ts",
+    "#test/*.tsx": "./test/*.tsx"
   },
   "files": [
     "dist",

--- a/packages/aio-commerce-lib-admin-ui/package.json
+++ b/packages/aio-commerce-lib-admin-ui/package.json
@@ -173,8 +173,11 @@
     "@aio-commerce-sdk/scripting-utils": "workspace:*",
     "@aio-commerce-sdk/scripts": "workspace:*",
     "@react-spectrum/s2": "catalog:react",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "catalog:react",
     "@types/react-dom": "catalog:react",
+    "jsdom": "^29.1.1",
     "react": "catalog:react",
     "react-dom": "catalog:react",
     "typescript": "catalog:"

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
@@ -39,16 +39,19 @@ function getCommerceHostPromise(
     .integration;
 
   if (!integration) {
-    // Rejects synchronously, so there's no pending window for `use` to keep stable and nothing
-    // to cache: a later attempt re-checks for free and could succeed if the host changes.
-    return Promise.reject(
-      new Error(
-        "The host does not provide the integration API needed to resolve the Commerce host.",
-      ),
+    // Throw during render so the error surfaces to the boundary immediately: this is a static
+    // property of the connection, so there's nothing async to await or cache.
+    throw new Error(
+      "The host does not provide the integration API needed to resolve the Commerce host.",
     );
   }
 
-  return commerceHosts(extensionId, () => integration.getCommerceHost());
+  return commerceHosts.get(extensionId, () => integration.getCommerceHost());
+}
+
+/** Drops the cached Commerce host for `extensionId`, so a later render re-resolves it. */
+export function resetCommerceHost(extensionId: string) {
+  commerceHosts.evict(extensionId);
 }
 
 /**

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
@@ -49,9 +49,9 @@ function getCommerceHostPromise(
   return commerceHosts.get(extensionId, () => integration.getCommerceHost());
 }
 
-/** Drops the cached Commerce host for `extensionId`, so a later render re-resolves it. */
-export function resetCommerceHost(extensionId: string) {
-  commerceHosts.evict(extensionId);
+/** Drops a failed Commerce host resolution for `extensionId`, so a later render retries it. */
+export function retryCommerceHost(extensionId: string) {
+  commerceHosts.evictIfRejected(extensionId);
 }
 
 /**

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-guest-connection.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-guest-connection.ts
@@ -22,7 +22,7 @@ const guestConnections = createRetryablePromiseCache<GuestConnection>();
 function getGuestConnectionPromise(
   extensionId: string,
 ): Promise<GuestConnection> {
-  return guestConnections(extensionId, () => {
+  return guestConnections.get(extensionId, () => {
     const promise = attach({ id: extensionId });
     promise.catch((err) => {
       console.error("UIX guest attach failed:", err);
@@ -38,4 +38,9 @@ function getGuestConnectionPromise(
  */
 export function useGuestConnection(extensionId: string): GuestConnection {
   return use(getGuestConnectionPromise(extensionId));
+}
+
+/** Drops the cached connection for `extensionId`, so a later render re-attaches. */
+export function resetGuestConnection(extensionId: string) {
+  guestConnections.evict(extensionId);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-guest-connection.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-guest-connection.ts
@@ -40,7 +40,7 @@ export function useGuestConnection(extensionId: string): GuestConnection {
   return use(getGuestConnectionPromise(extensionId));
 }
 
-/** Drops the cached connection for `extensionId`, so a later render re-attaches. */
-export function resetGuestConnection(extensionId: string) {
-  guestConnections.evict(extensionId);
+/** Drops a failed connection for `extensionId`, so a later render re-attaches. */
+export function retryGuestConnection(extensionId: string) {
+  guestConnections.evictIfRejected(extensionId);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/commerce-app.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/commerce-app.tsx
@@ -22,9 +22,9 @@ import {
   SharedContextProvider,
   useSharedContext,
 } from "#web/react/commerce/context/shared-context.tsx";
-import { resetCommerceHost } from "#web/react/commerce/hooks/use-commerce";
+import { retryCommerceHost } from "#web/react/commerce/hooks/use-commerce";
 import {
-  resetGuestConnection,
+  retryGuestConnection,
   useGuestConnection,
 } from "#web/react/commerce/hooks/use-guest-connection";
 import { isControlFrame } from "#web/react/commerce/lib";
@@ -83,9 +83,10 @@ export function CommerceExtensionApp(props: Readonly<{ extensionId: string }>) {
     <Provider colorScheme="light" router={spectrumRouter}>
       <ExtensionErrorBoundary
         onReset={() => {
-          // Drop cached failures so "Try again" re-attaches instead of replaying the rejection.
-          resetGuestConnection(extensionId);
-          resetCommerceHost(extensionId);
+          // Retry only failed steps so "Try again" re-attaches after a connection failure but
+          // keeps a healthy connection when the error came from elsewhere.
+          retryGuestConnection(extensionId);
+          retryCommerceHost(extensionId);
         }}>
         <Suspense fallback={<ConnectionFallback />}>
           <CommerceGuestConnection extensionId={extensionId} />

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/commerce-app.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/commerce-app.tsx
@@ -22,7 +22,11 @@ import {
   SharedContextProvider,
   useSharedContext,
 } from "#web/react/commerce/context/shared-context.tsx";
-import { useGuestConnection } from "#web/react/commerce/hooks/use-guest-connection";
+import { resetCommerceHost } from "#web/react/commerce/hooks/use-commerce";
+import {
+  resetGuestConnection,
+  useGuestConnection,
+} from "#web/react/commerce/hooks/use-guest-connection";
 import { isControlFrame } from "#web/react/commerce/lib";
 import { createRetryablePromiseCache } from "#web/react/promise-cache";
 import { useSpectrumRouter } from "#web/react/routing/hooks/use-spectrum-router";
@@ -39,7 +43,7 @@ const controlFrameRegistrations = createRetryablePromiseCache<unknown>();
  * @param extensionId - The unique identifier for the extension app.
  */
 function registerControlFrame(extensionId: string) {
-  return controlFrameRegistrations(extensionId, () => {
+  return controlFrameRegistrations.get(extensionId, () => {
     const promise = register({ id: extensionId, methods: {} });
     promise.catch((err) => {
       console.error("UIX guest register failed:", err);
@@ -77,7 +81,12 @@ export function CommerceExtensionApp(props: Readonly<{ extensionId: string }>) {
 
   return (
     <Provider colorScheme="light" router={spectrumRouter}>
-      <ExtensionErrorBoundary>
+      <ExtensionErrorBoundary
+        onReset={() => {
+          // Drop cached failures so "Try again" re-attaches instead of replaying the rejection.
+          resetGuestConnection(extensionId);
+          resetCommerceHost(extensionId);
+        }}>
         <Suspense fallback={<ConnectionFallback />}>
           <CommerceGuestConnection extensionId={extensionId} />
         </Suspense>

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/entrypoint.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/entrypoint.tsx
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { isControlFrame, isUiFrame } from "#web/react/commerce/lib";
+import {
+  isControlFrame,
+  isEmbeddedInHost,
+  isUiFrame,
+} from "#web/react/commerce/lib";
 
 import { CommerceExtensionApp } from "./commerce-app";
 import { ExperienceShellExtensionApp } from "./experience-shell-app";
@@ -38,12 +42,15 @@ export function Entrypoint(props: Readonly<EntrypointProps>) {
     return <CommerceExtensionApp extensionId={extensionId} />;
   }
 
-  return initialConfigurationPromise === null ? (
-    <StandaloneExtensionApp />
-  ) : (
-    <ExperienceShellExtensionApp
-      initialConfigurationPromise={initialConfigurationPromise}
-      runtime={runtime}
-    />
-  );
+  // The shell flow only applies when embedded in the Experience Cloud shell
+  if (isEmbeddedInHost() && initialConfigurationPromise !== null) {
+    return (
+      <ExperienceShellExtensionApp
+        initialConfigurationPromise={initialConfigurationPromise}
+        runtime={runtime}
+      />
+    );
+  }
+
+  return <StandaloneExtensionApp />;
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/error-boundary.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/error-boundary.tsx
@@ -76,17 +76,22 @@ function ErrorFallback({ error, resetErrorBoundary }: Readonly<FallbackProps>) {
  * A wrapper component that provides an error boundary for extension apps.
  * It catches JavaScript errors anywhere in its child component tree, logs those errors, and displays a fallback UI.
  *
- * @param props - The props for the component, including children elements.
+ * @param props - The props for the component, including children elements and an optional
+ * `onReset` callback run before the boundary re-renders its children (via "Try again" or a
+ * route change), e.g. to drop cached failures so a retry starts fresh.
  */
 export function ExtensionErrorBoundary(
-  props: Readonly<React.PropsWithChildren>,
+  props: Readonly<React.PropsWithChildren<{ onReset?: () => void }>>,
 ) {
   const routeKey = useRouterState({
     select: (state) => state.matches.at(-1)?.pathname,
   });
 
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback} resetKeys={[routeKey]}>
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onReset={props.onReset}
+      resetKeys={[routeKey]}>
       {props.children}
     </ErrorBoundary>
   );

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/promise-cache.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/promise-cache.ts
@@ -14,8 +14,8 @@ type RetryablePromiseCache<T> = {
   /** Returns the cached promise for `key`, or runs `create` to produce and cache one on a miss. */
   get: (key: string, create: () => Promise<T>) => Promise<T>;
 
-  /** Drops the cached promise for `key`, so the next lookup creates a fresh one. */
-  evict: (key: string) => void;
+  /** Drops the cached promise for `key` only if it rejected, so the next lookup retries. */
+  evictIfRejected: (key: string) => void;
 };
 
 /**
@@ -27,24 +27,28 @@ type RetryablePromiseCache<T> = {
  * suspending forever on a fresh pending promise. Retry a failed key via {@link RetryablePromiseCache.evict}.
  */
 export function createRetryablePromiseCache<T>(): RetryablePromiseCache<T> {
-  const cache = new Map<string, Promise<T>>();
+  const cache = new Map<string, { promise: Promise<T>; rejected: boolean }>();
 
   return {
     get(key, create) {
-      let promise = cache.get(key);
-      if (!promise) {
-        promise = create();
-
-        // Mark a retained rejection handled so it isn't flagged as unhandled; `use()` still sees it.
-        promise.catch(() => undefined);
-        cache.set(key, promise);
+      const cached = cache.get(key);
+      if (cached) {
+        return cached.promise;
       }
 
-      return promise;
+      const entry = { promise: create(), rejected: false };
+      entry.promise.catch(() => {
+        entry.rejected = true;
+      });
+
+      cache.set(key, entry);
+      return entry.promise;
     },
 
-    evict(key) {
-      cache.delete(key);
+    evictIfRejected(key) {
+      if (cache.get(key)?.rejected) {
+        cache.delete(key);
+      }
     },
   };
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/promise-cache.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/promise-cache.ts
@@ -10,33 +10,41 @@
  * governing permissions and limitations under the License.
  */
 
+type RetryablePromiseCache<T> = {
+  /** Returns the cached promise for `key`, or runs `create` to produce and cache one on a miss. */
+  get: (key: string, create: () => Promise<T>) => Promise<T>;
+
+  /** Drops the cached promise for `key`, so the next lookup creates a fresh one. */
+  evict: (key: string) => void;
+};
+
 /**
- * Creates a keyed cache of promises that memoizes in-flight and resolved promises and evicts
- * failed ones, so a later lookup for the same key retries instead of replaying the rejection.
+ * Creates a keyed cache that memoizes in-flight, resolved, and rejected promises, giving `use()`
+ * the reference-stable promise it needs while suspended and single-flighting side-effecting
+ * establishment calls across re-renders, remounts, and StrictMode double-invocation.
  *
- * This is the reference-stable memoization that `use()` requires while suspended, and the
- * single-flight guarantee that side-effecting establishment calls (which have no teardown to
- * undo a duplicate) need to survive re-renders, remounts, and StrictMode double-invocation.
- *
- * @returns A `get-or-create` function: it returns the cached promise for `key`, or runs
- * `create` to produce and cache one on a miss.
+ * Rejections are retained (not evicted) so `use()` replays them to an error boundary instead of
+ * suspending forever on a fresh pending promise. Retry a failed key via {@link RetryablePromiseCache.evict}.
  */
-export function createRetryablePromiseCache<T>() {
+export function createRetryablePromiseCache<T>(): RetryablePromiseCache<T> {
   const cache = new Map<string, Promise<T>>();
 
-  return (key: string, create: () => Promise<T>): Promise<T> => {
-    let promise = cache.get(key);
-    if (!promise) {
-      promise = create();
-      promise.catch(() => {
-        if (cache.get(key) === promise) {
-          cache.delete(key);
-        }
-      });
+  return {
+    get(key, create) {
+      let promise = cache.get(key);
+      if (!promise) {
+        promise = create();
 
-      cache.set(key, promise);
-    }
+        // Mark a retained rejection handled so it isn't flagged as unhandled; `use()` still sees it.
+        promise.catch(() => undefined);
+        cache.set(key, promise);
+      }
 
-    return promise;
+      return promise;
+    },
+
+    evict(key) {
+      cache.delete(key);
+    },
   };
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/routing/lib.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/routing/lib.ts
@@ -17,6 +17,7 @@ import {
   createRouter,
 } from "@tanstack/react-router";
 
+import type { RouterHistory } from "@tanstack/react-router";
 import type { IndexRoute, RouteEntry } from "./types";
 
 const HASH_ROUTE_PREFIX_PATTERN = /^[#/]+/u;
@@ -55,10 +56,13 @@ export function getRouteTo(path: string) {
  *
  * @param rootComponent The root component of the extension app.
  * @param routeEntries The route entries for the extension app.
+ * @param history The history implementation to use. Defaults to hash history; pass a memory
+ *   history to get deterministic, seedable navigation (e.g. in tests).
  */
 export function createExtensionRouter(
   rootComponent: React.JSX.Element,
   routeEntries: RouteEntry[],
+  history: RouterHistory = createHashHistory(),
 ) {
   const rootRoute = createRootRoute({
     component: () => rootComponent,
@@ -74,7 +78,7 @@ export function createExtensionRouter(
   );
 
   return createRouter({
-    history: createHashHistory(),
+    history,
     routeTree: rootRoute.addChildren(routes),
   });
 }

--- a/packages/aio-commerce-lib-admin-ui/test/fixtures/exc-app.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/fixtures/exc-app.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { vi } from "vitest";
+
+import type { Runtime } from "@adobe/exc-app";
+
+type RuntimeHandler = (event?: unknown) => void;
+
+/** A fake exc-app runtime plus the handlers it captured, so tests can fire events by name. */
+export type MockRuntime = Runtime & {
+  handlers: Record<string, RuntimeHandler>;
+};
+
+/**
+ * Builds a minimal fake exc-app runtime (an EventEmitter). `@adobe/exc-app` needs the real
+ * Experience Cloud runtime, so this stands in for it. Registered handlers are captured on
+ * `handlers` keyed by event name, so tests can drive an event with e.g.
+ * `runtime.handlers.configuration(payload)` instead of digging through `on.mock.calls`.
+ *
+ * @param overrides - Partial fields to merge over the defaults (e.g. `lastConfigurationPayload`).
+ */
+export function createMockRuntime(
+  overrides: Partial<Runtime> = {},
+): MockRuntime {
+  const handlers: Record<string, RuntimeHandler> = {};
+  const runtime: Runtime = {
+    on: vi.fn((type, handler) => {
+      handlers[type as string] = handler as RuntimeHandler;
+    }),
+    off: vi.fn(),
+    emit: vi.fn(),
+    configured: false,
+    lastConfigurationPayload: null,
+    ...overrides,
+  };
+
+  return Object.assign(runtime, { handlers });
+}

--- a/packages/aio-commerce-lib-admin-ui/test/fixtures/uix-guest.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/fixtures/uix-guest.ts
@@ -12,6 +12,11 @@
 
 import { vi } from "vitest";
 
+export type MockGuestConnectionOverrides = Partial<{
+  host: object;
+  sharedContext: Map<string, unknown>;
+}>;
+
 /**
  * Builds a minimal fake UIX guest connection, matching what `SharedContextProvider`
  * and `useGuestConnection` consume. `@adobe/uix-guest` needs a real uix-host across
@@ -20,14 +25,11 @@ import { vi } from "vitest";
  * @param overrides - Partial fields to merge over the defaults.
  */
 export function createMockGuestConnection(
-  overrides: Partial<{
-    host: object;
-    sharedContext: Map<string, unknown>;
-  }> = {},
+  overrides: MockGuestConnectionOverrides = {},
 ) {
   return {
     host: {},
-    sharedContext: new Map<string, unknown>([["locale", "en_US"]]),
+    sharedContext: new Map<string, unknown>([["theme", "dark"]]),
     addEventListener: vi.fn(() => vi.fn()),
     ...overrides,
   };

--- a/packages/aio-commerce-lib-admin-ui/test/fixtures/uix-guest.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/fixtures/uix-guest.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { vi } from "vitest";
+
+/**
+ * Builds a minimal fake UIX guest connection, matching what `SharedContextProvider`
+ * and `useGuestConnection` consume. `@adobe/uix-guest` needs a real uix-host across
+ * the iframe bridge, so this stands in for the resolved connection object.
+ *
+ * @param overrides - Partial fields to merge over the defaults.
+ */
+export function createMockGuestConnection(
+  overrides: Partial<{
+    host: object;
+    sharedContext: Map<string, unknown>;
+  }> = {},
+) {
+  return {
+    host: {},
+    sharedContext: new Map<string, unknown>([["locale", "en_US"]]),
+    addEventListener: vi.fn(() => vi.fn()),
+    ...overrides,
+  };
+}
+
+/**
+ * Factory for `vi.mock("@adobe/uix-guest", ...)`. `register`/`attach` reach a real
+ * uix-host, so they are the legitimate external boundary to fake. Import the mocked
+ * `attach`/`register` in the test and drive them with `vi.mocked(...).mockResolvedValue`.
+ */
+export function uixGuestMock() {
+  return { register: vi.fn(), attach: vi.fn() };
+}

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/auth/context/ims-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/auth/context/ims-context.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render, renderHook } from "vitest-browser-react";
+
+import { mockConsole } from "#test/utils/console";
+import { stubControlFrame, stubStandaloneFrame } from "#test/utils/frame";
+import {
+  ImsContextProvider,
+  useIms,
+} from "#web/react/auth/context/ims-context.tsx";
+
+import type { ReactNode } from "react";
+
+const CREDENTIALS = { imsToken: "t", imsOrgId: "o" };
+
+let restoreFrame: () => void = () => undefined;
+afterEach(() => {
+  restoreFrame();
+  vi.restoreAllMocks();
+});
+
+describe("useIms", () => {
+  test("throws when used outside an ImsContextProvider", async () => {
+    mockConsole("error");
+    await expect(renderHook(() => useIms())).rejects.toThrow(
+      "useIms must be used inside an ImsContextProvider.",
+    );
+  });
+
+  test("returns the credentials provided by the ImsContextProvider", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ImsContextProvider credentials={CREDENTIALS}>
+        {children}
+      </ImsContextProvider>
+    );
+
+    const { result } = await renderHook(() => useIms(), { wrapper });
+    expect(result.current).toEqual(CREDENTIALS);
+  });
+
+  test("renders children but throws when credentials are null and not embedded", async () => {
+    restoreFrame = stubStandaloneFrame();
+
+    const screen = await render(
+      <ImsContextProvider credentials={null}>
+        <div data-testid="child" />
+      </ImsContextProvider>,
+    );
+
+    await expect.element(screen.getByTestId("child")).toBeInTheDocument();
+
+    mockConsole("error");
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ImsContextProvider credentials={null}>{children}</ImsContextProvider>
+    );
+
+    await expect(renderHook(() => useIms(), { wrapper })).rejects.toThrow(
+      "useIms requires running inside the Commerce Admin or the Experience Cloud shell",
+    );
+  });
+});
+
+describe("ImsContextProvider", () => {
+  test("withholds children while embedded in a host and credentials are null (loading)", async () => {
+    restoreFrame = stubControlFrame();
+
+    const screen = await render(
+      <ImsContextProvider credentials={null}>
+        <div data-testid="child" />
+      </ImsContextProvider>,
+    );
+
+    await expect.element(screen.getByTestId("child")).not.toBeInTheDocument();
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/auth/lib.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/auth/lib.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  resolveCommerceImsCredentials,
+  resolveShellImsCredentials,
+} from "#web/react/auth/lib";
+
+import type { SharedContext } from "#web/react/commerce/types";
+import type { ShellConfiguration } from "#web/react/shell/types";
+
+/** Builds a minimal stand-in for the `SharedContext` map provided by the UIX host. */
+function makeSharedContext(values: Record<string, string>) {
+  const map = new Map(Object.entries(values));
+
+  // @ts-expect-error -- The `SharedContext` class of `@adobe/uix-guest` has private members
+  // and is not exported, so a structural `get` stub is the closest possible stand-in.
+  const sharedContext: SharedContext["sharedContext"] = {
+    get: (key: string) => map.get(key) ?? null,
+  };
+
+  return sharedContext;
+}
+
+describe("resolveCommerceImsCredentials", () => {
+  test("returns the credentials when both values are present", () => {
+    const sharedContext = makeSharedContext({
+      imsToken: "test-token",
+      imsOrgId: "test-org",
+    });
+
+    expect(resolveCommerceImsCredentials(sharedContext)).toEqual({
+      imsToken: "test-token",
+      imsOrgId: "test-org",
+    });
+  });
+
+  test.each([
+    ["imsToken", { imsOrgId: "test-org" }],
+    ["imsOrgId", { imsToken: "test-token" }],
+    ["both values", {}],
+  ])("returns null when %s is missing", (_label, values) => {
+    expect(resolveCommerceImsCredentials(makeSharedContext(values))).toBeNull();
+  });
+});
+
+describe("resolveShellImsCredentials", () => {
+  test("returns null when no shell configuration is available", () => {
+    expect(resolveShellImsCredentials(null)).toBeNull();
+  });
+
+  test("maps the shell configuration to IMS credentials", () => {
+    const shellConfiguration: ShellConfiguration = {
+      imsToken: "t",
+      imsOrg: "o",
+      theme: "light",
+    };
+
+    expect(resolveShellImsCredentials(shellConfiguration)).toEqual({
+      imsToken: "t",
+      imsOrgId: "o",
+    });
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/centered-progress.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/centered-progress.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { CenteredProgress } from "#web/react/centered-progress.tsx";
+
+describe("CenteredProgress", () => {
+  test("renders an indeterminate progress indicator with the given aria-label", async () => {
+    const screen = await render(
+      <CenteredProgress aria-label="Loading extension" />,
+    );
+
+    const progress = screen.getByRole("progressbar", {
+      name: "Loading extension",
+    });
+
+    await expect.element(progress).toBeInTheDocument();
+    await expect.element(progress).not.toHaveAttribute("aria-valuenow");
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/context/shared-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/context/shared-context.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { mockConsole } from "#test/utils/console";
+import { sharedContextProvider } from "#test/utils/shared-context.tsx";
+import { useSharedContext } from "#web/react/commerce/context/shared-context.tsx";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Builds a minimal fake UIX guest connection for the provider. */
+function makeConnection() {
+  return {
+    host: {},
+    sharedContext: new Map([
+      ["imsToken", "t"],
+      ["imsOrgId", "o"],
+    ]),
+
+    addEventListener: vi.fn((_event: string, _onChange: () => void) => vi.fn()),
+  };
+}
+
+describe("useSharedContext", () => {
+  test("throws when used outside a SharedContextProvider", async () => {
+    mockConsole("error");
+    await expect(renderHook(() => useSharedContext())).rejects.toThrow(
+      "useSharedContext must be used inside a SharedContextProvider",
+    );
+  });
+
+  test("returns the extension ID, shared context and host from the provider", async () => {
+    const connection = makeConnection();
+    const { result } = await renderHook(() => useSharedContext(), {
+      wrapper: sharedContextProvider(connection),
+    });
+
+    expect(result.current.extensionId).toBe("ext-1");
+    expect(result.current.sharedContext).toBe(connection.sharedContext);
+    expect(result.current.host).toBe(connection.host);
+  });
+
+  test("re-renders with the new shared context on a contextchange event", async () => {
+    const connection = makeConnection();
+    const { result, act } = await renderHook(() => useSharedContext(), {
+      wrapper: sharedContextProvider(connection),
+    });
+
+    expect(connection.addEventListener).toHaveBeenCalledWith(
+      "contextchange",
+      expect.any(Function),
+    );
+
+    const [, onContextChange] = connection.addEventListener.mock.calls[0];
+    const newSharedContext = new Map([
+      ["imsToken", "t2"],
+      ["imsOrgId", "o2"],
+    ]);
+
+    connection.sharedContext = newSharedContext;
+    await act(() => onContextChange());
+
+    expect(result.current.sharedContext).toBe(newSharedContext);
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render, renderHook } from "vitest-browser-react";
+
+import { mockConsole } from "#test/utils/console";
+import { SharedContextProvider } from "#web/react/commerce/context/shared-context.tsx";
+import { useCommerce } from "#web/react/commerce/hooks/use-commerce";
+
+import type { ReactNode } from "react";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Builds a minimal fake UIX guest connection with the given host object. */
+function makeConnection(host: object) {
+  return {
+    host,
+    sharedContext: new Map<string, unknown>(),
+    addEventListener: vi.fn(() => vi.fn()),
+  };
+}
+
+// The module-level promise cache in `use-commerce` is keyed by `extensionId`,
+// so each test uses a unique ID to avoid cross-test cache hits.
+describe("useCommerce", () => {
+  test("suspends and resolves the Commerce host over the connection, caching the promise", async () => {
+    const getCommerceHost = vi.fn().mockResolvedValue("my-store.example.com");
+    const connection = makeConnection({ integration: { getCommerceHost } });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SharedContextProvider
+        extensionId="ext-use-commerce-happy"
+        // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+        guestConnection={connection}>
+        <Suspense fallback={null}>{children}</Suspense>
+      </SharedContextProvider>
+    );
+
+    const { result } = await renderHook(() => useCommerce(), { wrapper });
+    await vi.waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(result.current.commerceHost).toBe("my-store.example.com");
+    expect(getCommerceHost).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates the error to the error boundary when the host lacks the integration API", async () => {
+    mockConsole("error");
+
+    const connection = makeConnection({});
+    const onError = vi.fn();
+
+    function HookProbe() {
+      useCommerce();
+      return null;
+    }
+
+    await render(
+      <SharedContextProvider
+        extensionId="ext-use-commerce-no-integration"
+        // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+        guestConnection={connection}>
+        <ErrorBoundary fallbackRender={() => null} onError={onError}>
+          <Suspense fallback={null}>
+            <HookProbe />
+          </Suspense>
+        </ErrorBoundary>
+      </SharedContextProvider>,
+    );
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+    const [error] = onError.mock.calls[0] as [Error];
+
+    expect(error.message).toContain(
+      "The host does not provide the integration API",
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { createMockGuestConnection } from "#test/fixtures/uix-guest";
+import { mockConsole } from "#test/utils/console";
+import { sharedContextProvider } from "#test/utils/shared-context.tsx";
+import {
+  useMassActionContext,
+  useOrderViewButtonContext,
+} from "#web/react/commerce/hooks/use-extension-context";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Builds a wrapper with a fake connection exposing the given shared context entries. */
+function provide(entries: Record<string, unknown>) {
+  return sharedContextProvider(
+    createMockGuestConnection({
+      sharedContext: new Map(Object.entries(entries)),
+    }),
+  );
+}
+
+describe("useMassActionContext", () => {
+  test("returns the selected IDs from the shared context", async () => {
+    const { result } = await renderHook(() => useMassActionContext(), {
+      wrapper: provide({ selectedIds: ["1", "2"] }),
+    });
+
+    expect(result.current).toEqual({ selectedIds: ["1", "2"] });
+  });
+
+  test("returns an empty selection when no rows are selected", async () => {
+    const { result } = await renderHook(() => useMassActionContext(), {
+      wrapper: provide({ selectedIds: [] }),
+    });
+
+    expect(result.current).toEqual({ selectedIds: [] });
+  });
+
+  test("throws when the shared context has no selectedIds key", async () => {
+    mockConsole("error");
+    await expect(
+      renderHook(() => useMassActionContext(), { wrapper: provide({}) }),
+    ).rejects.toThrow(
+      "Could not find `selectedIds` in the Commerce shared context",
+    );
+  });
+});
+
+describe("useOrderViewButtonContext", () => {
+  afterEach(() => {
+    history.replaceState(null, "", "/");
+  });
+
+  test("returns the order ID from the URL search params", async () => {
+    window.history.replaceState(null, "", "?orderId=000000123");
+
+    const { result } = await renderHook(() => useOrderViewButtonContext());
+    expect(result.current).toEqual({ orderId: "000000123" });
+  });
+
+  test("returns the order ID from the URL hash", async () => {
+    window.history.replaceState(null, "", "/#/view?orderId=7");
+
+    const { result } = await renderHook(() => useOrderViewButtonContext());
+    expect(result.current).toEqual({ orderId: "7" });
+  });
+
+  test("throws when the URL has no order ID", async () => {
+    mockConsole("error");
+    await expect(renderHook(() => useOrderViewButtonContext())).rejects.toThrow(
+      "Could not find an order ID",
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-guest-connection.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-guest-connection.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { attach } from "@adobe/uix-guest";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render, renderHook } from "vitest-browser-react";
+
+import { createMockGuestConnection } from "#test/fixtures/uix-guest";
+import { mockConsole } from "#test/utils/console";
+import { useGuestConnection } from "#web/react/commerce/hooks/use-guest-connection";
+
+import type { ReactNode } from "react";
+
+vi.mock("@adobe/uix-guest", () => ({ attach: vi.fn() }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  // `attach` is a module mock, not a spy, so `restoreAllMocks` leaves its call history intact;
+  // clear it so per-test call-count assertions don't accumulate across tests.
+  vi.clearAllMocks();
+});
+
+const suspenseWrapper = ({ children }: { children: ReactNode }) => (
+  <Suspense fallback={null}>{children}</Suspense>
+);
+
+// The module-level promise cache in `use-guest-connection` is keyed by `extensionId`,
+// so each test uses a unique ID to avoid cross-test cache hits.
+describe("useGuestConnection", () => {
+  test("suspends and resolves to the attached guest connection", async () => {
+    const connection = createMockGuestConnection({ host: { integration: {} } });
+
+    // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+    vi.mocked(attach).mockResolvedValue(connection);
+    const { result } = await renderHook(
+      () => useGuestConnection("ext-use-guest-happy"),
+      { wrapper: suspenseWrapper },
+    );
+
+    await vi.waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(result.current).toBe(connection);
+    expect(attach).toHaveBeenCalledTimes(1);
+    expect(attach).toHaveBeenCalledWith({ id: "ext-use-guest-happy" });
+  });
+
+  test("reuses the cached promise for the same extensionId across multiple hooks", async () => {
+    const connection = createMockGuestConnection({ host: { integration: {} } });
+
+    // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+    vi.mocked(attach).mockResolvedValue(connection);
+    const first = await renderHook(
+      () => useGuestConnection("ext-use-guest-cached"),
+      { wrapper: suspenseWrapper },
+    );
+
+    const second = await renderHook(
+      () => useGuestConnection("ext-use-guest-cached"),
+      { wrapper: suspenseWrapper },
+    );
+
+    await vi.waitFor(() => expect(first.result.current).not.toBeNull());
+    await vi.waitFor(() => expect(second.result.current).not.toBeNull());
+
+    expect(first.result.current).toBe(connection);
+    expect(second.result.current).toBe(connection);
+    expect(attach).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs and propagates an attach rejection to the error boundary", async () => {
+    const consoleError = mockConsole("error");
+
+    const attachError = new Error("attach boom");
+    vi.mocked(attach).mockRejectedValue(attachError);
+
+    const onError = vi.fn();
+
+    function HookProbe() {
+      useGuestConnection("ext-use-guest-error");
+      return null;
+    }
+
+    await render(
+      <ErrorBoundary fallbackRender={() => null} onError={onError}>
+        <Suspense fallback={null}>
+          <HookProbe />
+        </Suspense>
+      </ErrorBoundary>,
+    );
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+    const [error] = onError.mock.calls[0] as [Error];
+    expect(error).toBe(attachError);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "UIX guest attach failed:",
+      attachError,
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-host-connection.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-host-connection.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { createMockGuestConnection } from "#test/fixtures/uix-guest";
+import { sharedContextProvider } from "#test/utils/shared-context.tsx";
+import { useHostConnection } from "#web/react/commerce/hooks/use-host-connection";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Builds a wrapper with a fake connection exposing the given host object. */
+function provide(host: object) {
+  return sharedContextProvider(createMockGuestConnection({ host }));
+}
+
+describe("useHostConnection", () => {
+  test("invokes the host frame actions when the host provides them", async () => {
+    const field = {
+      close: vi.fn().mockResolvedValue(undefined),
+      onError: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const { result } = await renderHook(() => useHostConnection(), {
+      wrapper: provide({ field }),
+    });
+
+    await result.current.close();
+    expect(field.close).toHaveBeenCalledTimes(1);
+
+    await result.current.closeWithError();
+    expect(field.onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when the host does not provide the frame actions", async () => {
+    const { result } = await renderHook(() => useHostConnection(), {
+      wrapper: provide({}),
+    });
+
+    expect(() => result.current.close()).toThrow(
+      "Host frame actions are unavailable",
+    );
+
+    expect(() => result.current.closeWithError()).toThrow(
+      "Host frame actions are unavailable",
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/lib.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/lib.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { stubControlFrame, stubFrame, stubUiFrame } from "#test/utils/frame";
+import {
+  isControlFrame,
+  isEmbeddedInHost,
+  isUiFrame,
+  parseOrderId,
+} from "#web/react/commerce/lib";
+
+describe("parseOrderId", () => {
+  test.each([
+    ["https://host.test/?orderId=5", "5"],
+    ["https://host.test/#/view?orderId=7", "7"],
+    ["https://host.test/?orderId=5#/view?orderId=7", "5"],
+    ["https://host.test/", null],
+  ])("parses %j to %j", (href, expected) => {
+    expect(parseOrderId(href)).toBe(expected);
+  });
+});
+
+describe("frame detection", () => {
+  let restoreFrame: () => void = () => undefined;
+  afterEach(() => {
+    restoreFrame();
+  });
+
+  test("detects a standalone window as not embedded, ignoring the name", () => {
+    // Not embedded, yet carrying a uix-guest name: the name must be ignored.
+    restoreFrame = stubFrame({ embedded: false, name: "uix-guest-1" });
+
+    expect(isEmbeddedInHost()).toBe(false);
+    expect(isUiFrame()).toBe(false);
+    expect(isControlFrame()).toBe(false);
+  });
+
+  test("detects a UI frame when embedded with a uix-guest name", () => {
+    restoreFrame = stubUiFrame();
+
+    expect(isEmbeddedInHost()).toBe(true);
+    expect(isUiFrame()).toBe(true);
+    expect(isControlFrame()).toBe(false);
+  });
+
+  test("detects a control frame when embedded with an empty name", () => {
+    restoreFrame = stubControlFrame();
+
+    expect(isEmbeddedInHost()).toBe(true);
+    expect(isUiFrame()).toBe(false);
+    expect(isControlFrame()).toBe(true);
+  });
+
+  test("detects neither frame when embedded with an unrelated name", () => {
+    restoreFrame = stubFrame({ embedded: true, name: "other" });
+
+    expect(isEmbeddedInHost()).toBe(true);
+    expect(isUiFrame()).toBe(false);
+    expect(isControlFrame()).toBe(false);
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/commerce-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/commerce-app.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { attach, register } from "@adobe/uix-guest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createMockGuestConnection } from "#test/fixtures/uix-guest";
+import { mockConsole } from "#test/utils/console";
+import { stubControlFrame, stubUiFrame } from "#test/utils/frame";
+import { renderWithRouter } from "#test/utils/router.tsx";
+import { CommerceExtensionApp } from "#web/react/extension/commerce-app.tsx";
+
+import type { RouteEntry } from "#web/react/routing/types";
+
+// @adobe/uix-guest reaches a real uix-host across the iframe bridge; it is the only external boundary faked here.
+vi.mock("@adobe/uix-guest", async () =>
+  (await import("#test/fixtures/uix-guest")).uixGuestMock(),
+);
+
+const ROUTES: RouteEntry[] = [
+  { index: true, element: <div data-testid="route-content" /> },
+];
+
+function mockAttachedConnection() {
+  vi.mocked(attach).mockResolvedValue(
+    // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+    createMockGuestConnection({
+      sharedContext: new Map<string, unknown>([
+        ["imsToken", "t"],
+        ["imsOrgId", "o"],
+      ]),
+    }),
+  );
+}
+
+let restoreFrame: () => void = () => undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  restoreFrame();
+  delete document.documentElement.dataset.colorScheme;
+  vi.restoreAllMocks();
+});
+
+describe("CommerceExtensionApp", () => {
+  test("renders the routed UI frame tree once the guest connection attaches", async () => {
+    restoreFrame = stubUiFrame();
+    mockAttachedConnection();
+
+    const { screen } = await renderWithRouter(
+      <CommerceExtensionApp extensionId="ext-ui" />,
+      { routes: ROUTES },
+    );
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .toBeInTheDocument();
+
+    expect(attach).toHaveBeenCalledWith({ id: "ext-ui" });
+  });
+
+  test("syncs the root color scheme to light on mount", async () => {
+    restoreFrame = stubUiFrame();
+    mockAttachedConnection();
+
+    await renderWithRouter(<CommerceExtensionApp extensionId="ext-color" />, {
+      routes: ROUTES,
+    });
+
+    await vi.waitFor(() =>
+      expect(document.documentElement.dataset.colorScheme).toBe("light"),
+    );
+  });
+
+  test("registers the control frame once per extension id and renders no content", async () => {
+    restoreFrame = stubControlFrame();
+    // @ts-expect-error -- the resolved guest server handle is unused by these tests
+    vi.mocked(register).mockResolvedValue(undefined);
+
+    const { screen } = await renderWithRouter(
+      <CommerceExtensionApp extensionId="ext-cf-memo" />,
+      { routes: ROUTES },
+    );
+
+    await vi.waitFor(() =>
+      expect(register).toHaveBeenCalledWith({
+        id: "ext-cf-memo",
+        methods: {},
+      }),
+    );
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .not.toBeInTheDocument();
+
+    // The registration is memoized per extension id, so a remount must not register again.
+    await renderWithRouter(<CommerceExtensionApp extensionId="ext-cf-memo" />, {
+      routes: ROUTES,
+    });
+
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs when the control frame registration rejects", async () => {
+    const consoleError = mockConsole("error");
+
+    const err = new Error("register failed");
+    vi.mocked(register).mockRejectedValue(err);
+    restoreFrame = stubControlFrame();
+
+    await renderWithRouter(
+      <CommerceExtensionApp extensionId="ext-cf-reject" />,
+      {
+        routes: ROUTES,
+      },
+    );
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "UIX guest register failed:",
+        err,
+      ),
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/create-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/create-app.test.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createMockRuntime } from "#test/fixtures/exc-app";
+import { mockConsole } from "#test/utils/console";
+import { stubShellFrame, stubStandaloneFrame } from "#test/utils/frame";
+import { createExtensionApp } from "#web/react/extension/create-app.tsx";
+
+import type { ExtensionAppRoutes } from "#web/react/routing/types";
+
+// @adobe/exc-app and the runtime loader reach the real Experience Cloud shell/runtime; they are the
+// external boundaries faked here. react-dom, the router, and the Entrypoint all run for real.
+const mocks = vi.hoisted(() => ({
+  runtimeFactory: vi.fn(),
+  init: vi.fn(),
+  page: { title: "", done: vi.fn() },
+  loadExperienceCloudRuntime: vi.fn(),
+  createMockRuntime: vi.fn(),
+}));
+
+// The real `@adobe/exc-app` is CJS: the browser's ESM interop resolves the default import to the whole
+// module object, so the mock's `default` must be the callable module itself.
+vi.mock("@adobe/exc-app", () =>
+  Object.assign(mocks.runtimeFactory, {
+    init: mocks.init,
+    default: mocks.runtimeFactory,
+  }),
+);
+
+vi.mock("@adobe/exc-app/page", () =>
+  Object.assign(mocks.page, { default: mocks.page }),
+);
+
+vi.mock("#web/runtime-loader", () => ({
+  createMockRuntime: mocks.createMockRuntime,
+  loadExperienceCloudRuntime: mocks.loadExperienceCloudRuntime,
+}));
+
+const ROUTES: ExtensionAppRoutes = [
+  { index: true, element: <div data-testid="route-content" /> },
+];
+const OPTIONS = { metadata: { extensionId: "ext-1" }, routes: ROUTES };
+
+let restoreFrame: () => void = () => undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.page.done.mockResolvedValue(undefined);
+  mocks.loadExperienceCloudRuntime.mockReturnValue(undefined);
+
+  document.body.innerHTML = '<div id="root"></div>';
+  restoreFrame = stubStandaloneFrame();
+});
+
+afterEach(() => {
+  restoreFrame();
+
+  delete document.documentElement.dataset.colorScheme;
+  document.body.innerHTML = "";
+
+  vi.restoreAllMocks();
+});
+
+describe("createExtensionApp", () => {
+  test("throws when no #root element exists and no root option is given", () => {
+    document.body.innerHTML = "";
+    expect(() => createExtensionApp(OPTIONS)).toThrow(
+      'Could not find an element with id "root".',
+    );
+  });
+
+  test("uses the provided root option without querying the DOM for #root", async () => {
+    const getById = vi.spyOn(document, "getElementById");
+    const root = document.createElement("div");
+    document.body.append(root);
+
+    // no shell runtime, so it renders the standalone app immediately.
+    mocks.createMockRuntime.mockReturnValue(createMockRuntime());
+    mocks.loadExperienceCloudRuntime.mockImplementation(() => {
+      throw new Error("no shell");
+    });
+
+    createExtensionApp({ ...OPTIONS, root });
+    expect(getById).not.toHaveBeenCalled();
+
+    await vi.waitFor(() =>
+      expect(
+        root.querySelector('[data-testid="route-content"]'),
+      ).not.toBeNull(),
+    );
+  });
+
+  test("renders through the shell path and registers a ready handler", () => {
+    const runtime = createMockRuntime();
+    mocks.runtimeFactory.mockReturnValue(runtime);
+    mocks.init.mockImplementation((cb: () => void) => cb());
+
+    createExtensionApp(OPTIONS);
+
+    expect(runtime.on).toHaveBeenCalledWith("ready", expect.any(Function));
+    expect(mocks.page.title).toBe(document.title);
+  });
+
+  test("resolves with the ready payload, marks the page done, and applies its theme", async () => {
+    // The shell flow only renders when embedded in the Experience Cloud shell.
+    restoreFrame();
+    restoreFrame = stubShellFrame();
+
+    const runtime = createMockRuntime();
+    mocks.runtimeFactory.mockReturnValue(runtime);
+    mocks.init.mockImplementation((cb: () => void) => cb());
+
+    createExtensionApp(OPTIONS);
+    runtime.handlers.ready({ imsOrg: "o", imsToken: "t", theme: "light" });
+
+    await vi.waitFor(() =>
+      expect(document.documentElement.dataset.colorScheme).toBe("light"),
+    );
+
+    expect(mocks.page.done).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the runtime's last configuration payload when ready has no payload", async () => {
+    // The shell flow only renders when embedded in the Experience Cloud shell.
+    restoreFrame();
+    restoreFrame = stubShellFrame();
+
+    const runtime = createMockRuntime({
+      // @ts-expect-error -- partial config data cannot satisfy the exc-app RuntimeConfiguration type
+      lastConfigurationPayload: { imsOrg: "o", imsToken: "t", theme: "dark" },
+    });
+
+    mocks.runtimeFactory.mockReturnValue(runtime);
+    mocks.init.mockImplementation((cb: () => void) => cb());
+
+    createExtensionApp(OPTIONS);
+    runtime.handlers.ready(undefined);
+
+    await vi.waitFor(() =>
+      expect(document.documentElement.dataset.colorScheme).toBe("dark"),
+    );
+  });
+
+  test("warns when marking the page done fails", async () => {
+    const warn = mockConsole("warn");
+    mocks.page.done.mockRejectedValue(new Error("shell gone"));
+
+    const runtime = createMockRuntime();
+    mocks.runtimeFactory.mockReturnValue(runtime);
+    mocks.init.mockImplementation((cb: () => void) => cb());
+
+    createExtensionApp(OPTIONS);
+    runtime.handlers.ready(undefined);
+
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        "Failed to mark page as done in Experience Cloud Shell.",
+      ),
+    );
+  });
+
+  test("renders with a mock runtime and no configuration when the shell runtime fails to load", async () => {
+    mocks.createMockRuntime.mockReturnValue(createMockRuntime());
+    mocks.loadExperienceCloudRuntime.mockImplementation(() => {
+      throw new Error("no shell");
+    });
+
+    createExtensionApp(OPTIONS);
+
+    expect(mocks.createMockRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.init).not.toHaveBeenCalled();
+
+    await vi.waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="route-content"]'),
+      ).not.toBeNull(),
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/entrypoint.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/entrypoint.test.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { attach, register } from "@adobe/uix-guest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createMockRuntime } from "#test/fixtures/exc-app";
+import { createMockGuestConnection } from "#test/fixtures/uix-guest";
+import {
+  stubControlFrame,
+  stubShellFrame,
+  stubStandaloneFrame,
+  stubUiFrame,
+} from "#test/utils/frame";
+import { renderWithRouter } from "#test/utils/router.tsx";
+import { Entrypoint } from "#web/react/extension/entrypoint.tsx";
+
+import type { RuntimeConfiguration } from "@adobe/exc-app";
+import type { RouteEntry } from "#web/react/routing/types";
+
+// @adobe/uix-guest reaches a real uix-host across the iframe bridge; it is the only external boundary faked here.
+vi.mock("@adobe/uix-guest", async () =>
+  (await import("#test/fixtures/uix-guest")).uixGuestMock(),
+);
+
+const ROUTES: RouteEntry[] = [
+  { index: true, element: <div data-testid="route-content" /> },
+];
+
+function renderEntrypoint(
+  extensionId: string,
+  runtime: ReturnType<typeof createMockRuntime>,
+  initialConfigurationPromise: Promise<RuntimeConfiguration | null> | null,
+) {
+  return renderWithRouter(
+    <Entrypoint
+      extensionId={extensionId}
+      initialConfigurationPromise={initialConfigurationPromise}
+      runtime={runtime}
+    />,
+    { routes: ROUTES },
+  );
+}
+
+let restoreFrame: () => void = () => undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  restoreFrame();
+  vi.restoreAllMocks();
+});
+
+describe("Entrypoint", () => {
+  test("renders the Commerce app (UI frame) and attaches the guest connection", async () => {
+    restoreFrame = stubUiFrame();
+
+    vi.mocked(attach).mockResolvedValue(
+      // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+      createMockGuestConnection({
+        sharedContext: new Map<string, unknown>([
+          // Both IMS keys are required, else the IMS provider withholds children and content never renders.
+          ["imsToken", "t"],
+          ["imsOrgId", "o"],
+        ]),
+      }),
+    );
+
+    const { screen } = await renderEntrypoint(
+      "ext-ui",
+      createMockRuntime(),
+      null,
+    );
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .toBeInTheDocument();
+
+    expect(attach).toHaveBeenCalledWith({ id: "ext-ui" });
+  });
+
+  test("renders the Commerce app (control frame) which registers and shows no content", async () => {
+    restoreFrame = stubControlFrame();
+
+    // @ts-expect-error -- the resolved guest server handle is unused by these tests
+    vi.mocked(register).mockResolvedValue(undefined);
+    const { screen } = await renderEntrypoint(
+      "ext-control",
+      createMockRuntime(),
+      Promise.resolve(null),
+    );
+
+    await vi.waitFor(() =>
+      expect(register).toHaveBeenCalledWith({ id: "ext-control", methods: {} }),
+    );
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .not.toBeInTheDocument();
+  });
+
+  test("renders the standalone app when not embedded with no configuration promise", async () => {
+    restoreFrame = stubStandaloneFrame();
+
+    const runtime = createMockRuntime();
+    const { screen } = await renderEntrypoint("ext-standalone", runtime, null);
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .toBeInTheDocument();
+
+    expect(attach).not.toHaveBeenCalled();
+    expect(runtime.on).not.toHaveBeenCalled();
+  });
+
+  test("renders the Experience Cloud shell app, subscribing to the runtime", async () => {
+    restoreFrame = stubShellFrame();
+
+    const runtime = createMockRuntime();
+    const promise: Promise<RuntimeConfiguration | null> = Promise.resolve({
+      imsOrg: "o",
+      imsToken: "t",
+      theme: "light",
+    } as RuntimeConfiguration);
+
+    const { screen } = await renderEntrypoint("ext-shell", runtime, promise);
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .toBeInTheDocument();
+
+    expect(runtime.on).toHaveBeenCalled();
+    expect(attach).not.toHaveBeenCalled();
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/error-boundary.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/error-boundary.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { mockConsole } from "#test/utils/console";
+import { renderWithRouter } from "#test/utils/router.tsx";
+import { ExtensionErrorBoundary } from "#web/react/extension/error-boundary.tsx";
+
+/** A child component that throws the given value on render. */
+function ThrowingChild({ error }: { error: unknown }): never {
+  throw error;
+}
+
+describe("ExtensionErrorBoundary", () => {
+  beforeEach(() => {
+    mockConsole("error");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders an Error's message in the fallback", async () => {
+    const { screen } = await renderWithRouter(
+      <ExtensionErrorBoundary>
+        <ThrowingChild error={new Error("boom")} />
+      </ExtensionErrorBoundary>,
+    );
+
+    await expect.element(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  test("renders a thrown string verbatim in the fallback", async () => {
+    const { screen } = await renderWithRouter(
+      <ExtensionErrorBoundary>
+        <ThrowingChild error="just a string" />
+      </ExtensionErrorBoundary>,
+    );
+
+    await expect.element(screen.getByText("just a string")).toBeInTheDocument();
+  });
+
+  test("renders a generic message for a non-error, non-string value", async () => {
+    const { screen } = await renderWithRouter(
+      <ExtensionErrorBoundary>
+        <ThrowingChild error={42} />
+      </ExtensionErrorBoundary>,
+    );
+
+    await expect
+      .element(screen.getByText("An unexpected error occurred."))
+      .toBeInTheDocument();
+  });
+
+  test("hides the 'Go back' button when the router cannot go back", async () => {
+    // A single history entry means there is nowhere to go back to.
+    const { screen } = await renderWithRouter(
+      <ExtensionErrorBoundary>
+        <ThrowingChild error={new Error("boom")} />
+      </ExtensionErrorBoundary>,
+      { initialEntries: ["/"] },
+    );
+
+    await expect.element(screen.getByText("boom")).toBeInTheDocument();
+    await expect.element(screen.getByText("Go back")).not.toBeInTheDocument();
+  });
+
+  test("shows the 'Go back' button and navigates back on press when possible", async () => {
+    // A seeded history stack makes useCanGoBack() genuinely true.
+    const { screen, router } = await renderWithRouter(
+      <ExtensionErrorBoundary>
+        <ThrowingChild error={new Error("boom")} />
+      </ExtensionErrorBoundary>,
+      { initialEntries: ["/first", "/second"] },
+    );
+
+    expect(router.state.location.pathname).toBe("/second");
+    await screen.getByText("Go back").click();
+
+    await vi.waitFor(() =>
+      expect(router.state.location.pathname).toBe("/first"),
+    );
+  });
+
+  test("recovers via 'Try again' by resetting the error boundary", async () => {
+    // The flag lives outside the component so it survives the reset remount.
+    let shouldThrow = true;
+    function ToggleChild() {
+      if (shouldThrow) {
+        throw new Error("boom");
+      }
+
+      return <div>recovered</div>;
+    }
+
+    const { screen } = await renderWithRouter(
+      <ExtensionErrorBoundary>
+        <ToggleChild />
+      </ExtensionErrorBoundary>,
+    );
+
+    await expect.element(screen.getByText("boom")).toBeInTheDocument();
+    shouldThrow = false;
+
+    await screen.getByText("Try again").click();
+    await expect.element(screen.getByText("recovered")).toBeInTheDocument();
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/experience-shell-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/experience-shell-app.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createMockRuntime } from "#test/fixtures/exc-app";
+import { stubShellFrame } from "#test/utils/frame";
+import { renderWithRouter } from "#test/utils/router.tsx";
+import { ExperienceShellExtensionApp } from "#web/react/extension/experience-shell-app.tsx";
+
+import type { RuntimeConfiguration } from "@adobe/exc-app";
+import type { RouteEntry } from "#web/react/routing/types";
+
+const ROUTES: RouteEntry[] = [
+  { index: true, element: <div data-testid="route-content" /> },
+];
+
+// The runtime is the exc-app boundary; a minimal fake EventEmitter is enough.
+const runtime = createMockRuntime();
+
+function renderApp(
+  initialConfigurationPromise: Promise<RuntimeConfiguration | null>,
+) {
+  return renderWithRouter(
+    <ExperienceShellExtensionApp
+      initialConfigurationPromise={initialConfigurationPromise}
+      runtime={runtime}
+    />,
+    { routes: ROUTES },
+  );
+}
+
+let restoreFrame: () => void = () => undefined;
+
+beforeEach(() => {
+  // The shell runs embedded; the IMS provider renders children once credentials resolve.
+  restoreFrame = stubShellFrame();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  restoreFrame();
+  delete document.documentElement.dataset.colorScheme;
+  vi.restoreAllMocks();
+});
+
+describe("ExperienceShellExtensionApp", () => {
+  test("shows the shell fallback while the configuration promise is pending", async () => {
+    const { screen } = await renderApp(new Promise(() => undefined));
+    await expect
+      .element(
+        screen.getByRole("progressbar", {
+          name: "Loading experience cloud runtime",
+        }),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("renders the routed content and applies the theme once the promise resolves", async () => {
+    const { screen } = await renderApp(
+      Promise.resolve({
+        imsOrg: "o",
+        imsToken: "t",
+        theme: "dark",
+      } as RuntimeConfiguration),
+    );
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .toBeInTheDocument();
+
+    expect(document.documentElement.dataset.colorScheme).toBe("dark");
+    expect(runtime.on).toHaveBeenCalledWith(
+      "configuration",
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/standalone-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/standalone-app.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { stubStandaloneFrame } from "#test/utils/frame";
+import { renderWithRouter } from "#test/utils/router.tsx";
+import { StandaloneExtensionApp } from "#web/react/extension/standalone-app.tsx";
+
+import type { RouteEntry } from "#web/react/routing/types";
+
+const ROUTES: RouteEntry[] = [
+  { index: true, element: <div data-testid="route-content" /> },
+];
+
+let restoreFrame: () => void = () => undefined;
+
+beforeEach(() => {
+  // Standalone means no host frame: the IMS provider then renders children with null credentials.
+  restoreFrame = stubStandaloneFrame();
+});
+
+afterEach(() => {
+  restoreFrame();
+  delete document.documentElement.dataset.colorScheme;
+});
+
+describe("StandaloneExtensionApp", () => {
+  test("renders the routed content and clears the root color scheme on mount", async () => {
+    document.documentElement.dataset.colorScheme = "stale";
+
+    const { screen } = await renderWithRouter(<StandaloneExtensionApp />, {
+      routes: ROUTES,
+    });
+
+    await expect
+      .element(screen.getByTestId("route-content"))
+      .toBeInTheDocument();
+
+    expect(document.documentElement.dataset.colorScheme).toBeUndefined();
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
@@ -64,13 +64,27 @@ describe("createRetryablePromiseCache", () => {
     expect(second).toBe(first);
     expect(create).toHaveBeenCalledTimes(1);
 
-    // Evicting drops the entry, so the next lookup retries.
-    cache.evict("key");
+    // evictIfRejected drops the failed entry, so the next lookup retries.
+    cache.evictIfRejected("key");
     const third = cache.get("key", create);
 
     expect(third).not.toBe(first);
     expect(create).toHaveBeenCalledTimes(2);
 
     await expect(third).resolves.toBe("recovered");
+  });
+
+  test("evictIfRejected keeps a resolved promise", async () => {
+    const cache = createRetryablePromiseCache<string>();
+    const create = vi.fn(() => Promise.resolve("value"));
+
+    const first = cache.get("key", create);
+    await expect(first).resolves.toBe("value");
+
+    cache.evictIfRejected("key");
+    const second = cache.get("key", create);
+
+    expect(second).toBe(first);
+    expect(create).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
@@ -16,53 +16,61 @@ import { createRetryablePromiseCache } from "#web/react/promise-cache";
 
 describe("createRetryablePromiseCache", () => {
   test("returns the identical promise for the same key and runs create once", () => {
-    const getOrCreate = createRetryablePromiseCache<string>();
+    const cache = createRetryablePromiseCache<string>();
     const create = vi.fn(() => Promise.resolve("value"));
 
-    const first = getOrCreate("key", create);
-    const second = getOrCreate("key", create);
+    const first = cache.get("key", create);
+    const second = cache.get("key", create);
 
     expect(second).toBe(first);
     expect(create).toHaveBeenCalledTimes(1);
   });
 
   test("creates separate promises for different keys", () => {
-    const getOrCreate = createRetryablePromiseCache<string>();
+    const cache = createRetryablePromiseCache<string>();
     const create = vi.fn(() => Promise.resolve("value"));
 
-    const first = getOrCreate("first", create);
-    const second = getOrCreate("second", create);
+    const first = cache.get("first", create);
+    const second = cache.get("second", create);
 
     expect(second).not.toBe(first);
     expect(create).toHaveBeenCalledTimes(2);
   });
 
   test("keeps a resolved promise cached", async () => {
-    const getOrCreate = createRetryablePromiseCache<string>();
+    const cache = createRetryablePromiseCache<string>();
     const create = vi.fn(() => Promise.resolve("value"));
 
-    const first = getOrCreate("key", create);
+    const first = cache.get("key", create);
     await expect(first).resolves.toBe("value");
 
-    const second = getOrCreate("key", create);
+    const second = cache.get("key", create);
     expect(second).toBe(first);
     expect(create).toHaveBeenCalledTimes(1);
   });
 
-  test("evicts a rejected promise so the next lookup retries", async () => {
-    const getOrCreate = createRetryablePromiseCache<string>();
+  test("keeps a rejected promise cached until it is evicted", async () => {
+    const cache = createRetryablePromiseCache<string>();
     const create = vi
       .fn<() => Promise<string>>()
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce("recovered");
 
-    const first = getOrCreate("key", create);
+    const first = cache.get("key", create);
     await expect(first).rejects.toThrow("boom");
 
-    const second = getOrCreate("key", create);
-    expect(second).not.toBe(first);
+    // The rejection stays cached, so a later lookup replays it without re-running create.
+    const second = cache.get("key", create);
+    expect(second).toBe(first);
+    expect(create).toHaveBeenCalledTimes(1);
+
+    // Evicting drops the entry, so the next lookup retries.
+    cache.evict("key");
+    const third = cache.get("key", create);
+
+    expect(third).not.toBe(first);
     expect(create).toHaveBeenCalledTimes(2);
 
-    await expect(second).resolves.toBe("recovered");
+    await expect(third).resolves.toBe("recovered");
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+import { createRetryablePromiseCache } from "#web/react/promise-cache";
+
+describe("createRetryablePromiseCache", () => {
+  test("returns the identical promise for the same key and runs create once", () => {
+    const getOrCreate = createRetryablePromiseCache<string>();
+    const create = vi.fn(() => Promise.resolve("value"));
+
+    const first = getOrCreate("key", create);
+    const second = getOrCreate("key", create);
+
+    expect(second).toBe(first);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates separate promises for different keys", () => {
+    const getOrCreate = createRetryablePromiseCache<string>();
+    const create = vi.fn(() => Promise.resolve("value"));
+
+    const first = getOrCreate("first", create);
+    const second = getOrCreate("second", create);
+
+    expect(second).not.toBe(first);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  test("keeps a resolved promise cached", async () => {
+    const getOrCreate = createRetryablePromiseCache<string>();
+    const create = vi.fn(() => Promise.resolve("value"));
+
+    const first = getOrCreate("key", create);
+    await expect(first).resolves.toBe("value");
+
+    const second = getOrCreate("key", create);
+    expect(second).toBe(first);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test("evicts a rejected promise so the next lookup retries", async () => {
+    const getOrCreate = createRetryablePromiseCache<string>();
+    const create = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("recovered");
+
+    const first = getOrCreate("key", create);
+    await expect(first).rejects.toThrow("boom");
+
+    const second = getOrCreate("key", create);
+    expect(second).not.toBe(first);
+    expect(create).toHaveBeenCalledTimes(2);
+
+    await expect(second).resolves.toBe("recovered");
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/hooks/use-spectrum-router.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/hooks/use-spectrum-router.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { renderHookWithRouter } from "#test/utils/router.tsx";
+import { useSpectrumRouter } from "#web/react/routing/hooks/use-spectrum-router";
+
+import type { RouteEntry } from "#web/react/routing/types";
+
+const ROUTES: RouteEntry[] = [
+  { index: true, element: null },
+  { path: "settings", element: null },
+  { path: "bar", element: null },
+];
+
+describe("useSpectrumRouter", () => {
+  describe("navigate", () => {
+    test("maps a string href through getRouteTo and navigates", async () => {
+      const { result, router } = await renderHookWithRouter(
+        () => useSpectrumRouter(),
+        { routes: ROUTES },
+      );
+
+      // The leading hash is stripped by the real getRouteTo, proving strings are transformed.
+      await result.current.navigate("#/settings");
+      expect(router.state.location.pathname).toBe("/settings");
+    });
+
+    test("passes an object href through unchanged and navigates", async () => {
+      const { result, router } = await renderHookWithRouter(
+        () => useSpectrumRouter(),
+        { routes: ROUTES },
+      );
+
+      await result.current.navigate({ to: "/bar" });
+      expect(router.state.location.pathname).toBe("/bar");
+    });
+  });
+
+  describe("useHref", () => {
+    test("maps a string href through getRouteTo and returns the built href", async () => {
+      const { result } = await renderHookWithRouter(() => useSpectrumRouter(), {
+        routes: ROUTES,
+      });
+
+      expect(result.current.useHref("#/settings")).toBe("/settings");
+    });
+
+    test("passes an object href through unchanged and returns the built href", async () => {
+      const { result } = await renderHookWithRouter(() => useSpectrumRouter(), {
+        routes: ROUTES,
+      });
+
+      expect(result.current.useHref({ to: "/bar" })).toBe("/bar");
+    });
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/lib.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/lib.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Outlet as ActiveRoute, RouterProvider } from "@tanstack/react-router";
+import { describe, expect, test } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { createExtensionRouter, getRouteTo } from "#web/react/routing/lib";
+
+describe("getRouteTo", () => {
+  test.each([
+    ["#/foo", "/foo"],
+    ["/foo", "/foo"],
+    ["foo/bar", "/foo/bar"],
+    ["", "/"],
+    ["#/", "/"],
+  ])("converts %j to %j", (path, expected) => {
+    expect(getRouteTo(path)).toBe(expected);
+  });
+});
+
+describe("createExtensionRouter", () => {
+  test("builds a router with the index and hash-stripped route paths", () => {
+    const router = createExtensionRouter(<div />, [
+      { index: true, element: <div>home</div> },
+      { path: "#/settings", element: <div>settings</div> },
+    ]);
+
+    const paths = Object.keys(router.routesByPath);
+    expect(paths).toContain("/");
+    expect(paths).toContain("/settings");
+    expect(paths).not.toContain("/#/settings");
+  });
+
+  test("renders the root component and the matched route element", async () => {
+    const router = createExtensionRouter(<ActiveRoute />, [
+      { index: true, element: <div>home</div> },
+    ]);
+
+    const screen = await render(<RouterProvider router={router} />);
+    await expect.element(screen.getByText("home")).toBeInTheDocument();
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/shell/hooks/use-extension-color-scheme.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/shell/hooks/use-extension-color-scheme.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { useExtensionColorScheme } from "#web/react/shell/hooks/use-extension-color-scheme";
+
+import type { ShellConfiguration } from "#web/react/shell/types";
+
+const BASE: Omit<ShellConfiguration, "theme"> = {
+  imsOrg: "org@AdobeOrg",
+  imsToken: "token",
+};
+
+afterEach(() => {
+  delete document.documentElement.dataset.colorScheme;
+});
+
+describe("useExtensionColorScheme", () => {
+  test("derives the scheme from the configuration theme and syncs the root attribute", async () => {
+    const { result } = await renderHook(() =>
+      useExtensionColorScheme({ ...BASE, theme: "dark" }),
+    );
+
+    expect(result.current).toBe("dark");
+    expect(document.documentElement.dataset.colorScheme).toBe("dark");
+  });
+
+  test("returns undefined and clears the root attribute when the configuration is null", async () => {
+    const { result } = await renderHook(() => useExtensionColorScheme(null));
+
+    expect(result.current).toBeUndefined();
+    expect(document.documentElement.dataset.colorScheme).toBeUndefined();
+  });
+
+  test("re-syncs only when the derived scheme changes", async () => {
+    const { result, rerender } = await renderHook(
+      ({ theme }: { theme: string } = { theme: "light" }) =>
+        useExtensionColorScheme({ ...BASE, theme }),
+      { initialProps: { theme: "light" } },
+    );
+
+    expect(document.documentElement.dataset.colorScheme).toBe("light");
+
+    // A different theme value that maps to the same scheme must not re-run the effect:
+    // the sentinel we write here should survive the rerender.
+    document.documentElement.dataset.colorScheme = "sentinel";
+    await rerender({ theme: "spectrum--lightest" });
+
+    expect(result.current).toBe("light");
+    expect(document.documentElement.dataset.colorScheme).toBe("sentinel");
+
+    // A theme that changes the derived scheme re-runs the effect and overwrites the attribute.
+    await rerender({ theme: "dark" });
+    expect(document.documentElement.dataset.colorScheme).toBe("dark");
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/shell/hooks/use-shell-configuration.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/shell/hooks/use-shell-configuration.test.tsx
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createMockRuntime } from "#test/fixtures/exc-app";
+import { renderHookWithRouter } from "#test/utils/router.tsx";
+import { useShellConfiguration } from "#web/react/shell/hooks/use-shell-configuration";
+
+import type { RouteEntry } from "#web/react/routing/types";
+
+const CURRENT_PATHNAME = "/current";
+
+const ROUTES: RouteEntry[] = [
+  { index: true, element: null },
+  { path: "current", element: null },
+  { path: "other", element: null },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useShellConfiguration", () => {
+  test("derives the initial state from the initial configuration", async () => {
+    const runtime = createMockRuntime();
+    const initial = {
+      imsOrg: "org@AdobeOrg",
+      imsToken: "token",
+      theme: "dark",
+      locale: "en-US",
+    };
+
+    const { result } = await renderHookWithRouter(() =>
+      // @ts-expect-error -- fakes cannot satisfy the exc-app Runtime/RuntimeConfiguration types
+      useShellConfiguration(runtime, initial),
+    );
+
+    expect(result.current).toEqual({
+      imsOrg: "org@AdobeOrg",
+      imsToken: "token",
+      theme: "dark",
+    });
+  });
+
+  test("starts with a null state when no initial configuration is provided", async () => {
+    const runtime = createMockRuntime();
+    const { result } = await renderHookWithRouter(() =>
+      useShellConfiguration(runtime, null),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  test("ignores a falsy configuration event and keeps the previous state", async () => {
+    const runtime = createMockRuntime();
+    const { result } = await renderHookWithRouter(() =>
+      useShellConfiguration(runtime, null),
+    );
+
+    runtime.handlers.configuration(undefined);
+    expect(result.current).toBeNull();
+  });
+
+  test("updates the state on a truthy configuration event", async () => {
+    const runtime = createMockRuntime();
+    const { result } = await renderHookWithRouter(() =>
+      useShellConfiguration(runtime, null),
+    );
+
+    runtime.handlers.configuration({
+      imsOrg: "org@AdobeOrg",
+      imsToken: "token",
+      theme: "light",
+      locale: "en-US",
+    });
+
+    await vi.waitFor(() =>
+      expect(result.current).toEqual({
+        imsOrg: "org@AdobeOrg",
+        imsToken: "token",
+        theme: "light",
+      }),
+    );
+  });
+
+  test("navigates on an external history event to a different route", async () => {
+    const runtime = createMockRuntime();
+    const { router } = await renderHookWithRouter(
+      () => useShellConfiguration(runtime, null),
+      { routes: ROUTES, initialEntries: [CURRENT_PATHNAME] },
+    );
+
+    runtime.handlers.history({ type: "external", path: "/other" });
+
+    await vi.waitFor(() =>
+      expect(router.state.location.pathname).toBe("/other"),
+    );
+  });
+
+  test("skips navigation when the target route matches the current pathname", async () => {
+    const runtime = createMockRuntime();
+    const { router } = await renderHookWithRouter(
+      () => useShellConfiguration(runtime, null),
+      { routes: ROUTES, initialEntries: [CURRENT_PATHNAME] },
+    );
+
+    const navigate = vi.spyOn(router, "navigate");
+    runtime.handlers.history({ type: "external", path: CURRENT_PATHNAME });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test("ignores non-external history events", async () => {
+    const runtime = createMockRuntime();
+    const { router } = await renderHookWithRouter(
+      () => useShellConfiguration(runtime, null),
+      { routes: ROUTES, initialEntries: [CURRENT_PATHNAME] },
+    );
+
+    const navigate = vi.spyOn(router, "navigate");
+    runtime.handlers.history({ type: "internal", path: "/other" });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test("ignores history events without a string path", async () => {
+    const runtime = createMockRuntime();
+    const { router } = await renderHookWithRouter(
+      () => useShellConfiguration(runtime, null),
+      { routes: ROUTES, initialEntries: [CURRENT_PATHNAME] },
+    );
+
+    const navigate = vi.spyOn(router, "navigate");
+    runtime.handlers.history({ type: "external" });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test("subscribes on mount and unsubscribes on unmount", async () => {
+    const runtime = createMockRuntime();
+    const { screen } = await renderHookWithRouter(() =>
+      useShellConfiguration(runtime, null),
+    );
+
+    expect(runtime.on).toHaveBeenCalledWith("history", expect.any(Function));
+    expect(runtime.on).toHaveBeenCalledWith(
+      "configuration",
+      expect.any(Function),
+    );
+
+    await screen.unmount();
+    expect(runtime.off).toHaveBeenCalledWith(
+      "configuration",
+      expect.any(Function),
+    );
+
+    expect(runtime.off).toHaveBeenCalledWith("history", expect.any(Function));
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/theme.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/theme.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { getShellColorScheme, syncRootColorScheme } from "#web/react/theme";
+
+describe("getShellColorScheme", () => {
+  test.each([
+    ["dark", "dark"],
+    ["spectrum--darkest", "dark"],
+    ["light", "light"],
+    ["spectrum--lightest", "light"],
+    ["unknown", undefined],
+    [null, undefined],
+    [undefined, undefined],
+  ] as const)("maps %j to %j", (theme, expected) => {
+    expect(getShellColorScheme(theme)).toBe(expected);
+  });
+});
+
+describe("syncRootColorScheme", () => {
+  afterEach(() => {
+    delete document.documentElement.dataset.colorScheme;
+  });
+
+  test("sets the root color scheme attribute", () => {
+    syncRootColorScheme("dark");
+    expect(document.documentElement.dataset.colorScheme).toBe("dark");
+  });
+
+  test("removes the root color scheme attribute when undefined", () => {
+    syncRootColorScheme("light");
+    syncRootColorScheme(undefined);
+
+    expect(document.documentElement.dataset.colorScheme).toBeUndefined();
+    expect(document.documentElement.hasAttribute("data-color-scheme")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/utils/console.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/console.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { vi } from "vitest";
+
+/**
+ * Silences a console method for the test and returns the spy, so callers can also assert on what
+ * was logged. Use for tests that intentionally trigger expected logging (e.g. error-boundary throws).
+ *
+ * @param method - The console method to silence.
+ */
+export function mockConsole(method: "error" | "warn" | "log") {
+  return vi.spyOn(console, method).mockImplementation(() => undefined);
+}

--- a/packages/aio-commerce-lib-admin-ui/test/utils/frame.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/frame.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** Frame modes recognized by the extension entrypoint. */
+export type FrameMode = "ui" | "control" | "standalone" | "shell";
+
+const ORIGINAL_PARENT = globalThis.window.parent;
+
+function setParent(parent: Window) {
+  Object.defineProperty(globalThis.window, "parent", {
+    value: parent,
+    configurable: true,
+  });
+}
+
+/**
+ * Drives the real frame detection (`#web/react/commerce/lib`) by setting
+ * `window.parent`/`window.name` instead of mocking the module. Browser mode runs
+ * tests in an iframe, so `window.parent !== window` by default — the standalone and
+ * shell cases must explicitly pin `window.parent` back to `window`.
+ *
+ * Pair with {@link restoreFrame} in an `afterEach`.
+ *
+ * @param mode - Which frame the app should detect.
+ */
+export function stubFrame(mode: FrameMode) {
+  switch (mode) {
+    case "ui":
+      setParent({} as Window);
+      globalThis.window.name = "uix-guest-1";
+      break;
+    case "control":
+      setParent({} as Window);
+      globalThis.window.name = "";
+      break;
+    case "standalone":
+    case "shell":
+      setParent(globalThis.window);
+      globalThis.window.name = "";
+      break;
+    default:
+      throw new Error(`Unknown frame mode: ${mode}`);
+  }
+}
+
+/** Restores `window.parent`/`window.name` after a {@link stubFrame} call. */
+export function restoreFrame() {
+  setParent(ORIGINAL_PARENT);
+  globalThis.window.name = "";
+}

--- a/packages/aio-commerce-lib-admin-ui/test/utils/frame.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/frame.ts
@@ -10,11 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/** Frame modes recognized by the extension entrypoint. */
-export type FrameMode = "ui" | "control" | "standalone" | "shell";
-
-const ORIGINAL_PARENT = globalThis.window.parent;
-
 function setParent(parent: Window) {
   Object.defineProperty(globalThis.window, "parent", {
     value: parent,
@@ -22,38 +17,54 @@ function setParent(parent: Window) {
   });
 }
 
+/** The two orthogonal axes that drive frame detection in `#web/react/commerce/lib`. */
+type FrameOptions = {
+  /** Whether the app runs inside a host frame (`window.parent !== window`). */
+  embedded: boolean;
+  /** The `window.name` the host assigns; a `uix-guest-*` name marks a UI frame. */
+  name?: string;
+};
+
 /**
- * Drives the real frame detection (`#web/react/commerce/lib`) by setting
- * `window.parent`/`window.name` instead of mocking the module. Browser mode runs
- * tests in an iframe, so `window.parent !== window` by default — the standalone and
- * shell cases must explicitly pin `window.parent` back to `window`.
+ * Drives the real frame detection by stubbing `window.parent`/`window.name`, instead
+ * of mocking the module. Browser mode runs tests in an iframe, so `window.parent !== window`
+ * by default — this pins both axes explicitly. Prefer the named helpers below; reach for
+ * this primitive only for states they don't express (e.g. embedded with an unrelated name).
  *
- * Pair with {@link restoreFrame} in an `afterEach`.
- *
- * @param mode - Which frame the app should detect.
+ * @param options - The frame's embedded state and host-assigned name.
+ * @returns A function that restores the previous `window.parent`/`window.name`.
  */
-export function stubFrame(mode: FrameMode) {
-  switch (mode) {
-    case "ui":
-      setParent({} as Window);
-      globalThis.window.name = "uix-guest-1";
-      break;
-    case "control":
-      setParent({} as Window);
-      globalThis.window.name = "";
-      break;
-    case "standalone":
-    case "shell":
-      setParent(globalThis.window);
-      globalThis.window.name = "";
-      break;
-    default:
-      throw new Error(`Unknown frame mode: ${mode}`);
-  }
+export function stubFrame({ embedded, name = "" }: FrameOptions) {
+  const previousParent = globalThis.window.parent;
+  const previousName = globalThis.window.name;
+
+  setParent(embedded ? ({} as Window) : globalThis.window);
+  globalThis.window.name = name;
+
+  return () => {
+    setParent(previousParent);
+    globalThis.window.name = previousName;
+  };
 }
 
-/** Restores `window.parent`/`window.name` after a {@link stubFrame} call. */
-export function restoreFrame() {
-  setParent(ORIGINAL_PARENT);
-  globalThis.window.name = "";
+/** Embedded UI frame (uix-guest name): `isUiFrame()` reports true. */
+export function stubUiFrame(name = "uix-guest-1") {
+  return stubFrame({ embedded: true, name });
+}
+
+/** Embedded control frame (no name): `isControlFrame()` reports true. */
+export function stubControlFrame() {
+  return stubFrame({ embedded: true, name: "" });
+}
+
+/** Top-level standalone window (not embedded). */
+export function stubStandaloneFrame(name = "") {
+  return stubFrame({ embedded: false, name });
+}
+
+/** Embedded in the Experience Cloud shell iframe: neither a UI nor a control frame. */
+export function stubShellFrame() {
+  // A name that is neither a uix-guest name nor empty keeps isUiFrame/isControlFrame false, so
+  // the shell flow is reached; it still needs a non-null initial configuration promise to render.
+  return stubFrame({ embedded: true, name: "exc-app" });
 }

--- a/packages/aio-commerce-lib-admin-ui/test/utils/router.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/router.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render } from "vitest-browser-react";
+
+import type { AnyRouter } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+/** A child route to mount inside the component under test's `<Outlet />`. */
+type RouteSpec = { index?: boolean; path?: string; element: ReactNode };
+
+type RouterOptions = {
+  /** Child routes rendered into the root component's `<Outlet />`. */
+  routes?: RouteSpec[];
+  /** Initial history stack; seed multiple entries to make `useCanGoBack` true. */
+  initialEntries?: string[];
+};
+
+/**
+ * Builds a real TanStack router backed by memory history, so tests get deterministic,
+ * isolated navigation. A catch-all splat route is always added so navigating to
+ * arbitrary paths matches without pre-declaring every route.
+ */
+function buildRouter(
+  rootComponent: () => ReactNode,
+  routes: RouteSpec[],
+  initialEntries: string[],
+): AnyRouter {
+  const rootRoute = createRootRoute({ component: rootComponent });
+
+  const specs = routes.some((route) => route.index)
+    ? routes
+    : [{ index: true, element: null } as RouteSpec, ...routes];
+
+  const children = specs.map((route) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: route.index ? "/" : (route.path as string),
+      component: () => route.element,
+    }),
+  );
+
+  const splat = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "$",
+    component: () => null,
+  });
+
+  return createRouter({
+    history: createMemoryHistory({ initialEntries }),
+    routeTree: rootRoute.addChildren([...children, splat]),
+  });
+}
+
+/**
+ * Renders `ui` as the root route of a real router. Use when the component under test
+ * needs router context (e.g. `useSpectrumRouter`) or renders an `<Outlet />`.
+ *
+ * @param ui - The element under test.
+ * @param options - Child routes and/or initial history entries.
+ * @returns The rendered screen and the live router (assert on `router.state`).
+ */
+export async function renderWithRouter(
+  ui: ReactNode,
+  options: RouterOptions = {},
+) {
+  const { routes = [], initialEntries = ["/"] } = options;
+  const router = buildRouter(() => ui, routes, initialEntries);
+  const screen = await render(<RouterProvider router={router} />);
+  return { screen, router };
+}
+
+/**
+ * Renders a hook inside a real router context and exposes its latest return value.
+ * Read `result.current` (after `vi.waitFor` when the value updates asynchronously).
+ *
+ * @param useHook - The hook invocation under test.
+ * @param options - Initial history entries.
+ * @returns `result` (live hook value), the router, and the rendered screen.
+ */
+export async function renderHookWithRouter<T>(
+  useHook: () => T,
+  options: Pick<RouterOptions, "initialEntries"> = {},
+) {
+  const { initialEntries = ["/"] } = options;
+  const result = { current: undefined as T };
+
+  function Probe() {
+    result.current = useHook();
+    return null;
+  }
+
+  const router = buildRouter(() => <Probe />, [], initialEntries);
+  const screen = await render(<RouterProvider router={router} />);
+  return { result, router, screen };
+}

--- a/packages/aio-commerce-lib-admin-ui/test/utils/router.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/router.tsx
@@ -10,95 +10,56 @@
  * governing permissions and limitations under the License.
  */
 
-import {
-  createMemoryHistory,
-  createRootRoute,
-  createRoute,
-  createRouter,
-  RouterProvider,
-} from "@tanstack/react-router";
+import { createMemoryHistory, RouterProvider } from "@tanstack/react-router";
 import { render } from "vitest-browser-react";
 
-import type { AnyRouter } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+import { createExtensionRouter } from "#web/react/routing/lib";
 
-/** A child route to mount inside the component under test's `<Outlet />`. */
-type RouteSpec = { index?: boolean; path?: string; element: ReactNode };
+import type { RouteEntry } from "#web/react/routing/types";
 
 type RouterOptions = {
-  /** Child routes rendered into the root component's `<Outlet />`. */
-  routes?: RouteSpec[];
+  /** Routes rendered into the root component's `<Outlet />`; declare every path a test navigates to. */
+  routes?: RouteEntry[];
   /** Initial history stack; seed multiple entries to make `useCanGoBack` true. */
   initialEntries?: string[];
 };
 
 /**
- * Builds a real TanStack router backed by memory history, so tests get deterministic,
- * isolated navigation. A catch-all splat route is always added so navigating to
- * arbitrary paths matches without pre-declaring every route.
- */
-function buildRouter(
-  rootComponent: () => ReactNode,
-  routes: RouteSpec[],
-  initialEntries: string[],
-): AnyRouter {
-  const rootRoute = createRootRoute({ component: rootComponent });
-
-  const specs = routes.some((route) => route.index)
-    ? routes
-    : [{ index: true, element: null } as RouteSpec, ...routes];
-
-  const children = specs.map((route) =>
-    createRoute({
-      getParentRoute: () => rootRoute,
-      path: route.index ? "/" : (route.path as string),
-      component: () => route.element,
-    }),
-  );
-
-  const splat = createRoute({
-    getParentRoute: () => rootRoute,
-    path: "$",
-    component: () => null,
-  });
-
-  return createRouter({
-    history: createMemoryHistory({ initialEntries }),
-    routeTree: rootRoute.addChildren([...children, splat]),
-  });
-}
-
-/**
- * Renders `ui` as the root route of a real router. Use when the component under test
- * needs router context (e.g. `useSpectrumRouter`) or renders an `<Outlet />`.
+ * Renders `ui` as the root route of the real extension router, backed by memory history so tests
+ * get deterministic, seedable, isolated navigation. Use when the component under test needs router
+ * context (e.g. `useSpectrumRouter`) or renders an `<Outlet />`.
  *
  * @param ui - The element under test.
  * @param options - Child routes and/or initial history entries.
  * @returns The rendered screen and the live router (assert on `router.state`).
  */
 export async function renderWithRouter(
-  ui: ReactNode,
+  ui: React.JSX.Element,
   options: RouterOptions = {},
 ) {
   const { routes = [], initialEntries = ["/"] } = options;
-  const router = buildRouter(() => ui, routes, initialEntries);
+  const router = createExtensionRouter(
+    ui,
+    routes,
+    createMemoryHistory({ initialEntries }),
+  );
   const screen = await render(<RouterProvider router={router} />);
   return { screen, router };
 }
 
 /**
- * Renders a hook inside a real router context and exposes its latest return value.
+ * Renders a hook inside the real router context and exposes its latest return value.
  * Read `result.current` (after `vi.waitFor` when the value updates asynchronously).
  *
  * @param useHook - The hook invocation under test.
- * @param options - Initial history entries.
+ * @param options - Child routes and/or initial history entries.
  * @returns `result` (live hook value), the router, and the rendered screen.
  */
 export async function renderHookWithRouter<T>(
   useHook: () => T,
-  options: Pick<RouterOptions, "initialEntries"> = {},
+  options: RouterOptions = {},
 ) {
-  const { initialEntries = ["/"] } = options;
+  const { routes = [], initialEntries = ["/"] } = options;
   const result = { current: undefined as T };
 
   function Probe() {
@@ -106,7 +67,11 @@ export async function renderHookWithRouter<T>(
     return null;
   }
 
-  const router = buildRouter(() => <Probe />, [], initialEntries);
+  const router = createExtensionRouter(
+    <Probe />,
+    routes,
+    createMemoryHistory({ initialEntries }),
+  );
   const screen = await render(<RouterProvider router={router} />);
   return { result, router, screen };
 }

--- a/packages/aio-commerce-lib-admin-ui/test/utils/shared-context.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/shared-context.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { SharedContextProvider } from "#web/react/commerce/context/shared-context.tsx";
+
+import type { ReactNode } from "react";
+
+/**
+ * Builds a `renderHook`/`render` wrapper that mounts the children inside a
+ * `SharedContextProvider` backed by the given fake connection. Pair with
+ * `createMockGuestConnection` to vary the host or shared context per test.
+ *
+ * @param connection - A fake UIX guest connection (e.g. from `createMockGuestConnection`).
+ * @param extensionId - The extension ID to expose through the provider.
+ */
+export function sharedContextProvider(
+  connection: object,
+  extensionId = "ext-1",
+) {
+  return ({ children }: { children: ReactNode }) => (
+    <SharedContextProvider
+      extensionId={extensionId}
+      // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+      guestConnection={connection}>
+      {children}
+    </SharedContextProvider>
+  );
+}

--- a/packages/aio-commerce-lib-admin-ui/vitest.config.ts
+++ b/packages/aio-commerce-lib-admin-ui/vitest.config.ts
@@ -11,21 +11,41 @@
  */
 
 import { baseConfig } from "@aio-commerce-sdk/config-vitest/vitest.config.base";
-import { defineConfig, mergeConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import { mergeConfig } from "vitest/config";
 
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    plugins: [],
-    test: {
-      passWithNoTests: true,
-      coverage: {
-        exclude: [
-          "./source/**/index.ts",
-          "./source/**/types.ts",
-          "./source/web/runtime-loader.ts",
-        ],
-      },
+export default mergeConfig(baseConfig, {
+  test: {
+    passWithNoTests: true,
+    coverage: {
+      exclude: [
+        "./source/**/index.ts",
+        "./source/**/types.ts",
+        "./source/web/runtime-loader.ts",
+      ],
     },
-  }),
-);
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "node",
+          include: ["test/unit/**/*.test.{ts,tsx}"],
+          exclude: ["test/unit/web/react/**"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "browser",
+          include: ["test/unit/web/react/**/*.test.{ts,tsx}"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,15 @@ importers:
       '@types/node':
         specifier: ^24.12.0
         version: 24.13.2
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.9
+        version: 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui':
         specifier: ^4.1.0
         version: 4.1.9(vitest@4.1.9)
@@ -128,7 +134,10 @@ importers:
         version: 7.8.4
       vitest:
         specifier: ^4.1.0
-        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest-browser-react:
+        specifier: ^2.2.0
+        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
 
   configs/tsdown:
     devDependencies:
@@ -304,21 +313,12 @@ importers:
       '@react-spectrum/s2':
         specifier: catalog:react
         version: 1.5.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@testing-library/dom':
-        specifier: ^10.4.1
-        version: 10.4.1
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: catalog:react
         version: 19.2.17
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.3(@types/react@19.2.17)
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
       react:
         specifier: catalog:react
         version: 19.2.7
@@ -952,10 +952,6 @@ packages:
     resolution: {integrity: sha512-kNhJKMxQb374KOVt63CZnGIpDcrKNzJeyANLJymxE9mCJSdRGzb+Iv9oSIiCj6tNMLypr530b9ObOiA/5OvwOg==}
     engines: {node: '>=20.0.0'}
 
-  '@babel/code-frame@7.29.7':
-    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -1058,6 +1054,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2198,25 +2197,6 @@ packages:
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
-  '@testing-library/dom@10.4.1':
-    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
-    engines: {node: '>=18'}
-
-  '@testing-library/react@16.3.2':
-    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@tsconfig/node-lts@24.0.0':
     resolution: {integrity: sha512-8mSTqWwCd6aQpvxSrpQlMoA9RiUZSs7bYhL5qsLXIIaN9HQaINeoydrRu/Y7/fws4bvfuyhs0BRnW9/NI8tySg==}
 
@@ -2262,9 +2242,6 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
-
-  '@types/aria-query@5.0.4':
-    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2331,6 +2308,30 @@ packages:
   '@typespec/ts-http-runtime@0.3.6':
     resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
     engines: {node: '>=20.0.0'}
+
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/browser-playwright@4.1.9':
+    resolution: {integrity: sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.9
+
+  '@vitest/browser@4.1.9':
+    resolution: {integrity: sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==}
+    peerDependencies:
+      vitest: 4.1.9
 
   '@vitest/coverage-v8@4.1.9':
     resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
@@ -2440,10 +2441,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
-
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2468,9 +2465,6 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
-
-  aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -2727,10 +2721,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2745,9 +2735,6 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-
-  dom-accessibility-api@0.5.16:
-    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
@@ -2951,6 +2938,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3456,10 +3448,6 @@ packages:
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
-  lz-string@1.5.0:
-    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
-    hasBin: true
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3752,6 +3740,20 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3765,10 +3767,6 @@ packages:
     resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
     hasBin: true
-
-  pretty-format@27.5.1:
-    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -3830,9 +3828,6 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-stately@3.48.0:
     resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
@@ -4419,6 +4414,20 @@ packages:
       yaml:
         optional: true
 
+  vitest-browser-react@2.2.0:
+    resolution: {integrity: sha512-oY3KM6305kwJMa6nHo92vVtkOsih7mjEf12dLKuphaF+9ywWPEc+qanIBd394SZ6m5LadVEaG6dicvvizOzmjA==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      vitest: ^4.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -4530,6 +4539,18 @@ packages:
   write-file-atomic@7.0.1:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
@@ -4786,6 +4807,7 @@ snapshots:
       '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -4794,10 +4816,13 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
+    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1': {}
+  '@asamuzakjp/generational-cache@1.0.1':
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -4912,12 +4937,6 @@ snapshots:
       - '@azure/core-client'
       - supports-color
 
-  '@babel/code-frame@7.29.7':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.0
@@ -4992,9 +5011,12 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.2':
     optional: true
 
+  '@blazediff/core@1.9.1': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+    optional: true
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -5168,12 +5190,14 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@csstools/color-helpers@6.1.0': {}
+  '@csstools/color-helpers@6.1.0':
+    optional: true
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5181,16 +5205,20 @@ snapshots:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+    optional: true
 
-  '@csstools/css-tokenizer@4.0.0': {}
+  '@csstools/css-tokenizer@4.0.0':
+    optional: true
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -5386,7 +5414,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1':
+    optional: true
 
   '@gar/promise-retry@1.0.3': {}
 
@@ -6042,27 +6071,6 @@ snapshots:
 
   '@tanstack/store@0.9.3': {}
 
-  '@testing-library/dom@10.4.1':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/runtime': 7.29.7
-      '@types/aria-query': 5.0.4
-      aria-query: 5.3.0
-      dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
-      picocolors: 1.1.1
-      pretty-format: 27.5.1
-
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@testing-library/dom': 10.4.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@tsconfig/node-lts@24.0.0': {}
 
   '@tsconfig/node-ts@23.6.4': {}
@@ -6098,8 +6106,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6169,7 +6175,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+  '@vitejs/plugin-react@6.0.3(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.9
@@ -6181,7 +6222,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -6228,7 +6271,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -6291,8 +6334,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@5.2.0: {}
-
   ansi-styles@6.2.3: {}
 
   ansis@4.3.1: {}
@@ -6312,10 +6353,6 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
-
-  aria-query@5.3.0:
-    dependencies:
-      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -6354,6 +6391,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   birpc@4.0.0: {}
 
@@ -6495,6 +6533,7 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+    optional: true
 
   csstype@3.2.3: {}
 
@@ -6504,6 +6543,7 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   dataloader@1.4.0: {}
 
@@ -6511,7 +6551,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   deepmerge@4.3.1: {}
 
@@ -6532,8 +6573,6 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  dequal@2.0.3: {}
-
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -6543,8 +6582,6 @@ snapshots:
       path-type: 4.0.0
 
   dlv@1.1.3: {}
-
-  dom-accessibility-api@0.5.16: {}
 
   dotenv@16.3.1: {}
 
@@ -6579,7 +6616,8 @@ snapshots:
 
   entities@4.5.0: {}
 
-  entities@8.0.0: {}
+  entities@8.0.0:
+    optional: true
 
   environment@1.1.0: {}
 
@@ -6786,6 +6824,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6904,6 +6945,7 @@ snapshots:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -6998,7 +7040,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1: {}
+  is-potential-custom-element-name@1.0.1:
+    optional: true
 
   is-stream@2.0.1: {}
 
@@ -7089,6 +7132,7 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   jsesc@3.1.0: {}
 
@@ -7274,8 +7318,6 @@ snapshots:
 
   lunr@2.3.9: {}
 
-  lz-string@1.5.0: {}
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7301,7 +7343,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.27.1:
+    optional: true
 
   mdurl@2.0.0: {}
 
@@ -7525,6 +7568,7 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+    optional: true
 
   path-exists@4.0.0: {}
 
@@ -7569,6 +7613,16 @@ snapshots:
       exsolve: 1.1.0
       pathe: 2.0.3
 
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
+
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.15
@@ -7578,12 +7632,6 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.8.4: {}
-
-  pretty-format@27.5.1:
-    dependencies:
-      ansi-regex: 5.0.1
-      ansi-styles: 5.2.0
-      react-is: 17.0.2
 
   pretty-ms@9.3.0:
     dependencies:
@@ -7608,7 +7656,8 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  punycode@2.3.1: {}
+  punycode@2.3.1:
+    optional: true
 
   quansync@0.2.11: {}
 
@@ -7651,8 +7700,6 @@ snapshots:
       react: 19.2.7
 
   react-is@16.13.1: {}
-
-  react-is@17.0.2: {}
 
   react-stately@3.48.0(react@19.2.7):
     dependencies:
@@ -7810,6 +7857,7 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
   scheduler@0.27.0: {}
 
@@ -7946,7 +7994,8 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
-  symbol-tree@3.2.4: {}
+  symbol-tree@3.2.4:
+    optional: true
 
   tagged-tag@1.0.0: {}
 
@@ -7988,6 +8037,7 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -8085,7 +8135,8 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.28.0: {}
+  undici@7.28.0:
+    optional: true
 
   unicorn-magic@0.3.0: {}
 
@@ -8131,7 +8182,16 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  vitest@4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -8155,7 +8215,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.2
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:
@@ -8164,6 +8225,7 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+    optional: true
 
   wcwidth@1.0.1:
     dependencies:
@@ -8171,9 +8233,11 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@8.0.1: {}
+  webidl-conversions@8.0.1:
+    optional: true
 
-  whatwg-mimetype@5.0.0: {}
+  whatwg-mimetype@5.0.0:
+    optional: true
 
   whatwg-url@16.0.1:
     dependencies:
@@ -8182,6 +8246,7 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -8251,6 +8316,8 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
+  ws@8.21.0: {}
+
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
@@ -8259,11 +8326,13 @@ snapshots:
     dependencies:
       sax: 1.6.0
 
-  xml-name-validator@5.0.0: {}
+  xml-name-validator@5.0.0:
+    optional: true
 
   xml-naming@0.1.0: {}
 
-  xmlchars@2.2.0: {}
+  xmlchars@2.2.0:
+    optional: true
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,12 +304,21 @@ importers:
       '@react-spectrum/s2':
         specifier: catalog:react
         version: 1.5.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: catalog:react
         version: 19.2.17
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: catalog:react
         version: 19.2.7
@@ -942,6 +951,10 @@ packages:
   '@azure/storage-common@12.4.0':
     resolution: {integrity: sha512-kNhJKMxQb374KOVt63CZnGIpDcrKNzJeyANLJymxE9mCJSdRGzb+Iv9oSIiCj6tNMLypr530b9ObOiA/5OvwOg==}
     engines: {node: '>=20.0.0'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
@@ -2185,6 +2198,25 @@ packages:
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tsconfig/node-lts@24.0.0':
     resolution: {integrity: sha512-8mSTqWwCd6aQpvxSrpQlMoA9RiUZSs7bYhL5qsLXIIaN9HQaINeoydrRu/Y7/fws4bvfuyhs0BRnW9/NI8tySg==}
 
@@ -2230,6 +2262,9 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2405,6 +2440,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2429,6 +2468,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -2685,6 +2727,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2699,6 +2745,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
@@ -3407,6 +3456,10 @@ packages:
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3713,6 +3766,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -3773,6 +3830,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-stately@3.48.0:
     resolution: {integrity: sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==}
@@ -4726,7 +4786,6 @@ snapshots:
       '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -4735,13 +4794,10 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1':
-    optional: true
+  '@asamuzakjp/generational-cache@1.0.1': {}
 
-  '@asamuzakjp/nwsapi@2.3.9':
-    optional: true
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -4856,6 +4912,12 @@ snapshots:
       - '@azure/core-client'
       - supports-color
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.0
@@ -4933,7 +4995,6 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-    optional: true
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -5107,14 +5168,12 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@csstools/color-helpers@6.1.0':
-    optional: true
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5122,20 +5181,16 @@ snapshots:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
-    optional: true
 
-  '@csstools/css-tokenizer@4.0.0':
-    optional: true
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -5331,8 +5386,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@exodus/bytes@1.15.1':
-    optional: true
+  '@exodus/bytes@1.15.1': {}
 
   '@gar/promise-retry@1.0.3': {}
 
@@ -5988,6 +6042,27 @@ snapshots:
 
   '@tanstack/store@0.9.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@tsconfig/node-lts@24.0.0': {}
 
   '@tsconfig/node-ts@23.6.4': {}
@@ -6023,6 +6098,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6214,6 +6291,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@4.3.1: {}
@@ -6233,6 +6312,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -6271,7 +6354,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-    optional: true
 
   birpc@4.0.0: {}
 
@@ -6413,7 +6495,6 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
-    optional: true
 
   csstype@3.2.3: {}
 
@@ -6423,7 +6504,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   dataloader@1.4.0: {}
 
@@ -6431,8 +6511,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -6453,6 +6532,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -6462,6 +6543,8 @@ snapshots:
       path-type: 4.0.0
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@16.3.1: {}
 
@@ -6496,8 +6579,7 @@ snapshots:
 
   entities@4.5.0: {}
 
-  entities@8.0.0:
-    optional: true
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -6822,7 +6904,6 @@ snapshots:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -6917,8 +6998,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-stream@2.0.1: {}
 
@@ -7009,7 +7089,6 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   jsesc@3.1.0: {}
 
@@ -7195,6 +7274,8 @@ snapshots:
 
   lunr@2.3.9: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7220,8 +7301,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.27.1:
-    optional: true
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -7445,7 +7525,6 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
-    optional: true
 
   path-exists@4.0.0: {}
 
@@ -7500,6 +7579,12 @@ snapshots:
 
   prettier@3.8.4: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -7523,8 +7608,7 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  punycode@2.3.1:
-    optional: true
+  punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
@@ -7567,6 +7651,8 @@ snapshots:
       react: 19.2.7
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-stately@3.48.0(react@19.2.7):
     dependencies:
@@ -7724,7 +7810,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scheduler@0.27.0: {}
 
@@ -7861,8 +7946,7 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
 
@@ -7904,7 +7988,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -8002,8 +8085,7 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.28.0:
-    optional: true
+  undici@7.28.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -8082,7 +8164,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
   wcwidth@1.0.1:
     dependencies:
@@ -8090,11 +8171,9 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@8.0.1:
-    optional: true
+  webidl-conversions@8.0.1: {}
 
-  whatwg-mimetype@5.0.0:
-    optional: true
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
     dependencies:
@@ -8103,7 +8182,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -8181,13 +8259,11 @@ snapshots:
     dependencies:
       sax: 1.6.0
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
   xml-naming@0.1.0: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       lint-staged:
         specifier: ^17.0.0
         version: 17.0.8
+      playwright:
+        specifier: 1.61.1
+        version: 1.61.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.4
@@ -819,6 +822,7 @@ packages:
   '@adobe/aio-lib-core-networking@5.1.0':
     resolution: {integrity: sha512-RZgA73yUHhikjIGy7k0DRobPbIXbtuI/0ixrBXOVqj19WTqFFrEuyHtzOuRsBAmu0OvVkf6slQHtDTL9oPLxfg==}
     engines: {node: '>=18'}
+    bundledDependencies: []
 
   '@adobe/aio-lib-core-tvm@4.0.3':
     resolution: {integrity: sha512-zwl4GeU5CryZBozpub4jI9tnGW2ewD6mMLaXX8HhO8DqKzcjnjYr+MbUS0c/QzGd8gTzZWbikm4J7tfpCn3cAA==}
@@ -827,6 +831,7 @@ packages:
   '@adobe/aio-lib-env@3.0.1':
     resolution: {integrity: sha512-UaLosV8jBowEA2ho4BNmWuHhrNCFbx26kJAr2SAIdEm4lZ/D8av8FUSMOEyAKJ/dfO2HCnLKMy77ie2AU7HI3g==}
     engines: {node: '>=18'}
+    bundledDependencies: []
 
   '@adobe/aio-lib-files@4.1.4':
     resolution: {integrity: sha512-YhUu5YV4hnFm6arsMYhl96bjbxnOpmMgE5WiwUvLlm9Dh4PGNGAaY52nED5xnbI+ODbj0vSd9s6KwC3kTmo6tQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,4 +37,5 @@ allowBuilds:
   core-js-pure: true
   esbuild: true
   msw: true
+  playwright: true
   protobufjs: true


### PR DESCRIPTION
## Description

Adds the React (browser-mode) test suite for `@adobe/aio-commerce-lib-admin-ui`, covering `source/web/react/**`: auth, commerce hooks/contexts, extension composition (create-app, entrypoint, commerce-app, experience-shell/standalone apps), routing, shell hooks, theme, and the promise cache. Includes shared test fixtures (`exc-app`, `uix-guest`) and utils (`console`, `frame`, `router`, `shared-context`).

Tests run in Vitest Browser Mode (Chromium via Playwright), split into two vitest projects: `node` for non-React logic and `browser` for `test/unit/web/react/**`. A handful of small source tweaks accompany the tests (use-commerce, use-guest-connection, commerce-app, entrypoint, error-boundary, promise-cache, routing/lib) surfaced while making the code testable.

CI (`.github/workflows/pr-checks.yml`) installs Playwright browsers so the browser-mode project runs in CI.

## Related Issue

CEXT-6338

## Motivation and Context

The admin-ui React layer had no test coverage. This establishes the browser-mode testing setup and brings the package to ~99% coverage.

## How Has This Been Tested?

- `pnpm --filter @adobe/aio-commerce-lib-admin-ui test` — 35 files, 209 tests passing; ~99% statement/branch coverage.
- `pnpm typecheck` — clean across the workspace.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
