### PR TITLE
CEXT-6482: re-export named exports from generated app.commerce.config.js

### DIFF
--- a/.changeset/green-rats-create.md
+++ b/.changeset/green-rats-create.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+The generated `#app.commerce.config` module now re-exports any named exports from your `app.commerce.config.*` file, in addition to its default export.

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -91,7 +91,7 @@ This produces the following files, organized by extension point:
 - `src/commerce-extensibility-1/.generated/actions/app-management/installation.js`: drives the installation flow, including any custom scripts you define
 - `src/commerce-extensibility-1/ext.config.yaml`: extension manifest with the `pre-app-build` hook
 
-Generated application code should import app metadata from `#app.commerce.config`. For static configurations, the alias points to `src/commerce-extensibility-1/.generated/app.commerce.manifest.json`. For dynamic configurations, it points to a generated runtime-safe ESM module.
+Generated application code should import app metadata from `#app.commerce.config`. The alias can be used to import the config's default export, as well as any other symbols exported from your `app.commerce.config.*` file.
 
 **`commerce/configuration/1`**: Business configuration (generated when `businessConfig` is defined):
 

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
@@ -149,7 +149,9 @@ async function writeJavaScriptAppConfigModule(
       isJson ? null : `export * from "${configImportPath}";`,
       "export default appConfig;",
       "",
-    ].filter(item => item !== null).join("\n"),
+    ]
+      .filter((item) => item !== null)
+      .join("\n"),
     "utf-8",
   );
 }

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
@@ -134,8 +134,8 @@ async function writeJavaScriptAppConfigModule(
   );
 
   // JSON imports require an import attribute under Node's ESM loader.
-  const importAttributes =
-    extname(configFilePath) === ".json" ? ' with { type: "json" }' : "";
+  const isJson = extname(configFilePath) === ".json";
+  const importAttributes = isJson ? ' with { type: "json" }' : "";
 
   await writeFile(
     outputPath,
@@ -145,10 +145,11 @@ async function writeJavaScriptAppConfigModule(
       "",
       `import appConfig from "${configImportPath}"${importAttributes};`,
       "",
-      `export * from "${configImportPath}"${importAttributes};`,
+      // JSON can't have any exports other than the default one.
+      isJson ? null : `export * from "${configImportPath}";`,
       "export default appConfig;",
       "",
-    ].join("\n"),
+    ].filter(item => item !== null).join("\n"),
     "utf-8",
   );
 }

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
@@ -145,6 +145,7 @@ async function writeJavaScriptAppConfigModule(
       "",
       `import appConfig from "${configImportPath}"${importAttributes};`,
       "",
+      `export * from "${configImportPath}"${importAttributes};`,
       "export default appConfig;",
       "",
     ].join("\n"),

--- a/packages/aio-commerce-lib-app/test/fixtures/business-config.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/business-config.ts
@@ -42,7 +42,9 @@ export const schemaWithDynamicListOptions = [
  * fixtures so codegen integration tests can bundle a real config file with a
  * `dynamicList` factory.
  */
-export const dynamicOptionsConfigFile = `export default {
+export const dynamicOptionsConfigFile = `export const paymentMethodOptions = [{ label: "Braintree", value: "braintree" }];
+
+export default {
   metadata: {
     id: "dynamic-options",
     displayName: "Dynamic Options",
@@ -54,7 +56,7 @@ export const dynamicOptionsConfigFile = `export default {
       name: "paymentMethod",
       type: "dynamicList",
       selectionMode: "single",
-      options: () => [{ label: "Braintree", value: "braintree" }],
+      options: () => paymentMethodOptions,
       default: (opts) => opts[0].value,
     }],
   },

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -230,6 +230,7 @@ describe("commands/generate/actions", () => {
           // JS config files get a passthrough wrapper.
           const moduleContents = await readFile(runtimeConfigPath, "utf-8");
           expect(moduleContents).toContain("import appConfig from");
+          expect(moduleContents).toContain("export * from");
           expect(moduleContents).toContain("export default appConfig");
 
           const pkg = JSON.parse(
@@ -238,6 +239,12 @@ describe("commands/generate/actions", () => {
           expect(pkg.imports["#app.commerce.config"]).toBe(
             "./src/commerce-extensibility-1/.generated/app.commerce.config.js",
           );
+
+          // Named exports from the source config file are re-exported alongside the default.
+          const mod = await import(runtimeConfigPath);
+          expect(mod.paymentMethodOptions).toEqual([
+            { label: "Braintree", value: "braintree" },
+          ]);
         },
       );
     });


### PR DESCRIPTION
## Description

The generated runtime-safe passthrough module written to `.generated/app.commerce.config.js` only forwarded the config file's default export. This adds a wildcard re-export so any other named exports declared in `app.commerce.config.*` are also available through the `#app.commerce.config` alias, alongside the default export.

## Related Issue

CEXT-6482

## Motivation and Context

Consumers of the generated config module (e.g. generated runtime actions, web-src) can now import named exports from their `app.commerce.config.*` file, not just the default config object.

## How Has This Been Tested?

- Added a named export to the shared `dynamicOptionsConfigFile` test fixture and asserted it's re-exported and importable from the generated module in `actions.test.ts`.
- `pnpm --filter @adobe/aio-commerce-lib-app test` and `pnpm --filter @adobe/aio-commerce-lib-app typecheck` pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.