### PR TITLE
CEXT-6367: extract MAINTAINERS.md and fix plugin package labeling

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,7 @@ be invited to the project. The existing committers employ an internal nomination
 process that must reach lazy consensus (silence is approval) before invitations
 are issued. If you feel you are qualified and want to get more deeply involved,
 feel free to reach out to existing committers to have a conversation about that.
+See [MAINTAINERS.md](./MAINTAINERS.md) for the operational responsibilities that come with that role.
 
 ## Security Issues
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,7 @@ be invited to the project. The existing committers employ an internal nomination
 process that must reach lazy consensus (silence is approval) before invitations
 are issued. If you feel you are qualified and want to get more deeply involved,
 feel free to reach out to existing committers to have a conversation about that.
+
 See [MAINTAINERS.md](./MAINTAINERS.md) for the operational responsibilities that come with that role.
 
 ## Security Issues

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -483,8 +483,6 @@ Once your feature PR is merged to `main`:
 3. Nothing is committed. Changeset files stay in `.changeset/` until promotion to `release`.
 4. A GitHub pre-release is created with release notes assembled from the pending changesets.
 
-You can also request a snapshot from any open PR by commenting `/snapshot`. This publishes an `alpha` snapshot of your PR's changes to Artifactory without affecting `main`.
-
 #### Commerce plugins
 
 Commerce plugins under `plugins/commerce/*` use the same changeset flow, but they are private
@@ -501,5 +499,3 @@ plugin version/changelog updates to `main`.
 #### Back-sync
 
 After a public release, the back-sync is automatic — the workflow merges `release` directly into `main` via a merge commit. No manual step needed.
-
-For triggering stable releases, applying hotfixes, and managing repository secrets, see [MAINTAINERS.md](./MAINTAINERS.md).

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -485,16 +485,7 @@ Once your feature PR is merged to `main`:
 
 You can also request a snapshot from any open PR by commenting `/snapshot`. This publishes an `alpha` snapshot of your PR's changes to Artifactory without affecting `main`.
 
-#### Public stable flow (`release`)
-
-When ready to publish to npm, use the **Promote to Release** workflow dispatch (`promote.yml`):
-
-1. Trigger it from GitHub Actions, optionally specifying a commit SHA on `main` to promote (defaults to latest).
-2. The workflow merges that commit directly into `release` via a merge commit. No config changes needed — changeset files come along unconsumed.
-3. Changesets creates/updates a `[CI] Release Packages` PR on `release`, including regenerated API reference docs.
-4. Merging that PR publishes stable versions to npm and writes changelogs.
-
-If there were snapshot versions like `1.2.5-beta-20260313T120000` on Artifactory, the resulting stable release is `1.2.5`.
+#### Commerce plugins
 
 Commerce plugins under `plugins/commerce/*` use the same changeset flow, but they are private
 workspace packages and are not published to npm. A changeset targeting a plugin package is the
@@ -511,28 +502,4 @@ plugin version/changelog updates to `main`.
 
 After a public release, the back-sync is automatic — the workflow merges `release` directly into `main` via a merge commit. No manual step needed.
 
-#### Hotfixes
-
-Urgent public fixes should be applied via a PR directly into `release` (patch changeset only) so the fix gets reviewed before going live. Once merged, changesets automatically opens a `[CI] Release Packages` PR — merge it to publish to npm. The back-sync to `main` runs automatically after publish.
-
-#### Repository secrets and deploy key
-
-The promotion and back-sync workflows push directly to `main` and `release`, both of which are protected branches. To allow this without a full admin bypass, the repository uses an SSH **deploy key** with write access, stored as the `DEPLOY_KEY` Actions secret.
-
-The corresponding public key is registered as a repository deploy key. Its `actor_id` is added to the branch ruleset as a `DeployKey` bypass actor (with `bypass_mode: always`), so CI pushes can land on protected branches without going through a pull request.
-
-If the deploy key ever needs to be rotated:
-
-1. Generate a new ed25519 key pair: `ssh-keygen -t ed25519 -C "ci deploy key" -f /tmp/deploy-key -N ""`
-2. Add the public key under **Settings → Deploy keys** (enable write access) and note the new key ID.
-3. Update the `DEPLOY_KEY` Actions secret with the new private key.
-4. Update the ruleset bypass actor with the new key ID via `gh api`.
-
-The Commerce plugin promotion step also requires an `ADOBE_SKILLS_TOKEN` Actions secret. Provision
-it as a fine-grained GitHub personal access token with the following settings:
-
-- **Resource owner:** `adobe`
-- **Repository access:** `adobe/skills` only
-- **Permissions:** Metadata (read), Contents (read/write), Pull requests (read/write)
-- **Expiration:** 366 days (the maximum); set a calendar reminder to regenerate it before it
-  expires, then update the `ADOBE_SKILLS_TOKEN` Actions secret with the new value.
+For triggering stable releases, applying hotfixes, and managing repository secrets, see [MAINTAINERS.md](./MAINTAINERS.md).

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -495,7 +495,3 @@ public release workflow opens or updates a promotion PR in
 Skill-only Release PRs are valid. They do not publish npm packages and do not send the package
 Slack notification, but they still run the `adobe/skills` promotion step and back-sync the
 plugin version/changelog updates to `main`.
