### PR TITLE
CEXT-6482: add resolveIoEventCode utility

### DIFF
--- a/.changeset/dark-bikes-create.md
+++ b/.changeset/dark-bikes-create.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Added `resolveIoEventCode` to compute an event's I/O Events event code from its app ID, name, and provider type, without needing to read it back from stored installation data.

--- a/.changeset/dark-bikes-create.md
+++ b/.changeset/dark-bikes-create.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-lib-app": minor
 ---
 
-Added `resolveIoEventCode` to compute an event's I/O Events event code from its app ID, name, and provider type, without needing to read it back from stored installation data.
+Added `resolveIoEventCode` to compute an event's I/O Events event code from an app ID, event name, and provider type.

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -10,6 +10,7 @@ The `@adobe/aio-commerce-lib-app` library provides:
 - **Admin UI Configuration** (`commerce/backend-ui/2`): Generate and manage the runtime action and `workerProcess` declarations for Admin UI extensions on `commerce/backend-ui/2`. Currently supports grid column extensions, mass actions, order view buttons, and menu declarations.
 - **Association Helpers**: Retrieve the Commerce instance the app is associated with from any runtime action via `getCommerceClient` and `getCommerceInstance`.
 - **Event Emission**: Publish a configured I/O Event from any runtime action by provider key and event name via `publishEvent`.
+- **Event Code Resolution**: Compute the I/O Events event code for a declared event via `resolveIoEventCode`, without reading it back from stored installation data.
 
 ## Reference
 
@@ -1102,6 +1103,24 @@ try {
   }
   throw error;
 }
