### PR TITLE
Fix Commerce integration (OAuth 1.0a) request signing for URLs with array-style query parameters

### DIFF
--- a/.changeset/fix-integration-oauth-query-signature.md
+++ b/.changeset/fix-integration-oauth-query-signature.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-lib-auth": patch
 ---
 
-Fix Commerce integration (OAuth 1.0a) request signing for URLs with array-style query parameters (e.g. `searchCriteria[...]`). Query parameters are now decoded via `URLSearchParams` and signed as normalized parameters against the query-less base URI (RFC 5849 §3.4.1.2), instead of delegating URL parsing to `oauth-1.0a` — whose `deParam` does not decode parameter keys, leaving percent-encoded keys double-encoded in the signature base string. This caused Adobe Commerce to reject affected requests with "The signature is invalid."
+Fix Commerce integration (OAuth 1.0a) request signing for URLs with array-style query parameters (e.g. `searchCriteria[...]`). This caused Adobe Commerce to reject affected requests with "The signature is invalid."

--- a/.changeset/fix-integration-oauth-query-signature.md
+++ b/.changeset/fix-integration-oauth-query-signature.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-auth": patch
+---
+
+Fix Commerce integration (OAuth 1.0a) request signing for URLs with array-style query parameters (e.g. `searchCriteria[...]`). Query parameters are now decoded via `URLSearchParams` and signed as normalized parameters against the query-less base URI (RFC 5849 §3.4.1.2), instead of delegating URL parsing to `oauth-1.0a` — whose `deParam` does not decode parameter keys, leaving percent-encoded keys double-encoded in the signature base string. This caused Adobe Commerce to reject affected requests with "The signature is invalid."