-
-#### Back-sync
-
-After a public release, the back-sync is automatic — the workflow merges `release` directly into `main` via a merge commit. No manual step needed.

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -1,0 +1,50 @@
+# Maintainers
+
+This document covers responsibilities and operations reserved for project maintainers — the
+actions that require elevated repository or GitHub Actions permissions, as opposed to the
+day-to-day contributor workflow covered in [DEVELOPMENT.md](./DEVELOPMENT.md). See
+[CONTRIBUTING.md](./CONTRIBUTING.md#from-contributor-to-committer) for how a contributor becomes
+a committer.
+
+## Release Process
+
+See [DEVELOPMENT.md](./DEVELOPMENT.md#release-process) for the full release process overview
+(semantic versioning, changesets workflow, branch channels, snapshot flow, back-sync). The
+following steps require maintainer-level access to execute.
+
+### Triggering a public release
+
+When ready to publish to npm, use the **Promote to Release** workflow dispatch (`promote.yml`):
+
+1. Trigger it from GitHub Actions, optionally specifying a commit SHA on `main` to promote (defaults to latest).
+2. The workflow merges that commit directly into `release` via a merge commit. No config changes needed — changeset files come along unconsumed.
+3. Changesets creates/updates a `[CI] Release Packages` PR on `release`, including regenerated API reference docs.
+4. Merging that PR publishes stable versions to npm and writes changelogs.
+
+If there were snapshot versions like `1.2.5-beta-20260313T120000` on Artifactory, the resulting stable release is `1.2.5`.
+
+### Hotfixes
+
+Urgent public fixes should be applied via a PR directly into `release` (patch changeset only) so the fix gets reviewed before going live. Once merged, changesets automatically opens a `[CI] Release Packages` PR — merge it to publish to npm. The back-sync to `main` runs automatically after publish.
+
+### Repository secrets and deploy key
+
+The promotion and back-sync workflows push directly to `main` and `release`, both of which are protected branches. To allow this without a full admin bypass, the repository uses an SSH **deploy key** with write access, stored as the `DEPLOY_KEY` Actions secret.
+
+The corresponding public key is registered as a repository deploy key. Its `actor_id` is added to the branch ruleset as a `DeployKey` bypass actor (with `bypass_mode: always`), so CI pushes can land on protected branches without going through a pull request.
+
+If the deploy key ever needs to be rotated:
+
+1. Generate a new ed25519 key pair: `ssh-keygen -t ed25519 -C "ci deploy key" -f /tmp/deploy-key -N ""`
+2. Add the public key under **Settings → Deploy keys** (enable write access) and note the new key ID.
+3. Update the `DEPLOY_KEY` Actions secret with the new private key.
+4. Update the ruleset bypass actor with the new key ID via `gh api`.
+
+The Commerce plugin promotion step also requires an `ADOBE_SKILLS_TOKEN` Actions secret. Provision
+it as a fine-grained GitHub personal access token with the following settings:
+
+- **Resource owner:** `adobe`
+- **Repository access:** `adobe/skills` only
+- **Permissions:** Metadata (read), Contents (read/write), Pull requests (read/write)
+- **Expiration:** 366 days (the maximum); set a calendar reminder to regenerate it before it
+  expires, then update the `ADOBE_SKILLS_TOKEN` Actions secret with the new value.

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -12,6 +12,12 @@ See [DEVELOPMENT.md](./DEVELOPMENT.md#release-process) for the full release proc
 (semantic versioning, changesets workflow, branch channels, snapshot flow, back-sync). The
 following steps require maintainer-level access to execute.
 
+### Requesting a PR snapshot
+
+Commenting `/snapshot` on an open PR publishes an `alpha` snapshot of that PR's changes to
+Artifactory without affecting `main`. The workflow that handles this comment checks that the
+commenter has **admin** permission on the repository, so this is restricted to maintainers.
+
 ### Triggering a public release
 
 When ready to publish to npm, use the **Promote to Release** workflow dispatch (`promote.yml`):

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -9,8 +9,8 @@ a committer.
 ## Release Process
 
 See [DEVELOPMENT.md](./DEVELOPMENT.md#release-process) for the full release process overview
-(semantic versioning, changesets workflow, branch channels, snapshot flow, back-sync). The
-following steps require maintainer-level access to execute.
+(semantic versioning, changesets workflow, branch channels, snapshot flow). The following steps
+require maintainer-level access to execute.
 
 ### Requesting a PR snapshot
 
@@ -28,6 +28,10 @@ When ready to publish to npm, use the **Promote to Release** workflow dispatch (
 4. Merging that PR publishes stable versions to npm and writes changelogs.
 
 If there were snapshot versions like `1.2.5-beta-20260313T120000` on Artifactory, the resulting stable release is `1.2.5`.
+
+### Back-sync
+
+After a public release, the back-sync is automatic — the workflow merges `release` directly into `main` via a merge commit. No manual step needed.
 
 ### Hotfixes
 

--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -44,6 +44,14 @@
   - changed-files:
       - any-glob-to-any-file: "packages-private/common-utils/**"
 
+"pkg: aio-commerce-plugin-app-management":
+  - changed-files:
+      - any-glob-to-any-file: "plugins/commerce/app-management/**"
+
+"pkg: aio-commerce-plugin-app-migration":
+  - changed-files:
+      - any-glob-to-any-file: "plugins/commerce/app-migration/**"
+
 "scripts":
   - changed-files:
       - any-glob-to-any-file: "scripts/**"

--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -44,11 +44,11 @@
   - changed-files:
       - any-glob-to-any-file: "packages-private/common-utils/**"
 
-"pkg: aio-commerce-plugin-app-management":
+"plugin: aio-commerce-plugin-app-management":
   - changed-files:
       - any-glob-to-any-file: "plugins/commerce/app-management/**"
 
-"pkg: aio-commerce-plugin-app-migration":
+"plugin: aio-commerce-plugin-app-migration":
   - changed-files:
       - any-glob-to-any-file: "plugins/commerce/app-migration/**"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 - Source is ESM only (`import/export`); build output ships both ESM and CJS (generated automatically by TSDown — don't modify format settings)
 - Build tool: TSDown; each package has a `tsdown.config.ts` extending `baseConfig` from `@aio-commerce-sdk/config-tsdown` via `mergeConfig`
 - New packages are scaffolded manually (interactive): `pnpm turbo gen create-package`
+- Every new package needs a matching entry in `.github/labeler-config.yml` so PRs touching it get labeled automatically — the `create-package` generator does not do this for you
 - Public packages: `@adobe/` scope (`"private": false`); internal: `@aio-commerce-sdk/` scope (`"private": true`)
 - Monorepo-local deps use `workspace:*`; third-party deps shared across multiple packages use `catalog:` (defined in `pnpm-workspace.yaml`)
 - Every public package must declare `"sideEffects"` in `package.json`: `false` if no side effects, or an array of files that do have side effects

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Agentic tooling lives under [`plugins/`](./plugins/). Each plugin is independent
 - [Adobe App Builder Documentation](https://developer.adobe.com/app-builder/docs/overview/)
 - [Adobe Commerce Documentation](https://developer.adobe.com/commerce/docs/)
 - [Development Guide](./.github/DEVELOPMENT.md)
+- [Maintainers Guide](./.github/MAINTAINERS.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 
 ## License


### PR DESCRIPTION
## Description

Two related documentation/process fixes:

1. Extracts a new `.github/MAINTAINERS.md` file from `.github/DEVELOPMENT.md`, moving the release
   steps that require maintainer-level repository/Actions permissions (triggering the Promote to
   Release workflow, applying hotfixes, deploy key rotation, and `ADOBE_SKILLS_TOKEN`
   provisioning) out of the contributor-facing development guide. `DEVELOPMENT.md` now links to
   `MAINTAINERS.md` for those steps, and `CONTRIBUTING.md`/`README.md` link to it as well.
2. Adds missing `.github/labeler-config.yml` entries for the commerce plugin packages
   (`plugins/commerce/app-management`, `plugins/commerce/app-migration`), which were registered
   as workspace members by the skills release process but never got a matching label. Also adds
   a note to `AGENTS.md` so new packages don't miss this step again.

## Related Issue

Follow-up from discussion on #540: https://github.com/adobe/aio-commerce-sdk/pull/540#discussion_r3521031695

## Motivation and Context

The `ADOBE_SKILLS_TOKEN` provisioning steps added in #540 were flagged as a repo-admin concern
that doesn't belong in the developer-facing `DEVELOPMENT.md`. This PR follows through on the
agreed plan to extract a dedicated `MAINTAINERS.md`. While reviewing the plugin workspace setup
introduced by the same skills release process, I also noticed PRs touching plugin packages
weren't getting a package-specific label, since the labeler config was never updated for them.

## How Has This Been Tested?

Documentation and config-only change. Ran `pnpm format:markdown` to confirm formatting is
unaffected, verified no other file references the anchors that moved out of `DEVELOPMENT.md`,
and reviewed the labeler config change against the existing `pkg:` naming convention.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.