+```
+
+### Resolving an Event's I/O Events Code
+
+`resolveIoEventCode(appId, eventName, providerType)` computes the same event code `publishEvent` sends, without needing installation to have run or reading it back from stored data. This is useful when a caller needs to know an event's code ahead of time, e.g. to match it against an incoming I/O Event.
+
+- `appId` — the application's `metadata.id`, as declared in `app.commerce.config.ts`.
+- `eventName` — the `name` of the event, as declared in `app.commerce.config.ts`.
+- `providerType` — `"commerce"` or `"external"`, matching the section the event is declared under.
+
+```ts
+import { resolveIoEventCode } from "@adobe/aio-commerce-lib-app";
+
+resolveIoEventCode("my-app", "observer.order_placed", "commerce");
+// => "com.adobe.commerce.my_app.observer.order_placed"
+
+resolveIoEventCode("my-app", "webhook.received", "external");
+// => "my_app.webhook.received"
 ```
 
 ## Best Practices

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -1107,7 +1107,7 @@ try {
 
 ### Resolving an Event's I/O Events Code
 
-`resolveIoEventCode(appId, eventName, providerType)` computes the same event code `publishEvent` sends, without needing installation to have run or reading it back from stored data. This is useful when a caller needs to know an event's code ahead of time, e.g. to match it against an incoming I/O Event.
+`resolveIoEventCode(appId, eventName, providerType)` computes an event code matching the prefixing rules used at installation time (and that `publishEvent` sends). This is useful when a caller needs to know an event's code ahead of time, e.g. to match it against an incoming I/O Event.
 
 - `appId` — the application's `metadata.id`, as declared in `app.commerce.config.ts`.
 - `eventName` — the `name` of the event, as declared in `app.commerce.config.ts`.

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -10,7 +10,7 @@ The `@adobe/aio-commerce-lib-app` library provides:
 - **Admin UI Configuration** (`commerce/backend-ui/2`): Generate and manage the runtime action and `workerProcess` declarations for Admin UI extensions on `commerce/backend-ui/2`. Currently supports grid column extensions, mass actions, order view buttons, and menu declarations.
 - **Association Helpers**: Retrieve the Commerce instance the app is associated with from any runtime action via `getCommerceClient` and `getCommerceInstance`.
 - **Event Emission**: Publish a configured I/O Event from any runtime action by provider key and event name via `publishEvent`.
-- **Event Code Resolution**: Compute the I/O Events event code for a declared event via `resolveIoEventCode`, without reading it back from stored installation data.
+- **Event Code Resolution**: Compute the I/O Events event code for a declared event via `resolveIoEventCode`, matching the prefixing rules used at installation time.
 
 ## Reference
 

--- a/packages/aio-commerce-lib-app/source/index.ts
+++ b/packages/aio-commerce-lib-app/source/index.ts
@@ -30,6 +30,6 @@ export {
   ProviderNotFoundError,
   PublishEventError,
 } from "./lib/errors";
-export { publishEvent } from "./lib/events";
+export { publishEvent, resolveIoEventCode } from "./lib/events";
 
 export type { AssociatedCommerceData } from "./management/association/types";

--- a/packages/aio-commerce-lib-app/source/lib/events.ts
+++ b/packages/aio-commerce-lib-app/source/lib/events.ts
@@ -12,7 +12,13 @@
 
 import { getSystemConfigByKey } from "@adobe/aio-commerce-lib-config";
 
-import { EVENTS_STORAGE_KEY } from "../management/installation/events/utils";
+import {
+  COMMERCE_PROVIDER_TYPE,
+  EVENTS_STORAGE_KEY,
+  EXTERNAL_PROVIDER_TYPE,
+  getIoEventCode,
+  getNamespacedEvent,
+} from "../management/installation/events/utils";
 import {
   EventNotFoundError,
   EventsDataNotInitializedError,
@@ -90,4 +96,40 @@ export async function publishEvent<
     payload,
     providerId: providerEntry.id,
   });
+}
+
+/**
+ * Resolves the I/O Events event code for an event, matching what {@link publishEvent}
+ * sends once the app is installed.
+ *
+ * Applies the same app-ID namespacing and Commerce-provider prefixing rules used at
+ * installation time, so callers can determine an event's code without waiting for
+ * installation to complete or reading it back from stored data.
+ *
+ * @param appId - The application's `metadata.id`, as declared in `app.commerce.config`.
+ * @param eventName - The `name` of the event, as declared in `app.commerce.config`.
+ * @param providerType - Whether the event belongs to a `"commerce"` or `"external"` provider.
+ *
+ * @example
+ * ```ts
+ * import { resolveIoEventCode } from "@adobe/aio-commerce-lib-app";
+ *
+ * resolveIoEventCode("my-app", "observer.order_placed", "commerce");
+ * // => "com.adobe.commerce.my_app.observer.order_placed"
+ *
+ * resolveIoEventCode("my-app", "webhook.received", "external");
+ * // => "my_app.webhook.received"
+ * ```
+ */
+export function resolveIoEventCode(
+  appId: string,
+  eventName: string,
+  providerType: "commerce" | "external",
+): string {
+  return getIoEventCode(
+    getNamespacedEvent({ id: appId }, eventName),
+    providerType === "commerce"
+      ? COMMERCE_PROVIDER_TYPE
+      : EXTERNAL_PROVIDER_TYPE,
+  );
 }

--- a/packages/aio-commerce-lib-app/source/lib/events.ts
+++ b/packages/aio-commerce-lib-app/source/lib/events.ts
@@ -99,12 +99,7 @@ export async function publishEvent<
 }
 
 /**
- * Resolves the I/O Events event code for an event, matching what {@link publishEvent}
- * sends once the app is installed.
- *
- * Applies the same app-ID namespacing and Commerce-provider prefixing rules used at
- * installation time, so callers can determine an event's code without waiting for
- * installation to complete or reading it back from stored data.
+ * Resolves the I/O Events event code for an event. Applies the same app-ID namespacing and Commerce-provider prefixing rules used at installation time.
  *
  * @param appId - The application's `metadata.id`, as declared in `app.commerce.config`.
  * @param eventName - The `name` of the event, as declared in `app.commerce.config`.

--- a/packages/aio-commerce-lib-app/source/management/installation/events/utils.ts
+++ b/packages/aio-commerce-lib-app/source/management/installation/events/utils.ts
@@ -131,7 +131,7 @@ export function findExistingRegistrations(
  * @param name
  */
 export function getNamespacedEvent(
-  metadata: ApplicationMetadata,
+  metadata: Pick<ApplicationMetadata, "id">,
   name: string,
 ) {
   const sanitizedId = metadata.id.toLowerCase().replace(/[^a-z0-9_]/g, "_");

--- a/packages/aio-commerce-lib-app/test/unit/lib/events.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/lib/events.test.ts
@@ -25,7 +25,7 @@ import {
   EventsDataNotInitializedError,
   ProviderNotFoundError,
 } from "#lib/errors";
-import { publishEvent } from "#lib/events";
+import { publishEvent, resolveIoEventCode } from "#lib/events";
 
 import type { AdobeIoEventsApiClient } from "@adobe/aio-commerce-lib-events/io-events";
 
@@ -151,5 +151,25 @@ describe("publishEvent", () => {
     ).rejects.toBeInstanceOf(EventNotFoundError);
 
     expect(client.publishEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveIoEventCode", () => {
+  test("prefixes with com.adobe.commerce. for commerce provider type", () => {
+    expect(
+      resolveIoEventCode("my-app", "observer.order_placed", "commerce"),
+    ).toBe("com.adobe.commerce.my_app.observer.order_placed");
+  });
+
+  test("does not prefix for external provider type", () => {
+    expect(resolveIoEventCode("my-app", "webhook.received", "external")).toBe(
+      "my_app.webhook.received",
+    );
+  });
+
+  test("sanitizes and lowercases the app id", () => {
+    expect(
+      resolveIoEventCode("My App!", "observer.order_placed", "commerce"),
+    ).toBe("com.adobe.commerce.my_app_.observer.order_placed");
   });
 });


### PR DESCRIPTION
## Description

Adds `resolveIoEventCode(appId, eventName, providerType)`, a public utility to compute an event's I/O Events event code (namespaced + Commerce-prefixed as applicable) without needing installation to have run or reading the code back from stored system config data.

## Related Issue

CEXT-6482

## Motivation and Context

Callers sometimes need to know an event's I/O Events code ahead of time (e.g. to match an incoming event), without waiting on stored installation data. This exposes the same namespacing/prefixing logic used internally at installation time as a small, synchronous public helper.

## How Has This Been Tested?

- Added unit tests in `test/unit/lib/events.test.ts` covering commerce prefixing, external (no prefix), and app-ID sanitization/lowercasing.
- `pnpm test` and `pnpm typecheck` pass for the package.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.