### PR TITLE
CEXT-6421: Publish previews in npm

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -444,7 +444,7 @@ After that, a new file is generated in the `.changeset` folder at the repository
 This repository uses two release channels:
 
 - `main` is the internal integration channel
-  - Uses snapshot releases (`beta` tag) and publishes to Artifactory. Nothing is committed, changeset files stay in `.changeset/` until promotion.
+  - Uses snapshot releases (`beta` tag) and publishes to the public npm registry. Nothing is committed, changeset files stay in `.changeset/` until promotion.
 - `release` is the public channel
   - Uses stable semver and publishes to NPM via the standard changesets flow.
 
@@ -479,11 +479,11 @@ _⬤ commit · PR: pull request_
 Once your feature PR is merged to `main`:
 
 1. CI runs `changeset version --snapshot beta` and `changeset publish --tag beta`.
-2. Packages are published to Artifactory with ephemeral snapshot versions (e.g., `1.2.5-beta-20260313T120000`).
+2. Packages are published to the public npm registry with ephemeral snapshot versions (e.g., `1.2.5-beta-20260313T120000`).
 3. Nothing is committed. Changeset files stay in `.changeset/` until promotion to `release`.
 4. A GitHub pre-release is created with release notes assembled from the pending changesets.
 
-You can also request a snapshot from any open PR by commenting `/snapshot`. This publishes an `alpha` snapshot of your PR's changes to Artifactory without affecting `main`.
+You can also request a snapshot from any open PR by commenting `/snapshot`. This publishes an `alpha` snapshot of your PR's changes to the public npm registry without affecting `main`.
 
 #### Public stable flow (`release`)
 
