### PR TITLE
Update labeler config for aio-commerce-lib-api path

### DIFF
--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -14,7 +14,7 @@
 
 "pkg: aio-commerce-lib-api":
   - changed-files:
-      - any-glob-to-any-file: "packages-private/aio-commerce-lib-api/**"
+      - any-glob-to-any-file: "packages/aio-commerce-lib-api/**"
 
 "pkg: aio-commerce-lib-events":
   - changed-files:


### PR DESCRIPTION
Fix path of labeler config for `lib-api`.