### PR TITLE
CEXT-6421: simplify slack release announcement to plain text payload

### DIFF
--- a/scripts/source/ci/release/announce.ts
+++ b/scripts/source/ci/release/announce.ts
@@ -39,17 +39,7 @@ function announce(): SlackPayload {
     packageBaseUrl,
   );
 
-  return {
-    blocks: [
-      {
-        text: {
-          text: announcement,
-          type: "mrkdwn",
-        },
-        type: "section",
-      },
-    ],
-  };
+  return { text: announcement };
 }
 
 /** Reads the inputs from the environment variables. */

--- a/scripts/source/ci/release/types.ts
+++ b/scripts/source/ci/release/types.ts
@@ -31,13 +31,7 @@ export type PublishedPackage = {
 
 /** Slack payload for release announcement messages. */
 export type SlackPayload = {
-  blocks: Array<{
-    type: string;
-    text: {
-      type: string;
-      text: string;
-    };
-  }>;
+  text: string;
 };
 
 /**

--- a/scripts/test/unit/ci/release/announce.test.ts
+++ b/scripts/test/unit/ci/release/announce.test.ts
@@ -67,7 +67,7 @@ describe("release/announce.ts", () => {
     });
 
     const payload = announce(asCore(core));
-    const text = payload.blocks[0]?.text.text ?? "";
+    const { text } = payload;
 
     expect(text).toContain("public (NPM)");
     expect(text).toContain(
@@ -89,7 +89,7 @@ describe("release/announce.ts", () => {
     });
 
     const payload = announce(asCore(core));
-    const text = payload.blocks[0]?.text.text ?? "";
+    const { text } = payload;
 
     expect(core.setFailed).not.toHaveBeenCalled();
     expect(text).toContain("public (NPM)");
@@ -106,7 +106,7 @@ describe("release/announce.ts", () => {
     });
 
     const payload = await announce(asCore(core));
-    const text = payload.blocks[0]?.text.text ?? "";
+    const { text } = payload;
 
     expect(text.indexOf("@adobe/aio-commerce-sdk@1.0.0")).toBeLessThan(
       text.indexOf("@adobe/aio-commerce-lib-alpha@1.0.0"),


### PR DESCRIPTION
## Description

Replaces the Block Kit (`blocks`/`section`) payload used for the release announcement Slack message with a plain `{"text": ...}` payload.

## Related Issue

CEXT-6421

## Motivation and Context

The Block Kit wrapper wasn't needed for a single mrkdwn text block; Slack's Incoming Webhook API renders the same mrkdwn formatting (bold, code, links) from a plain `text` field. Simplifying reduces the payload to just the content that matters.

## How Has This Been Tested?

Updated and ran the existing unit tests for `scripts/source/ci/release/announce.ts` (`pnpm --filter @aio-commerce-sdk/scripts test`), and manually reconstructed and posted the payload to a Slack webhook to confirm it renders identically to the previous Block Kit version.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.