@@ -494,7 +494,7 @@ When ready to publish to npm, use the **Promote to Release** workflow dispatch (
 3. Changesets creates/updates a `[CI] Release Packages` PR on `release`, including regenerated API reference docs.
 4. Merging that PR publishes stable versions to npm and writes changelogs.
 
-If there were snapshot versions like `1.2.5-beta-20260313T120000` on Artifactory, the resulting stable release is `1.2.5`.
+If there were snapshot versions like `1.2.5-beta-20260313T120000` on npm, the resulting stable release is `1.2.5`.
 
 Commerce plugins under `plugins/commerce/*` use the same changeset flow, but they are private
 workspace packages and are not published to npm. A changeset targeting a plugin package is the

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -483,19 +483,6 @@ Once your feature PR is merged to `main`:
 3. Nothing is committed. Changeset files stay in `.changeset/` until promotion to `release`.
 4. A GitHub pre-release is created with release notes assembled from the pending changesets.
 
-You can also request a snapshot from any open PR by commenting `/snapshot`. This publishes an `alpha` snapshot of your PR's changes to the public npm registry without affecting `main`.
-
-#### Public stable flow (`release`)
-
-When ready to publish to npm, use the **Promote to Release** workflow dispatch (`promote.yml`):
-
-1. Trigger it from GitHub Actions, optionally specifying a commit SHA on `main` to promote (defaults to latest).
-2. The workflow merges that commit directly into `release` via a merge commit. No config changes needed — changeset files come along unconsumed.
-3. Changesets creates/updates a `[CI] Release Packages` PR on `release`, including regenerated API reference docs.
-4. Merging that PR publishes stable versions to npm and writes changelogs.
-
-If there were snapshot versions like `1.2.5-beta-20260313T120000` on npm, the resulting stable release is `1.2.5`.
-
 #### Commerce plugins
 
 Commerce plugins under `plugins/commerce/*` use the same changeset flow, but they are private

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -15,8 +15,9 @@ require maintainer-level access to execute.
 ### Requesting a PR snapshot
 
 Commenting `/snapshot` on an open PR publishes an `alpha` snapshot of that PR's changes to
-Artifactory without affecting `main`. The workflow that handles this comment checks that the
-commenter has **admin** permission on the repository, so this is restricted to maintainers.
+the public npm registry without affecting `main`. The workflow that handles this comment checks
+that the commenter has **admin** permission on the repository, so this is restricted to
+maintainers.
 
 ### Triggering a public release
 
@@ -27,7 +28,7 @@ When ready to publish to npm, use the **Promote to Release** workflow dispatch (
 3. Changesets creates/updates a `[CI] Release Packages` PR on `release`, including regenerated API reference docs.
 4. Merging that PR publishes stable versions to npm and writes changelogs.
 
-If there were snapshot versions like `1.2.5-beta-20260313T120000` on Artifactory, the resulting stable release is `1.2.5`.
+If there were snapshot versions like `1.2.5-beta-20260313T120000` on npm, the resulting stable release is `1.2.5`.
 
 ### Back-sync
 

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -8,9 +8,6 @@ inputs:
   registry-package-base-url:
     description: Base URL for linking to published packages
     required: true
-  release-channel:
-    description: Release channel ("internal" or "public")
-    required: true
   slack-webhook-url:
     description: Slack incoming webhook URL
     required: true
@@ -24,7 +21,6 @@ runs:
       env:
         PUBLISHED_PACKAGES: ${{ inputs.published-packages }}
         REGISTRY_PACKAGE_BASE_URL: ${{ inputs.registry-package-base-url }}
-        RELEASE_CHANNEL: ${{ inputs.release-channel }}
       with:
         script: |
           const { default: execAnnouncement } = await import('${{ github.workspace }}/scripts/source/ci/release/announce.ts');

--- a/.github/actions/publish-snapshot/action.yml
+++ b/.github/actions/publish-snapshot/action.yml
@@ -10,9 +10,6 @@ inputs:
     description: Skip creating GitHub pre-releases
     required: false
     default: "false"
-  registry-url:
-    description: npm registry URL for publishing
-    required: true
 
 outputs:
   published:
@@ -35,18 +32,6 @@ runs:
           const { default: execPrepare } = await import('${{ github.workspace }}/scripts/source/ci/release/prepare.ts');
           await execPrepare(core, exec);
 
-    - name: Override publish registry for Artifactory
-      shell: bash
-      env:
-        REGISTRY_URL: ${{ inputs.registry-url }}
-      run: |
-        for dir in packages/*/; do
-          npm pkg set \
-            "publishConfig.registry=$REGISTRY_URL" \
-            "publishConfig.access=restricted" \
-            --prefix "$dir"
-        done
-
     - name: Build packages
       run: pnpm turbo build
       shell: bash
@@ -58,7 +43,6 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         SNAPSHOT_TAG: ${{ inputs.snapshot-tag }}
         SKIP_GITHUB_RELEASES: ${{ inputs.skip-github-releases }}
-        REGISTRY_URL: ${{ inputs.registry-url }}
       with:
         script: |
           const { default: execSnapshot } = await import('${{ github.workspace }}/scripts/source/ci/release/snapshot.ts');

--- a/.github/actions/setup-release/action.yml
+++ b/.github/actions/setup-release/action.yml
@@ -4,7 +4,8 @@ description: Setup pnpm and Node.js with registry auth, and install dependencies
 inputs:
   registry-url:
     description: npm registry URL to publish @adobe scope packages to
-    required: true
+    required: false
+    default: "https://registry.npmjs.org"
   token:
     description: Auth token for the npm registry
     required: true
@@ -16,7 +17,6 @@ runs:
     - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     # No registry-url/scope/token — install always resolves packages from public npm.
-    # Avoids 404 on @adobe/aio-lib-* packages not present in Artifactory.
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: lts/*
@@ -26,8 +26,8 @@ runs:
       shell: bash
 
     # Configure publish auth after install. Registry destination is declared via
-    # publishConfig.registry in each package (overridden at CI time by prepare.ts
-    # for internal/preview workflows that target Artifactory).
+    # publishConfig.registry in each package — every publish flow (public,
+    # internal, and preview) targets the public npm registry.
     - name: Configure publish auth
       shell: bash
       env:

--- a/.github/actions/setup-release/action.yml
+++ b/.github/actions/setup-release/action.yml
@@ -2,10 +2,6 @@ name: Setup Release Environment
 description: Setup pnpm and Node.js with registry auth, and install dependencies
 
 inputs:
-  registry-url:
-    description: npm registry URL to publish @adobe scope packages to
-    required: false
-    default: "https://registry.npmjs.org"
   token:
     description: Auth token for the npm registry
     required: true
@@ -31,10 +27,7 @@ runs:
     - name: Configure publish auth
       shell: bash
       env:
-        REGISTRY_URL: ${{ inputs.registry-url }}
         TOKEN: ${{ inputs.token }}
       run: |
-        REGISTRY_HOST="${REGISTRY_URL#https://}"
-        REGISTRY_HOST="${REGISTRY_HOST%/}"
         echo "NODE_AUTH_TOKEN=${TOKEN}" >> "$GITHUB_ENV"
-        echo "//${REGISTRY_HOST}/:_authToken=\${NODE_AUTH_TOKEN}" >> "$HOME/.npmrc"
+        echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> "$HOME/.npmrc"

--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -25,18 +25,14 @@ jobs:
 
       - uses: ./.github/actions/setup-release
         with:
-          registry-url: ${{ secrets.ARTIFACTORY_REPO_PUBLISH_URL }}
-          token: ${{ secrets.ARTIFACTORY_API_TOKEN }}
+          token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
 
       - uses: ./.github/actions/publish-snapshot
         id: snapshot
-        with:
-          registry-url: ${{ secrets.ARTIFACTORY_REPO_PUBLISH_URL }}
 
       - uses: ./.github/actions/notify-slack
         if: inputs.notify_slack && steps.snapshot.outputs.published == 'true'
         with:
           published-packages: ${{ steps.snapshot.outputs.publishedPackages }}
-          registry-package-base-url: ${{ secrets.ARTIFACTORY_PACKAGE_BASE_URL }}
-          release-channel: internal
+          registry-package-base-url: "https://npmx.dev/package"
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -111,15 +111,13 @@ jobs:
 
       - uses: ./.github/actions/setup-release
         with:
-          registry-url: ${{ secrets.ARTIFACTORY_REPO_PUBLISH_URL }}
-          token: ${{ secrets.ARTIFACTORY_API_TOKEN }}
+          token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
 
       - uses: ./.github/actions/publish-snapshot
         id: snapshot
         with:
           snapshot-tag: alpha
           skip-github-releases: "true"
-          registry-url: ${{ secrets.ARTIFACTORY_REPO_PUBLISH_URL }}
 
   comment:
     name: Comment on PR
@@ -134,11 +132,9 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
           PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
-          REGISTRY_URL: ${{ secrets.ARTIFACTORY_REPO_PUBLISH_URL }}
         with:
           script: |
             const packages = JSON.parse(process.env.PUBLISHED_PACKAGES);
-            const registryUrl = process.env.REGISTRY_URL;
 
             const rows = packages.map(p => `| \`${p.name}\` | \`${p.version}\` |`).join('\n');
             const installs = packages.map(p =>

--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -29,7 +29,6 @@ jobs:
 
       - uses: ./.github/actions/setup-release
         with:
-          registry-url: "https://registry.npmjs.org"
           token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
 
       - name: Build packages
@@ -53,7 +52,6 @@ jobs:
         with:
           published-packages: ${{ steps.changesets.outputs.publishedPackages }}
           registry-package-base-url: "https://npmx.dev/package"
-          release-channel: public
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       # hasChangesets is false only on the run that lands right after the "Version

--- a/scripts/source/ci/release/announce.ts
+++ b/scripts/source/ci/release/announce.ts
@@ -10,13 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import { parseReleaseChannel, runGitHubScript } from "./utils.ts";
+import { runGitHubScript } from "./utils.ts";
 
 import type {
   AnnounceEnvironment,
   AsyncFunctionArguments,
   PublishedPackage,
-  ReleaseChannel,
   SlackPayload,
 } from "./types.ts";
 
@@ -34,10 +33,9 @@ export default function main(core: AsyncFunctionArguments["core"]) {
 
 /** Entrypoint of the script. */
 function announce(): SlackPayload {
-  const { publishedPackages, channelArg, packageBaseUrl } = readInputs();
+  const { publishedPackages, packageBaseUrl } = readInputs();
   const announcement = formatMarkdownAnnouncement(
     publishedPackages,
-    channelArg,
     packageBaseUrl,
   );
 
@@ -59,7 +57,6 @@ function readInputs() {
   const {
     PUBLISHED_PACKAGES: publishedPackagesJson,
     REGISTRY_PACKAGE_BASE_URL: packageBaseUrl,
-    RELEASE_CHANNEL: channelArgValue,
   } = process.env as AnnounceEnvironment;
 
   if (!publishedPackagesJson) {
@@ -79,7 +76,6 @@ function readInputs() {
   ) as PublishedPackage[];
 
   return {
-    channelArg: parseReleaseChannel(channelArgValue),
     packageBaseUrl,
     publishedPackages,
   };
@@ -105,7 +101,6 @@ function joinPackageUrl(baseUrl: string, packageName: string): string {
  */
 function formatMarkdownAnnouncement(
   publishedPackages: PublishedPackage[],
-  channel: ReleaseChannel,
   packageBaseUrl: string,
 ): string {
   // Sort packages to ensure consistent order
@@ -120,10 +115,7 @@ function formatMarkdownAnnouncement(
     return a.name.localeCompare(b.name);
   });
 
-  const channelLabel =
-    channel === "internal" ? "internal (Artifactory)" : "public (NPM)";
-
-  let announcement = `:rocket: New ${channelLabel} packages for <${REPOSITORY_URL}|Adobe Commerce SDK for App Builder>\n\n`;
+  let announcement = `:rocket: New public (NPM) packages for <${REPOSITORY_URL}|Adobe Commerce SDK for App Builder>\n\n`;
 
   for (const pkg of publishedPackages) {
     const pkgRelease = `${pkg.name}@${pkg.version}`;

--- a/scripts/source/ci/release/snapshot.ts
+++ b/scripts/source/ci/release/snapshot.ts
@@ -229,8 +229,8 @@ function formatPreReleaseBody(
   pkg: PublishedPackage,
 ): string {
   const lines = [
-    "> [!IMPORTANT]",
-    "> Internal release only. This version is not publicly available.",
+    "> [!NOTE]",
+    "> Snapshot release published to the public npm registry. Not intended for production use.",
     "",
     changelog ?? `Snapshot release of \`${pkg.name}@${pkg.version}\`.`,
   ];

--- a/scripts/source/ci/release/types.ts
+++ b/scripts/source/ci/release/types.ts
@@ -10,14 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-/** The channel of the release. */
-export type ReleaseChannel = "internal" | "public";
-
 /** Environment variables for the release prepare script. */
 export type Environment = {
   REGISTRY_AUTH_TOKEN: string;
   REGISTRY_URL: string;
-  RELEASE_CHANNEL: ReleaseChannel;
   SNAPSHOT_TAG?: string;
 };
 
@@ -25,7 +21,6 @@ export type Environment = {
 export type AnnounceEnvironment = {
   PUBLISHED_PACKAGES: string;
   REGISTRY_PACKAGE_BASE_URL: string;
-  RELEASE_CHANNEL: ReleaseChannel;
 };
 
 /** A package published as part of a release. */

--- a/scripts/source/ci/release/utils.ts
+++ b/scripts/source/ci/release/utils.ts
@@ -14,7 +14,7 @@ import { execFile } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
-import type { AsyncFunctionArguments, ReleaseChannel } from "./types.ts";
+import type { AsyncFunctionArguments } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -50,15 +50,4 @@ export async function writeJson(path: string, value: unknown) {
     "--files-ignore-unknown=true",
     path,
   ]);
-}
-
-/** Parses the release channel from the given value. */
-export function parseReleaseChannel(value: string | undefined): ReleaseChannel {
-  if (value === "internal" || value === "public") {
-    return value;
-  }
-
-  throw new Error(
-    `Unsupported channel "${value ?? ""}". Expected "internal" or "public".`,
-  );
 }

--- a/scripts/test/unit/ci/release/announce.test.ts
+++ b/scripts/test/unit/ci/release/announce.test.ts
@@ -29,10 +29,8 @@ import {
 function stubAnnounceEnv(values: {
   publishedPackages?: string;
   registryPackageBaseUrl?: string;
-  releaseChannel?: string;
 }) {
   vi.stubEnv("PUBLISHED_PACKAGES", values.publishedPackages ?? "");
-  vi.stubEnv("RELEASE_CHANNEL", values.releaseChannel ?? "");
   vi.stubEnv("REGISTRY_PACKAGE_BASE_URL", values.registryPackageBaseUrl ?? "");
 }
 
@@ -47,7 +45,6 @@ describe("release/announce.ts", () => {
     stubAnnounceEnv({
       publishedPackages: SDK_AND_CORE_PACKAGES_JSON,
       registryPackageBaseUrl: PUBLIC_PACKAGE_BASE_URL,
-      releaseChannel: "public",
     });
 
     const payload = announce(asCore(core));
@@ -67,7 +64,6 @@ describe("release/announce.ts", () => {
     stubAnnounceEnv({
       publishedPackages: SDK_AND_CORE_PACKAGES_JSON,
       registryPackageBaseUrl: PUBLIC_PACKAGE_BASE_URL,
-      releaseChannel: "public",
     });
 
     const payload = announce(asCore(core));
@@ -90,14 +86,13 @@ describe("release/announce.ts", () => {
     stubAnnounceEnv({
       publishedPackages: INTERNAL_SDK_PACKAGE_JSON,
       registryPackageBaseUrl: INTERNAL_PACKAGE_BASE_URL,
-      releaseChannel: "internal",
     });
 
     const payload = announce(asCore(core));
     const text = payload.blocks[0]?.text.text ?? "";
 
     expect(core.setFailed).not.toHaveBeenCalled();
-    expect(text).toContain("internal (Artifactory)");
+    expect(text).toContain("public (NPM)");
     expect(text).toContain(
       `${INTERNAL_PACKAGE_BASE_URL}@adobe/aio-commerce-sdk`,
     );
@@ -108,7 +103,6 @@ describe("release/announce.ts", () => {
     stubAnnounceEnv({
       publishedPackages: THREE_PACKAGES_JSON,
       registryPackageBaseUrl: PUBLIC_PACKAGE_BASE_URL,
-      releaseChannel: "public",
     });
 
     const payload = await announce(asCore(core));
@@ -127,7 +121,6 @@ describe("release/announce.ts", () => {
     const core = createCoreMock();
     stubAnnounceEnv({
       registryPackageBaseUrl: PUBLIC_PACKAGE_BASE_URL,
-      releaseChannel: "public",
     });
 
     expect(() => announce(asCore(core))).toThrow();
@@ -137,18 +130,6 @@ describe("release/announce.ts", () => {
     const core = createCoreMock();
     stubAnnounceEnv({
       publishedPackages: CORE_PACKAGE_JSON,
-      releaseChannel: "public",
-    });
-
-    expect(() => announce(asCore(core))).toThrow();
-  });
-
-  test("fails when the release channel is invalid", () => {
-    const core = createCoreMock();
-    stubAnnounceEnv({
-      publishedPackages: CORE_PACKAGE_JSON,
-      registryPackageBaseUrl: PUBLIC_PACKAGE_BASE_URL,
-      releaseChannel: "beta",
     });
 
     expect(() => announce(asCore(core))).toThrow();
@@ -159,7 +140,6 @@ describe("release/announce.ts", () => {
     stubAnnounceEnv({
       publishedPackages: INVALID_PACKAGES_JSON,
       registryPackageBaseUrl: PUBLIC_PACKAGE_BASE_URL,
-      releaseChannel: "public",
     });
 
     expect(() => announce(asCore(core))).toThrow();

--- a/scripts/test/unit/ci/release/utils.test.ts
+++ b/scripts/test/unit/ci/release/utils.test.ts
@@ -16,12 +16,7 @@ import { join } from "node:path";
 import { withTempFiles } from "@aio-commerce-sdk/scripting-utils/filesystem";
 import { describe, expect, test } from "vitest";
 
-import {
-  parseReleaseChannel,
-  readJson,
-  runGitHubScript,
-  writeJson,
-} from "#ci/release/utils";
+import { readJson, runGitHubScript, writeJson } from "#ci/release/utils";
 import { asCore, createCoreMock } from "#test/fixtures/release";
 
 describe("release/utils.ts", () => {
@@ -72,17 +67,6 @@ describe("release/utils.ts", () => {
       ).rejects.toBe("boom");
 
       expect(core.setFailed).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("parseReleaseChannel", () => {
-    test("returns the release channel when it is valid", () => {
-      expect(parseReleaseChannel("internal")).toBe("internal");
-      expect(parseReleaseChannel("public")).toBe("public");
-    });
-
-    test("throws when the release channel is undefined", () => {
-      expect(() => parseReleaseChannel(undefined)).toThrow();
     });
   });
 


### PR DESCRIPTION
## Description

Preview (alpha, per-PR `/snapshot`) and internal (beta) package snapshots now publish to the public npm registry instead of Artifactory, reusing the same npm token and `publishConfig` that stable releases already use. Also drops the now-unused release-channel branching in the Slack announcement, defaults the npm registry URL in the shared setup action, and fixes a leftover pre-release notice that incorrectly said beta snapshots weren't publicly available.

## Related Issue

N/A

## Motivation and Context

Artifactory-hosted snapshots caused two recurring problems:

- Consumers testing a preview from another public GitHub repo couldn't install alpha/beta packages at all, since Artifactory isn't reachable without internal credentials.
- Anyone who did have access needed to keep tweaking their local `.npmrc` to point at Artifactory, which was a poor developer experience for something as routine as trying out a preview build.

Publishing snapshots to the public npm registry removes both frictions, at the cost of alpha/beta versions being publicly visible (mitigated via the existing deprecate workflow if one needs to be pulled back).

## How Has This Been Tested?

- `pnpm test` for the affected `scripts` package (40/40 passing).
- `pnpm typecheck` across the whole monorepo.
- `pnpm lint` (biome) on all changed files.
- Manual review of the updated workflow YAML for the preview, internal, and public publish flows.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.