--- a/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
+++ b/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
@@ -110,9 +110,35 @@ export function getIntegrationAuthProvider(
 
   return {
     getHeaders: (method: HttpMethodInput, url: AdobeCommerceUrl) => {
-      const urlString = parse(UrlSchema, url);
+      const parsed = new URL(parse(UrlSchema, url));
+
+      // OAuth 1.0a signs the request parameters (RFC 5849 §3.4.1.3) merged into
+      // the base string (§3.4.1.1); the base-string URI itself excludes the
+      // query (§3.4.1.2). oauth-1.0a normally derives those parameters from the
+      // URL via `deParam`, which decodes parameter values but NOT keys — so
+      // percent-encoded keys (e.g. `searchCriteria%5B...%5D`) get double-encoded
+      // in the base string and Adobe Commerce rejects the request with "The
+      // signature is invalid.". Instead we decode the query with URLSearchParams
+      // (keys and values) and pass it as `request.data`, which oauth-1.0a folds
+      // into the very same parameter string (getParameterString merges `data`) —
+      // so the params stay signed, just sourced correctly — and we sign against
+      // the query-less base URI. Repeated keys collapse to an array, matching
+      // oauth-1.0a's own multi-value handling.
+      const data: Record<string, string | string[]> = {};
+      for (const [key, value] of parsed.searchParams) {
+        const existing = data[key];
+        if (existing === undefined) {
+          data[key] = value;
+        } else {
+          data[key] = Array.isArray(existing)
+            ? [...existing, value]
+            : [existing, value];
+        }
+      }
+
+      const baseUri = `${parsed.origin}${parsed.pathname}`;
       return oauth.toHeader(
-        oauth.authorize({ method, url: urlString }, oauthToken),
+        oauth.authorize({ data, method, url: baseUri }, oauthToken),
       );
     },
   };

--- a/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
+++ b/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
@@ -112,18 +112,8 @@ export function getIntegrationAuthProvider(
     getHeaders: (method: HttpMethodInput, url: AdobeCommerceUrl) => {
       const parsed = new URL(parse(UrlSchema, url));
 
-      // OAuth 1.0a signs the request parameters (RFC 5849 §3.4.1.3) merged into
-      // the base string (§3.4.1.1); the base-string URI itself excludes the
-      // query (§3.4.1.2). oauth-1.0a normally derives those parameters from the
-      // URL via `deParam`, which decodes parameter values but NOT keys — so
-      // percent-encoded keys (e.g. `searchCriteria%5B...%5D`) get double-encoded
-      // in the base string and Adobe Commerce rejects the request with "The
-      // signature is invalid.". Instead we decode the query with URLSearchParams
-      // (keys and values) and pass it as `request.data`, which oauth-1.0a folds
-      // into the very same parameter string (getParameterString merges `data`) —
-      // so the params stay signed, just sourced correctly — and we sign against
-      // the query-less base URI. Repeated keys collapse to an array, matching
-      // oauth-1.0a's own multi-value handling.
+      // oauth-1.0a's authorize method re-encodes keys even if already encoded
+      // Split query parameters from base URL to avoid double encoding
       const data: Record<string, string | string[]> = {};
       for (const [key, value] of parsed.searchParams) {
         const existing = data[key];

--- a/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
+++ b/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
@@ -115,15 +115,11 @@ export function getIntegrationAuthProvider(
       // oauth-1.0a's authorize method re-encodes keys even if already encoded
       // Split query parameters from base URL to avoid double encoding
       const data: Record<string, string | string[]> = {};
-      for (const [key, value] of parsed.searchParams) {
-        const existing = data[key];
-        if (existing === undefined) {
-          data[key] = value;
-        } else {
-          data[key] = Array.isArray(existing)
-            ? [...existing, value]
-            : [existing, value];
-        }
+      const uniqueKeys = Array.from(new Set(parsed.searchParams.keys()))
+      
+      for (const key of uniqueKeys) {
+        const values = parsed.searchParams.getAll(key);
+        data[key] = values.length > 1 ? values : values[0];
       }
 
       const baseUri = `${parsed.origin}${parsed.pathname}`;

--- a/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
+++ b/packages/aio-commerce-lib-auth/source/lib/integration-auth/provider.ts
@@ -115,8 +115,8 @@ export function getIntegrationAuthProvider(
       // oauth-1.0a's authorize method re-encodes keys even if already encoded
       // Split query parameters from base URL to avoid double encoding
       const data: Record<string, string | string[]> = {};
-      const uniqueKeys = Array.from(new Set(parsed.searchParams.keys()))
-      
+      const uniqueKeys = Array.from(new Set(parsed.searchParams.keys()));
+
       for (const key of uniqueKeys) {
         const values = parsed.searchParams.getAll(key);
         data[key] = values.length > 1 ? values : values[0];

--- a/packages/aio-commerce-lib-auth/test/integration-auth.test.ts
+++ b/packages/aio-commerce-lib-auth/test/integration-auth.test.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
   getIntegrationAuthProvider,
@@ -54,6 +54,42 @@ describe("aio-commerce-lib-auth/integration-auth", () => {
         "Authorization",
         expect.stringMatching(OAUTH1_REGEX),
       );
+    });
+
+    test("signs array-style query params consistently regardless of key encoding", () => {
+      // Freeze the nonce and timestamp so signatures from two calls are directly
+      // comparable (oauth-1.0a derives both from Math.random / Date).
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+      try {
+        const provider = getIntegrationAuthProvider({
+          accessToken: "test-access-token",
+          accessTokenSecret: "test-access-token-secret",
+          consumerKey: "test-consumer-key",
+          consumerSecret: "test-consumer-secret",
+        });
+
+        // Same logical request, brackets percent-encoded vs. literal.
+        const encoded = provider.getHeaders(
+          "GET",
+          "http://localhost/rest/all/V1/products?searchCriteria%5BpageSize%5D=1",
+        );
+        const literal = provider.getHeaders(
+          "GET",
+          "http://localhost/rest/all/V1/products?searchCriteria[pageSize]=1",
+        );
+
+        // Before the fix these diverged (the encoded key was double-encoded in
+        // the signature base string), which Adobe Commerce rejected as an
+        // invalid signature.
+        expect(encoded.Authorization).toBe(literal.Authorization);
+        expect(encoded.Authorization).toMatch(OAUTH1_REGEX);
+      } finally {
+        randomSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Description

`getIntegrationAuthProvider` handed the fully-encoded request URL to  `oauth-1.0a`'s `authorize({ url })`. Internally that library's `deParam`  decodes parameter **values** but not **keys**, so a percent-encoded key such as  `searchCriteria%5BpageSize%5D` is re-encoded a second time (`%255B…`) when the  signature base string is built. Adobe Commerce reconstructs the base string  with  single-encoded keys, the two disagree, and the request is rejected with  `401 "The signature is invalid."`. This affects every OAuth 1.0a (PaaS) call  that  carries array-style query parameters — i.e. anything using `searchCriteria`  (`products`, `categories`, `products/attributes`, …).

 This change stops delegating URL parsing to `oauth-1.0a`. In `getHeaders` we  now:

- parse the URL and read its query via `URLSearchParams`, which decodes  **both**   keys and values;
- pass those decoded pairs as `request.data`, which `oauth-1.0a` merges into  the  signature parameter string (RFC 5849 §3.4.1.3 / §3.4.1.1); and
- sign against the **query-less** base URI (§3.4.1.2).

The parameters therefore remain part of the signature — they are simply sourced  correctly (decoded once, then single-encoded), so the base string matches  Commerce's. Repeated keys collapse to an array, matching `oauth-1.0a`'s  existing
multi-value handling. Public API and behaviour for query-less requests are  unchanged.
  
## Related Issue

Root cause is the upstream, unmaintained `oauth-1.0a` (last release 2019):
- ddo/oauth-1.0a#49 ("Base string incorrect for array type GET query string") and
- ddo/oauth-1.0a#24. Fixed here in the provider rather than waiting on the dependency.

## Motivation and Context

Any consumer using the Commerce integration (OAuth 1.0a) auth on a PaaS instance cannot call the standard search endpoints — the most common REST calls in an  App Builder app — because the signature never validates. There is no config or credential workaround; it fails purely on the request shape. This restores `searchCriteria`-based reads/writes for OAuth1 integrations.

## How Has This Been Tested?
- **New regression test** in `test/integration-auth.test.ts`: with a frozen  nonce and timestamp, the same logical request expressed with percent-encoded  (`%5B…%5D`) vs. literal (`[…]`) bracket keys must produce an identical `Authorization` header. Verified it **fails on the pre-fix code** (identical nonce/timestamp but different `oauth_signature`) and **passes after** the fix.
- Full package suite: `vitest run` — **35/35 passing**.
- `biome check` (formatter + linter + assist): clean, no fixes.
- `tsc --noEmit`: clean.
- **End-to-end** against a live Adobe Commerce PaaS instance: reproduced  `401 "The signature is invalid."` on `GET
  /V1/products/attributes?searchCriteria[...]` with the current release, and confirmed the corrected base string (decoded keys) is accepted (`200`).

Environment: Node.js 22, `vitest` 4, `@biomejs/biome` 2.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality  to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.