### PR TITLE
CEXT-6454: decouple Admin UI menu from routes

### DIFF
--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -580,7 +580,7 @@ function Actions() {
 
 #### Reading the mass-action selection
 
-`useMassActionContext` returns the row IDs the mass action was triggered with. It reads from the host-provided Commerce context and returns an error when that context doesn't include a mass-action selection:
+`useMassActionContext` returns the row IDs the mass action was triggered with. It reads from the host-provided Commerce context and returns an error when the selection is missing, empty, or contains a non-string row ID:
 
 ```jsx
 import { useMassActionContext } from "@adobe/aio-commerce-lib-admin-ui/web";
@@ -589,7 +589,7 @@ function MassActionPage() {
   const { data, error } = useMassActionContext();
   if (error) return null;
 
-  // data.selectedIds is string[] (an empty selection is valid).
+  // data.selectedIds is a non-empty string[].
 }
 ```
 

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -490,7 +490,7 @@ The `./web` entrypoint provides the browser side of a `commerce/backend-ui/2` ap
 
 #### Mounting an app
 
-`createExtensionApp` mounts the app into the element with id `root` (or into the `root` element you pass). `routes` must start with the index route; additional routes are path-based:
+`createExtensionApp` mounts the app into the element with id `root` (or into the `root` element you pass). When your app has a Commerce Admin menu, pass its page through the optional `menu` property. Experience Cloud Shell also renders this page by default. Use `routes` for additional pages:
 
 ```jsx
 // src/app.jsx
@@ -502,38 +502,63 @@ import { SettingsPage } from "./pages/settings-page.jsx";
 
 createExtensionApp({
   metadata: { extensionId: "my-extension-id" },
-  routes: [
-    { index: true, element: <MainPage /> },
-    { path: "/settings", element: <SettingsPage /> },
-  ],
+  menu: <MainPage />,
+  routes: [{ path: "/settings", element: <SettingsPage /> }],
 });
 ```
+
+When you provide `menu`, it owns the root route. Don't also add a root-equivalent path such as `"/"` or `"#/"` to `routes`; `createExtensionApp` reports that duplicate declaration as an error. When your app doesn't have a menu, omit `menu` and declare the root page in `routes` instead.
 
 The whole app is wrapped in React's [`<StrictMode>`](https://react.dev/reference/react/StrictMode). When running locally with `aio app dev` or `aio app run` (which serve React's development build), StrictMode runs its extra development-only checks: components render twice, and effects run an extra setup + cleanup cycle on mount. Duplicated renders, effect runs, or requests fired from effects during development are therefore expected — not a bug — and surface unsafe side effects early. These checks do not run in production builds, where StrictMode has no effect.
 
 #### Reading IMS credentials
 
-`useIms` returns the IMS credentials provided by the host (`{ imsToken, imsOrgId }`). It works inside both the Commerce Admin and the Experience Cloud shell, and throws when the app runs standalone (no host provides credentials):
+The browser hooks return a `Result` with complementary `data` and `error` fields. When the requested host data is available, `data` contains it and `error` is `null`. Otherwise, `data` is `null` and `error` explains why the `data` can't be provided.
+
+You can forward an error to the app's error boundary when you don't need custom fallback UI:
+
+```jsx
+const { data, error } = useIms();
+if (error) throw error;
+```
+
+`useIms` returns the IMS credentials provided by the host (`{ imsToken, imsOrgId }`). It works inside both the Commerce Admin and the Experience Cloud shell, and returns an error when the app runs standalone because no host provides credentials:
 
 ```jsx
 import { useIms } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function Welcome() {
-  const { imsToken, imsOrgId } = useIms();
-  // Use imsToken to call IMS-authenticated APIs on behalf of the admin user.
+  const { data, error } = useIms();
+  if (error) return <span>{error.message}</span>;
+
+  // Use data.imsToken to call IMS-authenticated APIs on behalf of the admin user.
+  return <span>{data.imsOrgId}</span>;
 }
 ```
 
+When a component is guaranteed to render within a supported host and you intentionally don't need explicit error handling, you can ignore `error` and use optional chaining:
+
+```jsx
+function Welcome() {
+  const { data } = useIms();
+  return <span>{data?.imsOrgId}</span>;
+}
+```
+
+This is valid, but it is less explicit and not recommended. If the component renders outside the expected host, it silently renders an absent value instead of explaining or forwarding the error.
+
 #### Resolving the Commerce host
 
-`useCommerce` returns the host (domain) of the Commerce Admin the extension is embedded in. The value is resolved over the guest connection via the host's integration API. It throws when used outside the Commerce Admin frame, or when the host does not expose that integration API:
+`useCommerce` returns the host (domain) of the Commerce Admin the extension is embedded in. The value is resolved over the guest connection via the host's integration API. It returns an error when used outside the Commerce Admin frame, when the host doesn't expose that integration API, or when host resolution fails:
 
 ```jsx
 import { useCommerce } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function CommerceInfo() {
-  const { commerceHost } = useCommerce();
-  return <span>{commerceHost}</span>;
+  const { data, error } = useCommerce();
+  if (error) return <span>Commerce features aren't available here.</span>;
+
+  return <span>{data.commerceHost}</span>;
 }
 ```
 
@@ -545,34 +570,41 @@ function CommerceInfo() {
 import { useHostConnection } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function Actions() {
-  const { close, closeWithError } = useHostConnection();
-  // close() closes the current iframe and navigates back to the originating grid or order.
-  // closeWithError() does the same, flagging that an error occurred.
+  const { actions, error } = useHostConnection();
+  if (error) return null;
+
+  // actions.close() closes the current iframe and navigates back to the originating grid or order.
+  // actions.closeWithError() does the same, flagging that an error occurred.
 }
 ```
 
 #### Reading the mass-action selection
 
-`useMassActionContext` returns the row IDs the mass action was triggered with. It reads from the host-provided Commerce context and throws when that context does not include a mass-action selection:
+`useMassActionContext` returns the row IDs the mass action was triggered with. It reads from the host-provided Commerce context and returns an error when that context doesn't include a mass-action selection:
 
 ```jsx
 import { useMassActionContext } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function MassActionPage() {
-  const { selectedIds } = useMassActionContext();
-  // selectedIds is string[] (an empty selection is valid).
+  const { data, error } = useMassActionContext();
+  if (error) return null;
+
+  // data.selectedIds is string[] (an empty selection is valid).
 }
 ```
 
 #### Reading the order view-button context
 
-`useOrderViewButtonContext` returns the ID of the order the view button was triggered from. It throws when no order ID is present in the page URL:
+`useOrderViewButtonContext` returns the ID of the order the view button was triggered from. It returns an error when no order ID is present in the page URL:
 
 ```jsx
 import { useOrderViewButtonContext } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function OrderViewButtonPage() {
-  const { orderId } = useOrderViewButtonContext();
+  const { data, error } = useOrderViewButtonContext();
+  if (error) return null;
+
+  return <span>{data.orderId}</span>;
 }
 ```
 
@@ -584,9 +616,11 @@ function OrderViewButtonPage() {
 import { useSharedContext } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function Advanced() {
-  const { extensionId, sharedContext, host } = useSharedContext();
-  const selectedIds = sharedContext.get("selectedIds");
+  const { data, error } = useSharedContext();
+  if (error) return null;
+
+  const selectedIds = data.sharedContext.get("selectedIds");
 }
 ```
 
-`useSharedContext` (and the hooks built on it) require the Commerce guest connection, so they only work inside the Commerce Admin — not in the Experience Cloud shell.
+`useSharedContext` (and the hooks built on it) require the Commerce guest connection. In Experience Cloud Shell or a standalone page, they will always return an error.

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -511,16 +511,20 @@ When you provide `menu`, it owns the root route. Don't also add a root-equivalen
 
 The whole app is wrapped in React's [`<StrictMode>`](https://react.dev/reference/react/StrictMode). When running locally with `aio app dev` or `aio app run` (which serve React's development build), StrictMode runs its extra development-only checks: components render twice, and effects run an extra setup + cleanup cycle on mount. Duplicated renders, effect runs, or requests fired from effects during development are therefore expected — not a bug — and surface unsafe side effects early. These checks do not run in production builds, where StrictMode has no effect.
 
-#### Reading IMS credentials
+#### Handling hook errors
 
 The browser hooks return an object with complementary `data` and `error` fields. When the requested host data is available, `data` contains it and `error` is `null`. Otherwise, `data` is `null` and `error` explains why the `data` can't be provided.
 
-You can forward an error to the app's error boundary when you don't need custom fallback UI:
+The hooks don't throw these errors themselves. When you throw a returned error during render, the SDK's error boundary catches it and replaces the extension content with its fallback UI. Use this when the current page can't continue without the requested data:
 
 ```jsx
 const { data, error } = useIms();
 if (error) throw error;
 ```
+
+To keep the page mounted, handle the error locally instead. You can render a message, offer a retry, disable the affected feature, or otherwise provide a degraded experience. Returning custom UI from the component, as in the next example, handles the error locally instead of sending it to the error boundary.
+
+#### Reading IMS credentials
 
 `useIms` returns the IMS credentials provided by the host (`{ imsToken, imsOrgId }`). It works inside both the Commerce Admin and the Experience Cloud shell, and returns an error when the app runs standalone because no host provides credentials:
 

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -513,7 +513,7 @@ The whole app is wrapped in React's [`<StrictMode>`](https://react.dev/reference
 
 #### Reading IMS credentials
 
-The browser hooks return a `Result` with complementary `data` and `error` fields. When the requested host data is available, `data` contains it and `error` is `null`. Otherwise, `data` is `null` and `error` explains why the `data` can't be provided.
+The browser hooks return an object with complementary `data` and `error` fields. When the requested host data is available, `data` contains it and `error` is `null`. Otherwise, `data` is `null` and `error` explains why the `data` can't be provided.
 
 You can forward an error to the app's error boundary when you don't need custom fallback UI:
 

--- a/packages/aio-commerce-lib-admin-ui/source/web/index.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/index.ts
@@ -35,8 +35,4 @@ export type {
   SharedContext,
 } from "#web/react/commerce/types";
 export type { CreateExtensionAppOptions } from "#web/react/extension/create-app.tsx";
-export type {
-  ExtensionAppRoutes,
-  ExtensionRoute,
-  IndexRoute,
-} from "#web/react/routing/types";
+export type { ExtensionRoute } from "#web/react/routing/types";

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/auth/context/ims-context.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/auth/context/ims-context.tsx
@@ -16,6 +16,7 @@ import { isEmbeddedInHost } from "#web/react/commerce/lib";
 
 import type { ReactNode } from "react";
 import type { ImsContext } from "#web/react/auth/types";
+import type { Result } from "#web/react/types";
 
 // `undefined` means there is no provider (a usage error); `null` means the provider is mounted but no host
 // has provided credentials (running standalone, outside both the Commerce Admin and the Experience Cloud shell).
@@ -25,22 +26,27 @@ const ImsContextValue = createContext<ImsContext | null | undefined>(undefined);
  * Returns the IMS credentials provided by the host. Works inside the Commerce Admin and the
  * Experience Cloud shell.
  *
- * @throws If no host provides credentials (e.g. the app is running standalone, outside both the
- * Commerce Admin and the Experience Cloud shell).
+ * Returns an error when no host provides credentials.
  */
-export function useIms(): ImsContext {
+export function useIms(): Result<ImsContext> {
   const credentials = use(ImsContextValue);
   if (credentials === undefined) {
-    throw new Error("useIms must be used inside an ImsContextProvider.");
+    return {
+      data: null,
+      error: new Error("useIms must be used inside an ImsContextProvider."),
+    };
   }
 
   if (!credentials) {
-    throw new Error(
-      "useIms requires running inside the Commerce Admin or the Experience Cloud shell, which provide the IMS credentials.",
-    );
+    return {
+      data: null,
+      error: new Error(
+        "useIms requires running inside the Commerce Admin or the Experience Cloud shell, which provide the IMS credentials.",
+      ),
+    };
   }
 
-  return credentials;
+  return { data: credentials, error: null };
 }
 
 type ImsContextProviderProps = {
@@ -57,7 +63,7 @@ export function ImsContextProvider(props: Readonly<ImsContextProviderProps>) {
 
   // When embedded in a host, children are withheld until the credentials resolve, so consumers observe non-null
   // credentials and avoid a race against the asynchronous handshake. When running standalone (top-level window),
-  // children render immediately and `useIms` throws (as we won't have any host providing credentials).
+  // children render immediately and `useIms` reports the missing credentials.
   if (isEmbeddedInHost() && !credentials) {
     return null;
   }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/auth/context/ims-context.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/auth/context/ims-context.tsx
@@ -13,10 +13,11 @@
 import { createContext, use } from "react";
 
 import { isEmbeddedInHost } from "#web/react/commerce/lib";
+import { error, ok } from "#web/react/result";
 
 import type { ReactNode } from "react";
 import type { ImsContext } from "#web/react/auth/types";
-import type { Result } from "#web/react/types";
+import type { Result } from "#web/react/result";
 
 // `undefined` means there is no provider (a usage error); `null` means the provider is mounted but no host
 // has provided credentials (running standalone, outside both the Commerce Admin and the Experience Cloud shell).
@@ -31,22 +32,16 @@ const ImsContextValue = createContext<ImsContext | null | undefined>(undefined);
 export function useIms(): Result<ImsContext> {
   const credentials = use(ImsContextValue);
   if (credentials === undefined) {
-    return {
-      data: null,
-      error: new Error("useIms must be used inside an ImsContextProvider."),
-    };
+    return error("useIms must be used inside an ImsContextProvider.");
   }
 
   if (!credentials) {
-    return {
-      data: null,
-      error: new Error(
-        "useIms requires running inside the Commerce Admin or the Experience Cloud shell, which provide the IMS credentials.",
-      ),
-    };
+    return error(
+      "useIms requires running inside the Commerce Admin or the Experience Cloud shell, which provide the IMS credentials.",
+    );
   }
 
-  return { data: credentials, error: null };
+  return ok(credentials);
 }
 
 type ImsContextProviderProps = {

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/context/shared-context.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/context/shared-context.tsx
@@ -29,6 +29,7 @@ import type {
   SharedContext,
   SharedContextState,
 } from "#web/react/commerce/types";
+import type { Result } from "#web/react/types";
 
 const SharedContextValue = createContext<SharedContextState | undefined>(
   undefined,
@@ -37,15 +38,9 @@ const SharedContextValue = createContext<SharedContextState | undefined>(
 /**
  * Returns the current Commerce shared context provider state.
  */
-export function useInternalSharedContext(): SharedContextState {
-  const context = use(SharedContextValue);
-  if (context === undefined) {
-    throw new Error(
-      "useSharedContext must be used inside a SharedContextProvider, which is only available in the Commerce Admin.",
-    );
-  }
-
-  return context;
+export function useInternalSharedContext(): SharedContextState | undefined {
+  // Keep absence handleable so public hooks can return a Result instead of throwing first.
+  return use(SharedContextValue);
 }
 
 /**
@@ -56,26 +51,46 @@ export function useInternalSharedContext(): SharedContextState {
  * Prefer a purpose-built hook ({@link useCommerce}, {@link useMassActionContext},
  * {@link useOrderViewButtonContext}) when one covers what you need.
  *
- * @throws If used outside a {@link SharedContextProvider}.
- *
  * @example
  * ```tsx
  * import { useSharedContext } from "@adobe/aio-commerce-lib-admin-ui/web";
  *
  * function ImsTokenLabel() {
- *   const { sharedContext } = useSharedContext();
- *   return <span>{sharedContext.get("imsToken")}</span>;
+ *   const { data, error } = useSharedContext();
+ *   if (error) return null;
+ *   return <span>{data.sharedContext.get("imsToken")}</span>;
  * }
  * ```
  */
-export function useSharedContext(): SharedContext {
-  const { extensionId, guestConnection } = useInternalSharedContext();
-  const sharedContext = useLiveSharedContext(guestConnection);
+export function useSharedContext(): Result<SharedContext> {
+  const context = useInternalSharedContext();
+  const sharedContext = useLiveSharedContext(context?.guestConnection);
+
+  if (!context) {
+    return {
+      data: null,
+      error: new Error(
+        "useSharedContext must be used inside a SharedContextProvider, which is only available in the Commerce Admin.",
+      ),
+    };
+  }
+
+  if (!sharedContext) {
+    return {
+      data: null,
+      error: new Error(
+        "The Commerce host did not provide a shared context for this extension.",
+      ),
+    };
+  }
 
   return {
-    extensionId,
-    host: guestConnection.host,
-    sharedContext,
+    data: {
+      extensionId: context.extensionId,
+      host: context.guestConnection.host,
+      sharedContext,
+    },
+    error: null,
   };
 }
 
@@ -88,14 +103,22 @@ export function useSharedContext(): SharedContext {
  *
  * @param guestConnection - The established guest connection.
  */
-function useLiveSharedContext(guestConnection: GuestConnection) {
+function useLiveSharedContext(guestConnection?: GuestConnection) {
   const subscribe = useCallback(
-    (onContextChange: () => void) =>
-      guestConnection.addEventListener("contextchange", onContextChange),
+    (onContextChange: () => void) => {
+      if (!guestConnection) {
+        return () => undefined;
+      }
+
+      return guestConnection.addEventListener("contextchange", onContextChange);
+    },
     [guestConnection],
   );
 
-  return useSyncExternalStore(subscribe, () => guestConnection.sharedContext);
+  return useSyncExternalStore(
+    subscribe,
+    () => guestConnection?.sharedContext ?? null,
+  );
 }
 
 type SharedContextProviderProps = {

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/context/shared-context.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/context/shared-context.tsx
@@ -18,6 +18,8 @@ import {
   useSyncExternalStore,
 } from "react";
 
+import { error, ok } from "#web/react/result";
+
 import type { ReactNode } from "react";
 import type { useCommerce } from "#web/react/commerce/hooks/use-commerce";
 import type {
@@ -29,7 +31,7 @@ import type {
   SharedContext,
   SharedContextState,
 } from "#web/react/commerce/types";
-import type { Result } from "#web/react/types";
+import type { Result } from "#web/react/result";
 
 const SharedContextValue = createContext<SharedContextState | undefined>(
   undefined,
@@ -68,31 +70,22 @@ export function useSharedContext(): Result<SharedContext> {
 
   return useMemo<Result<SharedContext>>(() => {
     if (!context) {
-      return {
-        data: null,
-        error: new Error(
-          "useSharedContext must be used inside a SharedContextProvider, which is only available in the Commerce Admin.",
-        ),
-      };
+      return error(
+        "useSharedContext must be used inside a SharedContextProvider, which is only available in the Commerce Admin.",
+      );
     }
 
     if (!sharedContext) {
-      return {
-        data: null,
-        error: new Error(
-          "The Commerce host did not provide a shared context for this extension.",
-        ),
-      };
+      return error(
+        "The Commerce host did not provide a shared context for this extension.",
+      );
     }
 
-    return {
-      data: {
-        extensionId: context.extensionId,
-        host: context.guestConnection.host,
-        sharedContext,
-      },
-      error: null,
-    };
+    return ok({
+      extensionId: context.extensionId,
+      host: context.guestConnection.host,
+      sharedContext,
+    });
   }, [context, sharedContext]);
 }
 

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/context/shared-context.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/context/shared-context.tsx
@@ -66,32 +66,34 @@ export function useSharedContext(): Result<SharedContext> {
   const context = useInternalSharedContext();
   const sharedContext = useLiveSharedContext(context?.guestConnection);
 
-  if (!context) {
-    return {
-      data: null,
-      error: new Error(
-        "useSharedContext must be used inside a SharedContextProvider, which is only available in the Commerce Admin.",
-      ),
-    };
-  }
+  return useMemo<Result<SharedContext>>(() => {
+    if (!context) {
+      return {
+        data: null,
+        error: new Error(
+          "useSharedContext must be used inside a SharedContextProvider, which is only available in the Commerce Admin.",
+        ),
+      };
+    }
 
-  if (!sharedContext) {
-    return {
-      data: null,
-      error: new Error(
-        "The Commerce host did not provide a shared context for this extension.",
-      ),
-    };
-  }
+    if (!sharedContext) {
+      return {
+        data: null,
+        error: new Error(
+          "The Commerce host did not provide a shared context for this extension.",
+        ),
+      };
+    }
 
-  return {
-    data: {
-      extensionId: context.extensionId,
-      host: context.guestConnection.host,
-      sharedContext,
-    },
-    error: null,
-  };
+    return {
+      data: {
+        extensionId: context.extensionId,
+        host: context.guestConnection.host,
+        sharedContext,
+      },
+      error: null,
+    };
+  }, [context, sharedContext]);
 }
 
 /**

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
@@ -16,13 +16,18 @@ import { useInternalSharedContext } from "#web/react/commerce/context/shared-con
 import { createRetryablePromiseCache } from "#web/react/promise-cache";
 
 import type { GuestConnection } from "#web/react/commerce/types";
+import type { Result } from "#web/react/types";
 
 /** The host integration API exposed to every extension point. */
 type HostIntegration = {
   getCommerceHost: () => Promise<string>;
 };
 
-const commerceHosts = createRetryablePromiseCache<string>();
+type CommerceData = { commerceHost: string };
+
+const commerceHosts = createRetryablePromiseCache<Result<CommerceData>>(
+  ({ error }) => error !== null,
+);
 
 /**
  * Returns the cached Commerce Admin host promise for an extension, resolving it once over the
@@ -34,37 +39,59 @@ const commerceHosts = createRetryablePromiseCache<string>();
 function getCommerceHostPromise(
   extensionId: string,
   connection: GuestConnection,
-): Promise<string> {
-  const { integration } = connection.host as { integration?: HostIntegration };
+): Promise<Result<CommerceData>> {
+  return commerceHosts.get(extensionId, async () => {
+    const { integration } = connection.host as {
+      integration?: HostIntegration;
+    };
 
-  if (!integration) {
-    // Throw during render so the error surfaces to the boundary immediately: this is a static
-    // property of the connection, so there's nothing async to await or cache.
-    throw new Error(
-      "The host does not provide the integration API needed to resolve the Commerce host.",
-    );
-  }
+    if (!integration) {
+      return {
+        data: null,
+        error: new Error(
+          "The host does not provide the integration API needed to resolve the Commerce host.",
+        ),
+      };
+    }
 
-  return commerceHosts.get(extensionId, () => integration.getCommerceHost());
+    try {
+      const commerceHost = await integration.getCommerceHost();
+      return { data: { commerceHost }, error: null };
+    } catch (error) {
+      return {
+        data: null,
+        error: new Error("Failed to resolve the Commerce host.", {
+          cause: error,
+        }),
+      };
+    }
+  });
 }
 
 /** Drops a failed Commerce host resolution for `extensionId`, so a later render retries it. */
 export function retryCommerceHost(extensionId: string) {
-  commerceHosts.evictIfRejected(extensionId);
+  commerceHosts.evictIfFailed(extensionId);
 }
 
 /**
  * Returns the host (domain) of the Commerce Admin the extension is embedded in, resolving it over
  * the guest connection.
  *
- * @throws If used outside a Commerce Admin UI frame, or when the host does not expose the
- * Commerce integration API.
+ * Returns an error when used outside a Commerce Admin UI frame, when the host does not expose the
+ * Commerce integration API, or when resolving the host fails.
  */
-export function useCommerce() {
-  const { extensionId, guestConnection } = useInternalSharedContext();
-  const commerceHost = use(
-    getCommerceHostPromise(extensionId, guestConnection),
-  );
+export function useCommerce(): Result<CommerceData> {
+  const context = useInternalSharedContext();
+  if (!context) {
+    return {
+      data: null,
+      error: new Error(
+        "useCommerce requires running inside the Commerce Admin.",
+      ),
+    };
+  }
 
-  return { commerceHost };
+  return use(
+    getCommerceHostPromise(context.extensionId, context.guestConnection),
+  );
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-commerce.ts
@@ -14,9 +14,10 @@ import { use } from "react";
 
 import { useInternalSharedContext } from "#web/react/commerce/context/shared-context.tsx";
 import { createRetryablePromiseCache } from "#web/react/promise-cache";
+import { error, ok } from "#web/react/result";
 
 import type { GuestConnection } from "#web/react/commerce/types";
-import type { Result } from "#web/react/types";
+import type { Result } from "#web/react/result";
 
 /** The host integration API exposed to every extension point. */
 type HostIntegration = {
@@ -26,7 +27,7 @@ type HostIntegration = {
 type CommerceData = { commerceHost: string };
 
 const commerceHosts = createRetryablePromiseCache<Result<CommerceData>>(
-  ({ error }) => error !== null,
+  (result) => result.error !== null,
 );
 
 /**
@@ -46,24 +47,16 @@ function getCommerceHostPromise(
     };
 
     if (!integration) {
-      return {
-        data: null,
-        error: new Error(
-          "The host does not provide the integration API needed to resolve the Commerce host.",
-        ),
-      };
+      return error(
+        "The host does not provide the integration API needed to resolve the Commerce host.",
+      );
     }
 
     try {
       const commerceHost = await integration.getCommerceHost();
-      return { data: { commerceHost }, error: null };
-    } catch (error) {
-      return {
-        data: null,
-        error: new Error("Failed to resolve the Commerce host.", {
-          cause: error,
-        }),
-      };
+      return ok({ commerceHost });
+    } catch (cause) {
+      return error("Failed to resolve the Commerce host.", { cause });
     }
   });
 }
@@ -83,12 +76,7 @@ export function retryCommerceHost(extensionId: string) {
 export function useCommerce(): Result<CommerceData> {
   const context = useInternalSharedContext();
   if (!context) {
-    return {
-      data: null,
-      error: new Error(
-        "useCommerce requires running inside the Commerce Admin.",
-      ),
-    };
+    return error("useCommerce requires running inside the Commerce Admin.");
   }
 
   return use(

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-extension-context.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-extension-context.ts
@@ -14,12 +14,13 @@ import { useMemo } from "react";
 
 import { useSharedContext } from "#web/react/commerce/context/shared-context.tsx";
 import { parseOrderId } from "#web/react/commerce/lib";
+import { error, ok } from "#web/react/result";
 
 import type {
   MassActionContext,
   OrderViewButtonContext,
 } from "#web/react/commerce/types";
-import type { Result } from "#web/react/types";
+import type { Result } from "#web/react/result";
 
 /**
  * Returns the context for a mass-action extension point: the selected row IDs the action was
@@ -29,44 +30,35 @@ import type { Result } from "#web/react/types";
  * missing, empty, or contains a non-string row ID.
  */
 export function useMassActionContext(): Result<MassActionContext> {
-  const { data, error } = useSharedContext();
+  const { data, error: contextError } = useSharedContext();
 
   return useMemo<Result<MassActionContext>>(() => {
-    if (error) {
-      return { data: null, error };
+    if (contextError) {
+      return error(contextError.message, { cause: contextError });
     }
 
     // A missing key means the shared context was never populated with the mass-action payload.
     const selectedIds = data.sharedContext.get("selectedIds");
     if (!Array.isArray(selectedIds)) {
-      return {
-        data: null,
-        error: new Error(
-          "Could not find `selectedIds` in the Commerce shared context. Is this frame running as a mass-action extension point?",
-        ),
-      };
+      return error(
+        "Could not find `selectedIds` in the Commerce shared context. Is this frame running as a mass-action extension point?",
+      );
     }
 
     if (selectedIds.length === 0) {
-      return {
-        data: null,
-        error: new Error(
-          "No rows selected. A mass-action extension point must be triggered with at least one selected row.",
-        ),
-      };
+      return error(
+        "No rows selected. A mass-action extension point must be triggered with at least one selected row.",
+      );
     }
 
     if (selectedIds.some((id) => typeof id !== "string")) {
-      return {
-        data: null,
-        error: new Error(
-          "Some of the `selectedIds` in the Commerce shared context are not strings. All selected row IDs must be strings.",
-        ),
-      };
+      return error(
+        "Some of the `selectedIds` in the Commerce shared context are not strings. All selected row IDs must be strings.",
+      );
     }
 
-    return { data: { selectedIds: selectedIds as string[] }, error: null };
-  }, [data, error]);
+    return ok({ selectedIds: selectedIds as string[] });
+  }, [data, contextError]);
 }
 
 /**
@@ -79,14 +71,11 @@ export function useOrderViewButtonContext(): Result<OrderViewButtonContext> {
   return useMemo<Result<OrderViewButtonContext>>(() => {
     const orderId = parseOrderId(globalThis.location.href);
     if (orderId === null) {
-      return {
-        data: null,
-        error: new Error(
-          "Could not find an order ID. Is this frame running as an order view-button extension point?",
-        ),
-      };
+      return error(
+        "Could not find an order ID. Is this frame running as an order view-button extension point?",
+      );
     }
 
-    return { data: { orderId }, error: null };
+    return ok({ orderId });
   }, []);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-extension-context.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-extension-context.ts
@@ -19,46 +19,57 @@ import type {
   MassActionContext,
   OrderViewButtonContext,
 } from "#web/react/commerce/types";
+import type { Result } from "#web/react/types";
 
 /**
  * Returns the context for a mass-action extension point: the selected row IDs the action was
  * triggered with. The value is read from the host-provided Commerce context.
  *
- * @throws If used outside the Commerce shared context, or when that context does not include a
+ * Returns an error outside the Commerce shared context, or when that context does not include a
  * mass-action selection.
  */
-export function useMassActionContext(): MassActionContext {
-  const { sharedContext } = useSharedContext();
+export function useMassActionContext(): Result<MassActionContext> {
+  const { data, error } = useSharedContext();
 
-  return useMemo(() => {
-    // An empty selection is valid (a mass action with nothing selected), but a missing key means
-    // the shared context was never populated with the mass-action payload.
-    const selectedIds = sharedContext.get("selectedIds");
-    if (!Array.isArray(selectedIds)) {
-      throw new Error(
-        "Could not find `selectedIds` in the Commerce shared context. Is this frame running as a mass-action extension point?",
-      );
+  return useMemo<Result<MassActionContext>>(() => {
+    if (error) {
+      return { data: null, error };
     }
 
-    return { selectedIds: selectedIds as string[] };
-  }, [sharedContext]);
+    // An empty selection is valid (a mass action with nothing selected), but a missing key means
+    // the shared context was never populated with the mass-action payload.
+    const selectedIds = data.sharedContext.get("selectedIds");
+    if (!Array.isArray(selectedIds)) {
+      return {
+        data: null,
+        error: new Error(
+          "Could not find `selectedIds` in the Commerce shared context. Is this frame running as a mass-action extension point?",
+        ),
+      };
+    }
+
+    return { data: { selectedIds: selectedIds as string[] }, error: null };
+  }, [data, error]);
 }
 
 /**
  * Returns the context for an order view-button extension point: the order ID the button was
  * triggered from.
  *
- * @throws If no order ID is present in the page URL.
+ * Returns an error when no order ID is present in the page URL.
  */
-export function useOrderViewButtonContext(): OrderViewButtonContext {
-  return useMemo(() => {
+export function useOrderViewButtonContext(): Result<OrderViewButtonContext> {
+  return useMemo<Result<OrderViewButtonContext>>(() => {
     const orderId = parseOrderId(globalThis.location.href);
     if (orderId === null) {
-      throw new Error(
-        "Could not find an order ID. Is this frame running as an order view-button extension point?",
-      );
+      return {
+        data: null,
+        error: new Error(
+          "Could not find an order ID. Is this frame running as an order view-button extension point?",
+        ),
+      };
     }
 
-    return { orderId };
+    return { data: { orderId }, error: null };
   }, []);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-extension-context.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-extension-context.ts
@@ -25,8 +25,8 @@ import type { Result } from "#web/react/types";
  * Returns the context for a mass-action extension point: the selected row IDs the action was
  * triggered with. The value is read from the host-provided Commerce context.
  *
- * Returns an error outside the Commerce shared context, or when that context does not include a
- * mass-action selection.
+ * Returns an error outside the Commerce shared context, or when the mass-action selection is
+ * missing, empty, or contains a non-string row ID.
  */
 export function useMassActionContext(): Result<MassActionContext> {
   const { data, error } = useSharedContext();
@@ -36,14 +36,31 @@ export function useMassActionContext(): Result<MassActionContext> {
       return { data: null, error };
     }
 
-    // An empty selection is valid (a mass action with nothing selected), but a missing key means
-    // the shared context was never populated with the mass-action payload.
+    // A missing key means the shared context was never populated with the mass-action payload.
     const selectedIds = data.sharedContext.get("selectedIds");
     if (!Array.isArray(selectedIds)) {
       return {
         data: null,
         error: new Error(
           "Could not find `selectedIds` in the Commerce shared context. Is this frame running as a mass-action extension point?",
+        ),
+      };
+    }
+
+    if (selectedIds.length === 0) {
+      return {
+        data: null,
+        error: new Error(
+          "No rows selected. A mass-action extension point must be triggered with at least one selected row.",
+        ),
+      };
+    }
+
+    if (selectedIds.some((id) => typeof id !== "string")) {
+      return {
+        data: null,
+        error: new Error(
+          "Some of the `selectedIds` in the Commerce shared context are not strings. All selected row IDs must be strings.",
         ),
       };
     }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-guest-connection.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-guest-connection.ts
@@ -42,5 +42,5 @@ export function useGuestConnection(extensionId: string): GuestConnection {
 
 /** Drops a failed connection for `extensionId`, so a later render re-attaches. */
 export function retryGuestConnection(extensionId: string) {
-  guestConnections.evictIfRejected(extensionId);
+  guestConnections.evictIfFailed(extensionId);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-host-connection.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-host-connection.ts
@@ -13,9 +13,10 @@
 import { useMemo } from "react";
 
 import { useSharedContext } from "#web/react/commerce/context/shared-context.tsx";
+import { actionsError, okActions } from "#web/react/result";
 
 import type { HostConnection } from "#web/react/commerce/types";
-import type { ActionsResult } from "#web/react/types";
+import type { ActionsResult } from "#web/react/result";
 
 /**
  * Host frame actions used to close the extension iframe and return control to the Commerce Admin.
@@ -40,29 +41,23 @@ type HostFrameField = {
  * ```
  */
 export function useHostConnection(): ActionsResult<HostConnection> {
-  const { data, error } = useSharedContext();
+  const { data, error: contextError } = useSharedContext();
 
   return useMemo<ActionsResult<HostConnection>>(() => {
-    if (error) {
-      return { actions: null, error };
+    if (contextError) {
+      return actionsError(contextError.message, { cause: contextError });
     }
 
     const { field } = data.host as { field?: HostFrameField };
     if (!field) {
-      return {
-        actions: null,
-        error: new Error(
-          "Host frame actions are unavailable. They require an established guest connection with a host that exposes frame actions.",
-        ),
-      };
+      return actionsError(
+        "Host frame actions are unavailable. They require an established guest connection with a host that exposes frame actions.",
+      );
     }
 
-    return {
-      actions: {
-        close: () => field.close(),
-        closeWithError: () => field.onError(),
-      },
-      error: null,
-    };
-  }, [data, error]);
+    return okActions({
+      close: () => field.close(),
+      closeWithError: () => field.onError(),
+    });
+  }, [data, contextError]);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-host-connection.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/commerce/hooks/use-host-connection.ts
@@ -15,6 +15,7 @@ import { useMemo } from "react";
 import { useSharedContext } from "#web/react/commerce/context/shared-context.tsx";
 
 import type { HostConnection } from "#web/react/commerce/types";
+import type { ActionsResult } from "#web/react/types";
 
 /**
  * Host frame actions used to close the extension iframe and return control to the Commerce Admin.
@@ -27,37 +28,41 @@ type HostFrameField = {
 /**
  * Returns typed helpers for interacting with the Commerce Admin host.
  *
- * @throws If called before the guest connection is established, or when the host frame actions
- * are unavailable.
- *
  * @example
  * ```tsx
  * import { useHostConnection } from "@adobe/aio-commerce-lib-admin-ui/web";
  *
  * function DoneButton() {
- *   const { close } = useHostConnection();
- *   return <button onClick={() => void close()}>Done</button>;
+ *   const { actions, error } = useHostConnection();
+ *   if (error) return null;
+ *   return <button onClick={actions.close}>Done</button>;
  * }
  * ```
  */
-export function useHostConnection(): HostConnection {
-  const { host } = useSharedContext();
+export function useHostConnection(): ActionsResult<HostConnection> {
+  const { data, error } = useSharedContext();
 
-  return useMemo<HostConnection>(() => {
-    const { field } = host as { field?: HostFrameField };
-    const requireField = () => {
-      if (!field) {
-        throw new Error(
+  return useMemo<ActionsResult<HostConnection>>(() => {
+    if (error) {
+      return { actions: null, error };
+    }
+
+    const { field } = data.host as { field?: HostFrameField };
+    if (!field) {
+      return {
+        actions: null,
+        error: new Error(
           "Host frame actions are unavailable. They require an established guest connection with a host that exposes frame actions.",
-        );
-      }
-
-      return field;
-    };
+        ),
+      };
+    }
 
     return {
-      close: () => requireField().close(),
-      closeWithError: () => requireField().onError(),
+      actions: {
+        close: () => field.close(),
+        closeWithError: () => field.onError(),
+      },
+      error: null,
     };
-  }, [host]);
+  }, [data, error]);
 }

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/commerce-app.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/commerce-app.tsx
@@ -128,8 +128,12 @@ function CommerceGuestConnection(props: Readonly<{ extensionId: string }>) {
 
 /** Renders IMS-gated route content for a Commerce Admin UI frame. */
 function CommerceExtensionContent() {
-  const { sharedContext } = useSharedContext();
-  const credentials = resolveCommerceImsCredentials(sharedContext);
+  const { data, error } = useSharedContext();
+  if (error) {
+    throw error;
+  }
+
+  const credentials = resolveCommerceImsCredentials(data.sharedContext);
 
   return (
     <ImsContextProvider credentials={credentials}>

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/create-app.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/create-app.tsx
@@ -16,7 +16,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-import { createExtensionRouter } from "#web/react/routing/lib";
+import { createExtensionRouter, getRouteTo } from "#web/react/routing/lib";
 import {
   createMockRuntime,
   loadExperienceCloudRuntime,
@@ -25,7 +25,8 @@ import {
 import { Entrypoint } from "./entrypoint";
 
 import type { RuntimeConfiguration } from "@adobe/exc-app";
-import type { ExtensionAppRoutes } from "#web/react/routing/types";
+import type { ReactNode } from "react";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
 /** Configuration options when instantiating an extension app. */
 export type CreateExtensionAppOptions = {
@@ -35,11 +36,14 @@ export type CreateExtensionAppOptions = {
     extensionId: string;
   };
 
+  /** The optional app page opened from the Commerce Admin menu and by default in Experience Cloud Shell. */
+  menu?: ReactNode;
+
   /** Optional root element where the app will be mounted. */
   root?: HTMLElement;
 
-  /** A list of routes for the extension app, specifying an index route is mandatory. */
-  routes: ExtensionAppRoutes;
+  /** Additional path-based routes for the extension app. */
+  routes?: ExtensionRoute[];
 };
 
 /**
@@ -59,15 +63,25 @@ export type CreateExtensionAppOptions = {
  *
  * createExtensionApp({
  *   metadata: { extensionId: "my-extension-id" },
- *   routes: [{ index: true, element: <MainPage /> }],
+ *   menu: <MainPage />,
  * });
  * ```
  */
 export function createExtensionApp({
+  menu,
   metadata,
-  routes,
+  routes = [],
   root: customRoot,
 }: CreateExtensionAppOptions) {
+  if (
+    menu !== undefined &&
+    routes.some((route) => getRouteTo(route.path) === "/")
+  ) {
+    throw new Error(
+      'The "/" route is reserved for the menu. Pass its element through the menu option instead.',
+    );
+  }
+
   const rootElement = customRoot ?? document.getElementById("root");
   if (!rootElement) {
     throw new Error('Could not find an element with id "root".');
@@ -85,7 +99,10 @@ export function createExtensionApp({
     };
 
     const entrypoint = <Entrypoint {...entrypointProps} />;
-    const router = createExtensionRouter(entrypoint, routes);
+    const router = createExtensionRouter(
+      entrypoint,
+      menu === undefined ? routes : [{ element: menu, path: "/" }, ...routes],
+    );
 
     root.render(
       <StrictMode>

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/promise-cache.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/promise-cache.ts
@@ -14,24 +14,29 @@ type RetryablePromiseCache<T> = {
   /** Returns the cached promise for `key`, or runs `create` to produce and cache one on a miss. */
   get: (key: string, create: () => Promise<T>) => Promise<T>;
 
-  /** Drops the cached promise for `key` only if it rejected, so the next lookup retries. */
-  evictIfRejected: (key: string) => void;
+  /** Drops the cached promise for `key` only if it failed, so the next lookup retries. */
+  evictIfFailed: (key: string) => void;
 };
 
 /**
- * Creates a keyed cache that memoizes in-flight, resolved, and rejected promises, giving `use()`
+ * Creates a keyed cache that memoizes in-flight, successful, and failed promises, giving `use()`
  * the reference-stable promise it needs while suspended and single-flighting side-effecting
  * establishment calls across re-renders, remounts, and StrictMode double-invocation.
  *
- * Rejections are retained (not evicted) so `use()` replays them to an error boundary instead of
- * suspending forever on a fresh pending promise. Retry a failed key via {@link RetryablePromiseCache.evict}.
+ * Promise rejections are failures by default. Pass `isFailure` when a fulfilled value, such as an
+ * error result, must also be retryable. Failed entries remain cached until `evictIfFailed` is
+ * called, so retries never replace a stable promise during render.
+ *
+ * @param isFailure - Determines whether a fulfilled value represents a failure.
  */
-export function createRetryablePromiseCache<T>(): RetryablePromiseCache<T> {
-  const cache = new Map<string, { promise: Promise<T>; rejected: boolean }>();
+export function createRetryablePromiseCache<T>(
+  isFailure: (value: T) => boolean = () => false,
+): RetryablePromiseCache<T> {
+  const cache = new Map<string, { promise: Promise<T>; failed: boolean }>();
 
   return {
-    evictIfRejected(key) {
-      if (cache.get(key)?.rejected) {
+    evictIfFailed(key) {
+      if (cache.get(key)?.failed) {
         cache.delete(key);
       }
     },
@@ -41,10 +46,14 @@ export function createRetryablePromiseCache<T>(): RetryablePromiseCache<T> {
         return cached.promise;
       }
 
-      const entry = { promise: create(), rejected: false };
-      entry.promise.catch(() => {
-        entry.rejected = true;
-      });
+      const entry = { failed: false, promise: create() };
+      entry.promise
+        .then((value) => {
+          entry.failed = isFailure(value);
+        })
+        .catch(() => {
+          entry.failed = true;
+        });
 
       cache.set(key, entry);
       return entry.promise;

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/result.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/result.ts
@@ -23,3 +23,31 @@ type ActionMap = {
 export type ActionsResult<T extends ActionMap, E = Error> =
   | { actions: T; error: null }
   | { actions: null; error: E };
+
+/** Creates a successful data result. */
+export function ok<T>(data: T): { data: T; error: null } {
+  return { data, error: null };
+}
+
+/** Creates a failed data result. */
+export function error(
+  message: string,
+  options?: ErrorOptions,
+): { data: null; error: Error } {
+  return { data: null, error: new Error(message, options) };
+}
+
+/** Creates a successful actions result. */
+export function okActions<T extends ActionMap>(
+  actions: T,
+): { actions: T; error: null } {
+  return { actions, error: null };
+}
+
+/** Creates a failed actions result. */
+export function actionsError(
+  message: string,
+  options?: ErrorOptions,
+): { actions: null; error: Error } {
+  return { actions: null, error: new Error(message, options) };
+}

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/routing/lib.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/routing/lib.ts
@@ -18,28 +18,16 @@ import {
 } from "@tanstack/react-router";
 
 import type { RouterHistory } from "@tanstack/react-router";
-import type { IndexRoute, RouteEntry } from "./types";
+import type { ExtensionRoute } from "./types";
 
 const HASH_ROUTE_PREFIX_PATTERN = /^[#/]+/u;
-
-/**
- * Determines if a given route is an index route.
- * @param route The route to check.
- */
-function isIndexRoute(route: RouteEntry): route is IndexRoute {
-  return "index" in route && route.index;
-}
 
 /**
  * Returns the path for a given route, removing any leading hash or slash characters.
  * @param route The route to get the path for.
  */
-function getRoutePath(route: RouteEntry) {
-  if (isIndexRoute(route)) {
-    return "/";
-  }
-
-  return route.path.replace(HASH_ROUTE_PREFIX_PATTERN, "");
+function getRoutePath(route: ExtensionRoute) {
+  return route.path.replace(HASH_ROUTE_PREFIX_PATTERN, "") || "/";
 }
 
 /**
@@ -61,7 +49,7 @@ export function getRouteTo(path: string) {
  */
 export function createExtensionRouter(
   rootComponent: React.JSX.Element,
-  routeEntries: RouteEntry[],
+  routeEntries: ExtensionRoute[],
   history: RouterHistory = createHashHistory(),
 ) {
   const rootRoute = createRootRoute({

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/types.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/types.ts
@@ -10,22 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import type { NavigateOptions, ToOptions } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+/** The result of reading data that might not be available in the current host context. */
+export type Result<T, E = Error> =
+  | { data: T; error: null }
+  | { data: null; error: E };
 
-declare module "@react-spectrum/s2/Provider" {
-  // biome-ignore lint/style/useConsistentTypeDefinitions: For declaration merging, we need to use `interface` instead of `type`.
-  interface RouterConfig {
-    href: ToOptions;
-    routerOptions: Omit<NavigateOptions, keyof ToOptions>;
-  }
-}
-
-/** Defines a route that exists at a given path. */
-export type ExtensionRoute = {
-  /** The path for the route. */
-  path: string;
-
-  /** The React element to render for the route. */
-  element: ReactNode;
+type ActionMap = {
+  [key: string]: (...args: unknown[]) => PromiseLike<unknown>;
 };
+
+/** The result of exposing an API that might not be available in the current host context. */
+export type ActionsResult<T extends ActionMap, E = Error> =
+  | { actions: T; error: null }
+  | { actions: null; error: E };

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/auth/context/ims-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/auth/context/ims-context.test.tsx
@@ -13,7 +13,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { render, renderHook } from "vitest-browser-react";
 
-import { mockConsole } from "#test/utils/console";
 import { stubControlFrame, stubStandaloneFrame } from "#test/utils/frame";
 import {
   ImsContextProvider,
@@ -31,9 +30,11 @@ afterEach(() => {
 });
 
 describe("useIms", () => {
-  test("throws when used outside an ImsContextProvider", async () => {
-    mockConsole("error");
-    await expect(renderHook(() => useIms())).rejects.toThrow(
+  test("returns an error when used outside an ImsContextProvider", async () => {
+    const { result } = await renderHook(() => useIms());
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toBe(
       "useIms must be used inside an ImsContextProvider.",
     );
   });
@@ -46,10 +47,10 @@ describe("useIms", () => {
     );
 
     const { result } = await renderHook(() => useIms(), { wrapper });
-    expect(result.current).toEqual(CREDENTIALS);
+    expect(result.current).toEqual({ data: CREDENTIALS, error: null });
   });
 
-  test("renders children but throws when credentials are null and not embedded", async () => {
+  test("renders children but returns an error when credentials are null and not embedded", async () => {
     restoreFrame = stubStandaloneFrame();
 
     const screen = await render(
@@ -60,12 +61,13 @@ describe("useIms", () => {
 
     await expect.element(screen.getByTestId("child")).toBeInTheDocument();
 
-    mockConsole("error");
     const wrapper = ({ children }: { children: ReactNode }) => (
       <ImsContextProvider credentials={null}>{children}</ImsContextProvider>
     );
 
-    await expect(renderHook(() => useIms(), { wrapper })).rejects.toThrow(
+    const { result } = await renderHook(() => useIms(), { wrapper });
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
       "useIms requires running inside the Commerce Admin or the Experience Cloud shell",
     );
   });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/context/shared-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/context/shared-context.test.tsx
@@ -13,7 +13,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 
-import { mockConsole } from "#test/utils/console";
 import { sharedContextProvider } from "#test/utils/shared-context.tsx";
 import { useSharedContext } from "#web/react/commerce/context/shared-context.tsx";
 
@@ -34,9 +33,11 @@ function makeConnection() {
 }
 
 describe("useSharedContext", () => {
-  test("throws when used outside a SharedContextProvider", async () => {
-    mockConsole("error");
-    await expect(renderHook(() => useSharedContext())).rejects.toThrow(
+  test("returns an error when used outside a SharedContextProvider", async () => {
+    const { result } = await renderHook(() => useSharedContext());
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
       "useSharedContext must be used inside a SharedContextProvider",
     );
   });
@@ -47,9 +48,10 @@ describe("useSharedContext", () => {
       wrapper: sharedContextProvider(connection),
     });
 
-    expect(result.current.extensionId).toBe("ext-1");
-    expect(result.current.sharedContext).toBe(connection.sharedContext);
-    expect(result.current.host).toBe(connection.host);
+    expect.assert.isNull(result.current.error);
+    expect(result.current.data.extensionId).toBe("ext-1");
+    expect(result.current.data.sharedContext).toBe(connection.sharedContext);
+    expect(result.current.data.host).toBe(connection.host);
   });
 
   test("re-renders with the new shared context on a contextchange event", async () => {
@@ -72,6 +74,7 @@ describe("useSharedContext", () => {
     connection.sharedContext = newSharedContext;
     await act(() => onContextChange());
 
-    expect(result.current.sharedContext).toBe(newSharedContext);
+    expect.assert.isNull(result.current.error);
+    expect(result.current.data.sharedContext).toBe(newSharedContext);
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/context/shared-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/context/shared-context.test.tsx
@@ -34,12 +34,16 @@ function makeConnection() {
 
 describe("useSharedContext", () => {
   test("returns an error when used outside a SharedContextProvider", async () => {
-    const { result } = await renderHook(() => useSharedContext());
+    const { result, rerender } = await renderHook(() => useSharedContext());
+    const initialResult = result.current;
 
     expect.assert.isNull(result.current.data);
     expect(result.current.error.message).toContain(
       "useSharedContext must be used inside a SharedContextProvider",
     );
+
+    await rerender();
+    expect(result.current).toBe(initialResult);
   });
 
   test("returns the extension ID, shared context and host from the provider", async () => {
@@ -52,6 +56,18 @@ describe("useSharedContext", () => {
     expect(result.current.data.extensionId).toBe("ext-1");
     expect(result.current.data.sharedContext).toBe(connection.sharedContext);
     expect(result.current.data.host).toBe(connection.host);
+  });
+
+  test("preserves the result when the shared context is unchanged", async () => {
+    const connection = makeConnection();
+    const { result, rerender } = await renderHook(() => useSharedContext(), {
+      wrapper: sharedContextProvider(connection),
+    });
+    const initialResult = result.current;
+
+    await rerender();
+
+    expect(result.current).toBe(initialResult);
   });
 
   test("re-renders with the new shared context on a contextchange event", async () => {

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
@@ -79,7 +79,8 @@ describe("useCommerce", () => {
   });
 
   test("returns an error when resolving the Commerce host rejects", async () => {
-    const getCommerceHost = vi.fn().mockRejectedValue(new Error("unavailable"));
+    const error = new Error("unavailable");
+    const getCommerceHost = vi.fn().mockRejectedValue(error);
     const connection = makeConnection({ integration: { getCommerceHost } });
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -96,7 +97,10 @@ describe("useCommerce", () => {
 
     expect(result.current).toEqual({
       data: null,
-      error: new Error("unavailable"),
+      error: expect.objectContaining({
+        cause: error,
+        message: expect.stringContaining("Failed to resolve the Commerce host"),
+      }),
     });
   });
 

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
@@ -11,11 +11,9 @@
  */
 
 import { Suspense } from "react";
-import { ErrorBoundary } from "react-error-boundary";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { render, renderHook } from "vitest-browser-react";
+import { renderHook } from "vitest-browser-react";
 
-import { mockConsole } from "#test/utils/console";
 import { SharedContextProvider } from "#web/react/commerce/context/shared-context.tsx";
 import { useCommerce } from "#web/react/commerce/hooks/use-commerce";
 
@@ -24,10 +22,6 @@ import type { ReactNode } from "react";
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-function renderNullFallback() {
-  return null;
-}
 
 /** Builds a minimal fake UIX guest connection with the given host object. */
 function makeConnection(host: object) {
@@ -57,39 +51,61 @@ describe("useCommerce", () => {
     const { result } = await renderHook(() => useCommerce(), { wrapper });
     await vi.waitFor(() => expect(result.current).not.toBeNull());
 
-    expect(result.current.commerceHost).toBe("my-store.example.com");
     expect(getCommerceHost).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      data: { commerceHost: "my-store.example.com" },
+      error: null,
+    });
   });
 
-  test("propagates the error to the error boundary when the host lacks the integration API", async () => {
-    mockConsole("error");
-
+  test("returns an error when the host lacks the integration API", async () => {
     const connection = makeConnection({});
-    const onError = vi.fn();
-
-    function HookProbe() {
-      useCommerce();
-      return null;
-    }
-
-    await render(
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <SharedContextProvider
         extensionId="ext-use-commerce-no-integration"
         // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
         guestConnection={connection}>
-        <ErrorBoundary fallbackRender={renderNullFallback} onError={onError}>
-          <Suspense fallback={null}>
-            <HookProbe />
-          </Suspense>
-        </ErrorBoundary>
-      </SharedContextProvider>,
+        <Suspense fallback={null}>{children}</Suspense>
+      </SharedContextProvider>
     );
 
-    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
-    const [error] = onError.mock.calls[0] as [Error];
+    const { result } = await renderHook(() => useCommerce(), { wrapper });
+    await vi.waitFor(() => expect(result.current).not.toBeNull());
 
-    expect(error.message).toContain(
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
       "The host does not provide the integration API",
+    );
+  });
+
+  test("returns an error when resolving the Commerce host rejects", async () => {
+    const getCommerceHost = vi.fn().mockRejectedValue(new Error("unavailable"));
+    const connection = makeConnection({ integration: { getCommerceHost } });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SharedContextProvider
+        extensionId="ext-use-commerce-reject"
+        // @ts-expect-error -- fake connection cannot satisfy the uix-guest GuestConnection type
+        guestConnection={connection}>
+        <Suspense fallback={null}>{children}</Suspense>
+      </SharedContextProvider>
+    );
+
+    const { result } = await renderHook(() => useCommerce(), { wrapper });
+    await vi.waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(result.current).toEqual({
+      data: null,
+      error: new Error("unavailable"),
+    });
+  });
+
+  test("returns an error when used outside the Commerce shared context", async () => {
+    const { result } = await renderHook(() => useCommerce());
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
+      "useCommerce requires running inside the Commerce Admin",
     );
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-commerce.test.tsx
@@ -48,7 +48,10 @@ describe("useCommerce", () => {
       </SharedContextProvider>
     );
 
-    const { result } = await renderHook(() => useCommerce(), { wrapper });
+    const { result, rerender } = await renderHook(() => useCommerce(), {
+      wrapper,
+    });
+
     await vi.waitFor(() => expect(result.current).not.toBeNull());
 
     expect(getCommerceHost).toHaveBeenCalledTimes(1);
@@ -56,6 +59,12 @@ describe("useCommerce", () => {
       data: { commerceHost: "my-store.example.com" },
       error: null,
     });
+
+    const initialResult = result.current;
+    await rerender();
+
+    expect(result.current).toBe(initialResult);
+    expect(getCommerceHost).toHaveBeenCalledTimes(1);
   });
 
   test("returns an error when the host lacks the integration API", async () => {

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
@@ -53,6 +53,20 @@ describe("useMassActionContext", () => {
     expect(result.current).toEqual({ data: { selectedIds: [] }, error: null });
   });
 
+  test("preserves the result when the shared context is unchanged", async () => {
+    const { result, rerender } = await renderHook(
+      () => useMassActionContext(),
+      {
+        wrapper: provide({ selectedIds: ["1", "2"] }),
+      },
+    );
+
+    const initialResult = result.current;
+    await rerender();
+
+    expect(result.current).toBe(initialResult);
+  });
+
   test("returns an error when the shared context has no selectedIds key", async () => {
     const { result } = await renderHook(() => useMassActionContext(), {
       wrapper: provide({}),
@@ -82,11 +96,18 @@ describe("useOrderViewButtonContext", () => {
   test("returns the order ID from the URL search params", async () => {
     window.history.replaceState(null, "", "?orderId=000000123");
 
-    const { result } = await renderHook(() => useOrderViewButtonContext());
+    const { result, rerender } = await renderHook(() =>
+      useOrderViewButtonContext(),
+    );
     expect(result.current).toEqual({
       data: { orderId: "000000123" },
       error: null,
     });
+
+    const initialResult = result.current;
+    await rerender();
+
+    expect(result.current).toBe(initialResult);
   });
 
   test("returns the order ID from the URL hash", async () => {

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
@@ -45,12 +45,24 @@ describe("useMassActionContext", () => {
     });
   });
 
-  test("returns an empty selection when no rows are selected", async () => {
+  test("returns an error when no rows are selected", async () => {
     const { result } = await renderHook(() => useMassActionContext(), {
       wrapper: provide({ selectedIds: [] }),
     });
 
-    expect(result.current).toEqual({ data: { selectedIds: [] }, error: null });
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain("No rows selected");
+  });
+
+  test("returns an error when a selected ID is not a string", async () => {
+    const { result } = await renderHook(() => useMassActionContext(), {
+      wrapper: provide({ selectedIds: ["1", 2] }),
+    });
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
+      "All selected row IDs must be strings",
+    );
   });
 
   test("preserves the result when the shared context is unchanged", async () => {

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-extension-context.test.tsx
@@ -14,7 +14,6 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 
 import { createMockGuestConnection } from "#test/fixtures/uix-guest";
-import { mockConsole } from "#test/utils/console";
 import { sharedContextProvider } from "#test/utils/shared-context.tsx";
 import {
   useMassActionContext,
@@ -40,7 +39,10 @@ describe("useMassActionContext", () => {
       wrapper: provide({ selectedIds: ["1", "2"] }),
     });
 
-    expect(result.current).toEqual({ selectedIds: ["1", "2"] });
+    expect(result.current).toEqual({
+      data: { selectedIds: ["1", "2"] },
+      error: null,
+    });
   });
 
   test("returns an empty selection when no rows are selected", async () => {
@@ -48,15 +50,26 @@ describe("useMassActionContext", () => {
       wrapper: provide({ selectedIds: [] }),
     });
 
-    expect(result.current).toEqual({ selectedIds: [] });
+    expect(result.current).toEqual({ data: { selectedIds: [] }, error: null });
   });
 
-  test("throws when the shared context has no selectedIds key", async () => {
-    mockConsole("error");
-    await expect(
-      renderHook(() => useMassActionContext(), { wrapper: provide({}) }),
-    ).rejects.toThrow(
+  test("returns an error when the shared context has no selectedIds key", async () => {
+    const { result } = await renderHook(() => useMassActionContext(), {
+      wrapper: provide({}),
+    });
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
       "Could not find `selectedIds` in the Commerce shared context",
+    );
+  });
+
+  test("returns an error when used outside the Commerce shared context", async () => {
+    const { result } = await renderHook(() => useMassActionContext());
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
+      "useSharedContext must be used inside a SharedContextProvider",
     );
   });
 });
@@ -70,19 +83,24 @@ describe("useOrderViewButtonContext", () => {
     window.history.replaceState(null, "", "?orderId=000000123");
 
     const { result } = await renderHook(() => useOrderViewButtonContext());
-    expect(result.current).toEqual({ orderId: "000000123" });
+    expect(result.current).toEqual({
+      data: { orderId: "000000123" },
+      error: null,
+    });
   });
 
   test("returns the order ID from the URL hash", async () => {
     window.history.replaceState(null, "", "/#/view?orderId=7");
 
     const { result } = await renderHook(() => useOrderViewButtonContext());
-    expect(result.current).toEqual({ orderId: "7" });
+    expect(result.current).toEqual({ data: { orderId: "7" }, error: null });
   });
 
-  test("throws when the URL has no order ID", async () => {
-    mockConsole("error");
-    await expect(renderHook(() => useOrderViewButtonContext())).rejects.toThrow(
+  test("returns an error when the URL has no order ID", async () => {
+    const { result } = await renderHook(() => useOrderViewButtonContext());
+
+    expect.assert.isNull(result.current.data);
+    expect(result.current.error.message).toContain(
       "Could not find an order ID",
     );
   });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-host-connection.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-host-connection.test.tsx
@@ -37,24 +37,32 @@ describe("useHostConnection", () => {
       wrapper: provide({ field }),
     });
 
-    await result.current.close();
+    expect.assert.isNull(result.current.error);
+
+    await result.current.actions.close();
     expect(field.close).toHaveBeenCalledTimes(1);
 
-    await result.current.closeWithError();
+    await result.current.actions.closeWithError();
     expect(field.onError).toHaveBeenCalledTimes(1);
   });
 
-  test("throws when the host does not provide the frame actions", async () => {
+  test("returns an error when the host does not provide the frame actions", async () => {
     const { result } = await renderHook(() => useHostConnection(), {
       wrapper: provide({}),
     });
 
-    expect(() => result.current.close()).toThrow(
+    expect.assert.isNull(result.current.actions);
+    expect(result.current.error.message).toContain(
       "Host frame actions are unavailable",
     );
+  });
 
-    expect(() => result.current.closeWithError()).toThrow(
-      "Host frame actions are unavailable",
+  test("returns an error when used outside the Commerce shared context", async () => {
+    const { result } = await renderHook(() => useHostConnection());
+
+    expect.assert.isNull(result.current.actions);
+    expect(result.current.error.message).toContain(
+      "useSharedContext must be used inside a SharedContextProvider",
     );
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-host-connection.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/commerce/hooks/use-host-connection.test.tsx
@@ -46,6 +46,22 @@ describe("useHostConnection", () => {
     expect(field.onError).toHaveBeenCalledTimes(1);
   });
 
+  test("preserves the actions when the host is unchanged", async () => {
+    const field = {
+      close: vi.fn().mockResolvedValue(undefined),
+      onError: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const { result, rerender } = await renderHook(() => useHostConnection(), {
+      wrapper: provide({ field }),
+    });
+
+    const initialResult = result.current;
+    await rerender();
+
+    expect(result.current).toBe(initialResult);
+  });
+
   test("returns an error when the host does not provide the frame actions", async () => {
     const { result } = await renderHook(() => useHostConnection(), {
       wrapper: provide({}),

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/commerce-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/commerce-app.test.tsx
@@ -19,15 +19,15 @@ import { stubControlFrame, stubUiFrame } from "#test/utils/frame";
 import { renderWithRouter } from "#test/utils/router.tsx";
 import { CommerceExtensionApp } from "#web/react/extension/commerce-app.tsx";
 
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
 // @adobe/uix-guest reaches a real uix-host across the iframe bridge; it is the only external boundary faked here.
 vi.mock("@adobe/uix-guest", async () =>
   (await import("#test/fixtures/uix-guest")).uixGuestMock(),
 );
 
-const ROUTES: RouteEntry[] = [
-  { element: <div data-testid="route-content" />, index: true },
+const ROUTES: ExtensionRoute[] = [
+  { element: <div data-testid="route-content" />, path: "/" },
 ];
 
 function mockAttachedConnection() {

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/create-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/create-app.test.tsx
@@ -17,8 +17,6 @@ import { mockConsole } from "#test/utils/console";
 import { stubShellFrame, stubStandaloneFrame } from "#test/utils/frame";
 import { createExtensionApp } from "#web/react/extension/create-app.tsx";
 
-import type { ExtensionAppRoutes } from "#web/react/routing/types";
-
 // @adobe/exc-app and the runtime loader reach the real Experience Cloud shell/runtime; they are the
 // external boundaries faked here. react-dom, the router, and the Entrypoint all run for real.
 const mocks = vi.hoisted(() => ({
@@ -47,10 +45,10 @@ vi.mock("#web/runtime-loader", () => ({
   loadExperienceCloudRuntime: mocks.loadExperienceCloudRuntime,
 }));
 
-const ROUTES: ExtensionAppRoutes = [
-  { element: <div data-testid="route-content" />, index: true },
-];
-const OPTIONS = { metadata: { extensionId: "ext-1" }, routes: ROUTES };
+const OPTIONS = {
+  menu: <div data-testid="route-content" />,
+  metadata: { extensionId: "ext-1" },
+};
 
 let restoreFrame: () => void = () => undefined;
 
@@ -73,6 +71,36 @@ afterEach(() => {
 });
 
 describe("createExtensionApp", () => {
+  test.each([
+    "/",
+    "#/",
+  ])("throws when the menu is also declared as the %s root route", (path) => {
+    expect(() =>
+      createExtensionApp({
+        ...OPTIONS,
+        routes: [{ element: <div />, path }],
+      }),
+    ).toThrow('The "/" route is reserved for the menu.');
+  });
+
+  test("allows a root route when no menu is configured", async () => {
+    mocks.createMockRuntime.mockReturnValue(createMockRuntime());
+    mocks.loadExperienceCloudRuntime.mockImplementation(() => {
+      throw new Error("no shell");
+    });
+
+    createExtensionApp({
+      metadata: OPTIONS.metadata,
+      routes: [{ element: <div data-testid="route-content" />, path: "#/" }],
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        document.querySelector('[data-testid="route-content"]'),
+      ).not.toBeNull(),
+    );
+  });
+
   test("throws when no #root element exists and no root option is given", () => {
     document.body.innerHTML = "";
     expect(() => createExtensionApp(OPTIONS)).toThrow(

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/create-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/create-app.test.tsx
@@ -71,17 +71,17 @@ afterEach(() => {
 });
 
 describe("createExtensionApp", () => {
-  test.each([
-    "/",
-    "#/",
-  ])("throws when the menu is also declared as the %s root route", (path) => {
-    expect(() =>
-      createExtensionApp({
-        ...OPTIONS,
-        routes: [{ element: <div />, path }],
-      }),
-    ).toThrow('The "/" route is reserved for the menu.');
-  });
+  test.each(["/", "#/"])(
+    "throws when the menu is also declared as the %s root route",
+    (path) => {
+      expect(() =>
+        createExtensionApp({
+          ...OPTIONS,
+          routes: [{ element: <div />, path }],
+        }),
+      ).toThrow('The "/" route is reserved for the menu.');
+    },
+  );
 
   test("allows a root route when no menu is configured", async () => {
     mocks.createMockRuntime.mockReturnValue(createMockRuntime());

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/entrypoint.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/entrypoint.test.tsx
@@ -25,15 +25,15 @@ import { renderWithRouter } from "#test/utils/router.tsx";
 import { Entrypoint } from "#web/react/extension/entrypoint.tsx";
 
 import type { RuntimeConfiguration } from "@adobe/exc-app";
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
 // @adobe/uix-guest reaches a real uix-host across the iframe bridge; it is the only external boundary faked here.
 vi.mock("@adobe/uix-guest", async () =>
   (await import("#test/fixtures/uix-guest")).uixGuestMock(),
 );
 
-const ROUTES: RouteEntry[] = [
-  { element: <div data-testid="route-content" />, index: true },
+const ROUTES: ExtensionRoute[] = [
+  { element: <div data-testid="route-content" />, path: "/" },
 ];
 
 function renderEntrypoint(

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/experience-shell-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/experience-shell-app.test.tsx
@@ -18,10 +18,10 @@ import { renderWithRouter } from "#test/utils/router.tsx";
 import { ExperienceShellExtensionApp } from "#web/react/extension/experience-shell-app.tsx";
 
 import type { RuntimeConfiguration } from "@adobe/exc-app";
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
-const ROUTES: RouteEntry[] = [
-  { element: <div data-testid="route-content" />, index: true },
+const ROUTES: ExtensionRoute[] = [
+  { element: <div data-testid="route-content" />, path: "/" },
 ];
 
 // The runtime is the exc-app boundary; a minimal fake EventEmitter is enough.

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/standalone-app.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/extension/standalone-app.test.tsx
@@ -16,10 +16,10 @@ import { stubStandaloneFrame } from "#test/utils/frame";
 import { renderWithRouter } from "#test/utils/router.tsx";
 import { StandaloneExtensionApp } from "#web/react/extension/standalone-app.tsx";
 
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
-const ROUTES: RouteEntry[] = [
-  { element: <div data-testid="route-content" />, index: true },
+const ROUTES: ExtensionRoute[] = [
+  { element: <div data-testid="route-content" />, path: "/" },
 ];
 
 let restoreFrame: () => void = () => undefined;

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import { createRetryablePromiseCache } from "#web/react/promise-cache";
 
-import type { Result } from "#web/react/types";
+import type { Result } from "#web/react/result";
 
 describe("createRetryablePromiseCache", () => {
   test("returns the identical promise for the same key and runs create once", () => {

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/promise-cache.test.ts
@@ -14,6 +14,8 @@ import { describe, expect, test, vi } from "vitest";
 
 import { createRetryablePromiseCache } from "#web/react/promise-cache";
 
+import type { Result } from "#web/react/types";
+
 describe("createRetryablePromiseCache", () => {
   test("returns the identical promise for the same key and runs create once", () => {
     const cache = createRetryablePromiseCache<string>();
@@ -64,8 +66,8 @@ describe("createRetryablePromiseCache", () => {
     expect(second).toBe(first);
     expect(create).toHaveBeenCalledTimes(1);
 
-    // evictIfRejected drops the failed entry, so the next lookup retries.
-    cache.evictIfRejected("key");
+    // evictIfFailed drops the failed entry, so the next lookup retries.
+    cache.evictIfFailed("key");
     const third = cache.get("key", create);
 
     expect(third).not.toBe(first);
@@ -74,17 +76,43 @@ describe("createRetryablePromiseCache", () => {
     await expect(third).resolves.toBe("recovered");
   });
 
-  test("evictIfRejected keeps a resolved promise", async () => {
+  test("evictIfFailed keeps a successful promise", async () => {
     const cache = createRetryablePromiseCache<string>();
     const create = vi.fn(() => Promise.resolve("value"));
 
     const first = cache.get("key", create);
     await expect(first).resolves.toBe("value");
 
-    cache.evictIfRejected("key");
+    cache.evictIfFailed("key");
     const second = cache.get("key", create);
 
     expect(second).toBe(first);
     expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test("evicts a fulfilled value classified as a failure", async () => {
+    const cache = createRetryablePromiseCache<Result<string>>(
+      ({ error }) => error !== null,
+    );
+    const create = vi
+      .fn<() => Promise<Result<string>>>()
+      .mockResolvedValueOnce({ data: null, error: new Error("boom") })
+      .mockResolvedValueOnce({ data: "recovered", error: null });
+
+    const first = cache.get("key", create);
+    await expect(first).resolves.toEqual({
+      data: null,
+      error: new Error("boom"),
+    });
+
+    cache.evictIfFailed("key");
+    const second = cache.get("key", create);
+
+    expect(second).not.toBe(first);
+    expect(create).toHaveBeenCalledTimes(2);
+    await expect(second).resolves.toEqual({
+      data: "recovered",
+      error: null,
+    });
   });
 });

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/result.test.ts
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/result.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { actionsError, error, ok, okActions } from "#web/react/result";
+
+describe("result constructors", () => {
+  test("creates successful and failed data results", () => {
+    const data = { value: "available" };
+
+    expect(ok(data)).toEqual({ data, error: null });
+    expect(error("unavailable")).toEqual({
+      data: null,
+      error: expect.objectContaining({ message: "unavailable" }),
+    });
+  });
+
+  test("creates successful and failed actions results", () => {
+    const actions = { close: async () => undefined };
+
+    expect(okActions(actions)).toEqual({ actions, error: null });
+    expect(actionsError("unavailable")).toEqual({
+      actions: null,
+      error: expect.objectContaining({ message: "unavailable" }),
+    });
+  });
+
+  test("preserves an error cause", () => {
+    const cause = new Error("root cause");
+
+    expect(error("unavailable", { cause }).error.cause).toBe(cause);
+    expect(actionsError("unavailable", { cause }).error.cause).toBe(cause);
+  });
+});

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/hooks/use-spectrum-router.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/hooks/use-spectrum-router.test.tsx
@@ -15,10 +15,10 @@ import { describe, expect, test } from "vitest";
 import { renderHookWithRouter } from "#test/utils/router.tsx";
 import { useSpectrumRouter } from "#web/react/routing/hooks/use-spectrum-router";
 
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
-const ROUTES: RouteEntry[] = [
-  { element: null, index: true },
+const ROUTES: ExtensionRoute[] = [
+  { element: null, path: "/" },
   { element: null, path: "settings" },
   { element: null, path: "bar" },
 ];

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/lib.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/routing/lib.test.tsx
@@ -29,9 +29,9 @@ describe("getRouteTo", () => {
 });
 
 describe("createExtensionRouter", () => {
-  test("builds a router with the index and hash-stripped route paths", () => {
+  test("builds a router with root and hash-stripped route paths", () => {
     const router = createExtensionRouter(<div />, [
-      { element: <div>home</div>, index: true },
+      { element: <div>home</div>, path: "/" },
       { element: <div>settings</div>, path: "#/settings" },
     ]);
 
@@ -43,7 +43,7 @@ describe("createExtensionRouter", () => {
 
   test("renders the root component and the matched route element", async () => {
     const router = createExtensionRouter(<ActiveRoute />, [
-      { element: <div>home</div>, index: true },
+      { element: <div>home</div>, path: "/" },
     ]);
 
     const screen = await render(<RouterProvider router={router} />);

--- a/packages/aio-commerce-lib-admin-ui/test/unit/web/react/shell/hooks/use-shell-configuration.test.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/unit/web/react/shell/hooks/use-shell-configuration.test.tsx
@@ -16,12 +16,12 @@ import { createMockRuntime } from "#test/fixtures/exc-app";
 import { renderHookWithRouter } from "#test/utils/router.tsx";
 import { useShellConfiguration } from "#web/react/shell/hooks/use-shell-configuration";
 
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
 const CURRENT_PATHNAME = "/current";
 
-const ROUTES: RouteEntry[] = [
-  { element: null, index: true },
+const ROUTES: ExtensionRoute[] = [
+  { element: null, path: "/" },
   { element: null, path: "current" },
   { element: null, path: "other" },
 ];

--- a/packages/aio-commerce-lib-admin-ui/test/utils/router.tsx
+++ b/packages/aio-commerce-lib-admin-ui/test/utils/router.tsx
@@ -15,11 +15,11 @@ import { render } from "vitest-browser-react";
 
 import { createExtensionRouter } from "#web/react/routing/lib";
 
-import type { RouteEntry } from "#web/react/routing/types";
+import type { ExtensionRoute } from "#web/react/routing/types";
 
 type RouterOptions = {
   /** Routes rendered into the root component's `<Outlet />`; declare every path a test navigates to. */
-  routes?: RouteEntry[];
+  routes?: ExtensionRoute[];
   /** Initial history stack; seed multiple entries to make `useCanGoBack` true. */
   initialEntries?: string[];
 };

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/templates/admin-ui/web-src/src/app.jsx
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/templates/admin-ui/web-src/src/app.jsx
@@ -5,9 +5,8 @@ import config from "#app.commerce.config";
 import { MainPage } from "#web/pages/main-page.jsx";
 
 createExtensionApp({
+  menu: <MainPage />,
   metadata: {
     extensionId: config.metadata.id,
   },
-
-  routes: [{ element: <MainPage />, index: true }],
 });

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/templates/admin-ui/web-src/src/components/welcome.jsx
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/templates/admin-ui/web-src/src/components/welcome.jsx
@@ -2,11 +2,15 @@ import { useIms } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 /** A simple welcome component that displays the IMS token and org ID. */
 export function Welcome() {
-  const { imsOrgId } = useIms();
+  const { data, error } = useIms();
+  if (error) {
+    throw error;
+  }
+
   return (
     <>
       <h1>Welcome to your Adobe Commerce App</h1>
-      <p>Your IMS Org ID is {imsOrgId}</p>
+      <p>Your IMS Org ID is {data.imsOrgId}</p>
     </>
   );
 }

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -381,12 +381,20 @@ describe("commands/generate/actions", () => {
           expect(appContent).toContain("#app.commerce.config");
           expect(appContent).toContain("#web/pages/main-page.jsx");
           expect(appContent).toContain("createExtensionApp");
+          expect(appContent).toContain("menu: <MainPage />");
+          expect(appContent).not.toContain("index: true");
 
           const pageContent = await readFile(
             join(webSrcDir, "src", "pages", "main-page.jsx"),
             "utf-8",
           );
           expect(pageContent).toContain("#web/components/welcome.jsx");
+
+          const welcomeContent = await readFile(
+            join(webSrcDir, "src", "components", "welcome.jsx"),
+            "utf-8",
+          );
+          expect(welcomeContent).toContain("throw error");
 
           const pkg = JSON.parse(
             await readFile(join(tempDir, "package.json"), "utf-8"),

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -206,13 +206,15 @@ For each `view`-type **mass action** and **order view button** (both carry a `pa
 
 Pre-wire the hook by view type — all from `@adobe/aio-commerce-lib-admin-ui/web`:
 
-| View entry           | Context hook                                  | Also                                                         | Reference                                              |
-| -------------------- | --------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------ |
-| Mass action (`view`) | `useMassActionContext()` → `{ selectedIds }`  | `useHostConnection()` → `{ close, closeWithError }` to close | [mass-actions](references/mass-actions.md)             |
-| Order view button    | `useOrderViewButtonContext()` → `{ orderId }` | `useHostConnection()` → `{ close, closeWithError }` to close | [order-view-buttons](references/order-view-buttons.md) |
-| Menu                 | none (plain index page)                       | —                                                            | [menu](references/menu.md)                             |
+| View entry           | Context hook                                                          | Also                                                                | Reference                                              |
+| -------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------ |
+| Mass action (`view`) | `useMassActionContext()` → `{ data, error }`; use `data.selectedIds`  | `useHostConnection()` → `{ actions, error }`; use `actions.close()` | [mass-actions](references/mass-actions.md)             |
+| Order view button    | `useOrderViewButtonContext()` → `{ data, error }`; use `data.orderId` | `useHostConnection()` → `{ actions, error }`; use `actions.close()` | [order-view-buttons](references/order-view-buttons.md) |
+| Menu                 | none (plain index page)                                               | —                                                                   | [menu](references/menu.md)                             |
 
-A route component may also call `useIms()` → `{ imsToken, imsOrgId }` and `useCommerce()` → `{ commerceHost }` to reach the Commerce REST API (`imsToken` for auth, `commerceHost` for the base URL; the generated `Welcome` component demonstrates `useIms`). Add those only when the page actually needs them.
+These hooks return errors instead of throwing them. A route can throw a returned error during render to send it to the SDK's error boundary, which replaces the extension content with its fallback UI. If the route must stay mounted, handle the error locally by rendering a message, offering a retry, disabling the affected feature, or providing another degraded state. The placeholder examples below throw because they don't define custom recovery UI.
+
+A route component may also call `useIms()` and `useCommerce()` to reach the Commerce REST API or retrieve data directly from the host, respectively. Both return `{ data, error }`; after handling `error`, read `data.imsToken` and `data.imsOrgId` from `useIms()`, and `data.commerceHost` from `useCommerce()`. The generated `Welcome` component demonstrates this result handling for `useIms()`. Add those hooks only when the page actually needs them.
 
 Example — a `view` mass action placeholder page and its route registration:
 
@@ -224,8 +226,13 @@ import {
 } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 export function ExportCustomersPage() {
-  const { selectedIds } = useMassActionContext(); // string[] — the selected record ids
-  const { close } = useHostConnection(); // await close() (or closeWithError()) when done
+  const { data, error: contextError } = useMassActionContext();
+  const { actions, error: hostError } = useHostConnection();
+  if (contextError) throw contextError;
+  if (hostError) throw hostError;
+
+  const { selectedIds } = data; // non-empty string[] — the selected record ids
+  const { close } = actions; // await close() (or actions.closeWithError()) when done
 
   return (
     <main>
@@ -254,7 +261,7 @@ createExtensionApp({
 });
 ```
 
-For an order view button, swap the hook for `useOrderViewButtonContext()` (`{ orderId }`) — see [order-view-buttons](references/order-view-buttons.md).
+For an order view button, swap the hook for `useOrderViewButtonContext()` and read `data.orderId` after handling `error` — see [order-view-buttons](references/order-view-buttons.md).
 
 ## Step 5 — Validate
 

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
@@ -70,7 +70,7 @@
       "id": 4,
       "name": "product-mass-action-view",
       "prompt": "Add a view-based 'Export selected products' mass action to the product grid in my initialized Commerce admin app. It should open an iframe page in web-src where the user can download a CSV for the selected products. It should not call a backend worker action.",
-      "expected_output": "adminUi.product.massActions with a type: \"view\" entry containing id, label, path, and sandboxPermissions such as allow-downloads. The view entry must not include runtimeAction or timeout and must not scaffold/register a backend worker action. The iframe code reads the selection with useMassActionContext imported from @adobe/aio-commerce-lib-admin-ui/web (the web-src frontend is scaffolded by init/generate). Uses the v2 adminUi schema, avoids legacy wrappers (adminUiSdk.registration or commerce/backend-ui/1), and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
+      "expected_output": "adminUi.product.massActions with a type: \"view\" entry containing id, label, path, and sandboxPermissions such as allow-downloads. The view entry must not include runtimeAction or timeout and must not scaffold/register a backend worker action. The iframe code imports useMassActionContext and useHostConnection from @adobe/aio-commerce-lib-admin-ui/web, checks their errors and either throws during render for the error boundary or renders local fallback UI, reads selectedIds through the context hook's data, and invokes close or closeWithError through the host hook's actions. The web-src frontend is scaffolded by init/generate. Uses the v2 adminUi schema, avoids legacy wrappers (adminUiSdk.registration or commerce/backend-ui/1), and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
       "files": [],
       "assertions": [
         "Declares adminUi.product.massActions as an array containing a type: \"view\" entry",
@@ -78,7 +78,8 @@
         "View mass action includes sandboxPermissions for iframe downloads/modals/popups",
         "View mass action does NOT include worker-only fields (no runtimeAction, no timeout)",
         "Does not scaffold or register a backend worker action for the view mass action",
-        "Iframe/web-src code contains a route for the view mass action path and reads the selection with useMassActionContext from @adobe/aio-commerce-lib-admin-ui/web",
+        "Iframe/web-src code contains a route for the view mass action path and either throws the useMassActionContext error during render or renders local fallback UI before reading data.selectedIds",
+        "Iframe/web-src code either throws the useHostConnection error during render or renders local fallback UI before calling actions.close() or actions.closeWithError()",
         "Uses the v2 adminUi shape (no commerce/backend-ui/1 or adminUiSdk.registration legacy API)",
         "Notes mention running npx @adobe/aio-commerce-lib-app init and aio app build"
       ]
@@ -106,13 +107,14 @@
       "id": 6,
       "name": "order-view-button-view",
       "prompt": "Add a view-based 'Review fraud signals' button to the Commerce Admin order detail page in my initialized app. Clicking it should open an iframe route in web-src with the order id, not run a backend worker action.",
-      "expected_output": "adminUi.order.viewButtons with a type: \"view\" entry containing id, label, path, and sandboxPermissions. The view button must not include runtimeAction or timeout and must not scaffold/register a backend worker handler. The iframe code reads the order with useOrderViewButtonContext imported from @adobe/aio-commerce-lib-admin-ui/web (the web-src frontend is scaffolded by init/generate). It stays under the order entity only, uses the v2 adminUi schema, avoids legacy wrappers (adminUiSdk.registration or commerce/backend-ui/1), and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
+      "expected_output": "adminUi.order.viewButtons with a type: \"view\" entry containing id, label, path, and sandboxPermissions. The view button must not include runtimeAction or timeout and must not scaffold/register a backend worker handler. The iframe code imports useOrderViewButtonContext and useHostConnection from @adobe/aio-commerce-lib-admin-ui/web, checks their errors and either throws during render for the error boundary or renders local fallback UI, reads orderId through the context hook's data, and invokes close or closeWithError through the host hook's actions. The web-src frontend is scaffolded by init/generate. It stays under the order entity only, uses the v2 adminUi schema, avoids legacy wrappers (adminUiSdk.registration or commerce/backend-ui/1), and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
       "files": [],
       "assertions": [
         "Declares adminUi.order.viewButtons as an array containing a type: \"view\" entry",
         "View button has required id, label, and path fields",
         "View button has a valid path field (a web-src route); sandboxPermissions, if present, uses only valid values (allow-downloads, allow-modals, allow-popups)",
-        "Iframe/web-src code contains a route for the view button path and reads the order with useOrderViewButtonContext from @adobe/aio-commerce-lib-admin-ui/web",
+        "Iframe/web-src code contains a route for the view button path and either throws the useOrderViewButtonContext error during render or renders local fallback UI before reading data.orderId",
+        "Iframe/web-src code either throws the useHostConnection error during render or renders local fallback UI before calling actions.close() or actions.closeWithError()",
         "View button does NOT include worker-only fields (no runtimeAction, no timeout)",
         "Does not scaffold or register a backend worker action for the view button",
         "Does not declare viewButtons under product or customer because only order supports view buttons",

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/references/mass-actions.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/references/mass-actions.md
@@ -101,10 +101,15 @@ import {
 } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function ExportCustomersPage() {
-  const { selectedIds } = useMassActionContext(); // string[] — the selected record ids
-  const { close, closeWithError } = useHostConnection();
-  // ...render the UI, then await close() on success or closeWithError() on failure
+  const { data, error: contextError } = useMassActionContext();
+  const { actions, error: hostError } = useHostConnection();
+  if (contextError) throw contextError;
+  if (hostError) throw hostError;
+
+  const { selectedIds } = data; // non-empty string[] — the selected record ids
+  // ...render the UI, then await actions.close() on success
+  // or actions.closeWithError() on failure
 }
 ```
 
-`useMassActionContext` throws if the frame is not running as a mass-action extension point within Commerce.
+`useMassActionContext` returns an error if the frame is not running as a mass-action extension point within Commerce, or if `selectedIds` is missing, empty, or contains a non-string row ID. `useHostConnection` similarly returns an error when host frame actions are unavailable. The example throws these errors during render so the SDK's error boundary replaces the extension content with its fallback UI. To keep the page mounted, render custom recovery or degraded UI instead. Either throw or handle each error before reading `data.selectedIds` or calling `actions.close()` or `actions.closeWithError()`.

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/references/order-view-buttons.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/references/order-view-buttons.md
@@ -102,10 +102,15 @@ import {
 } from "@adobe/aio-commerce-lib-admin-ui/web";
 
 function EditShippingPage() {
-  const { orderId } = useOrderViewButtonContext(); // the order the button was clicked on
-  const { close, closeWithError } = useHostConnection();
-  // ...do the work, then await close() on success or closeWithError() on failure
+  const { data, error: contextError } = useOrderViewButtonContext();
+  const { actions, error: hostError } = useHostConnection();
+  if (contextError) throw contextError;
+  if (hostError) throw hostError;
+
+  const { orderId } = data; // the order the button was clicked on
+  // ...do the work, then await actions.close() on success
+  // or actions.closeWithError() on failure
 }
 ```
 
-On `close()` / `closeWithError()`, Commerce closes the frame, redirects back to the order view page, and renders the configured notification. `useOrderViewButtonContext` throws when the frame is not running as an order view-button extension point within Commerce.
+On `actions.close()` / `actions.closeWithError()`, Commerce closes the frame, redirects back to the order view page, and renders the configured notification. `useOrderViewButtonContext` returns an error when the frame is not running as an order view-button extension point within Commerce. The example throws hook errors during render so the SDK's error boundary replaces the extension content with its fallback UI. To keep the page mounted, render custom recovery or degraded UI instead. Either throw or handle each error before reading `data.orderId` or calling the host actions.

--- a/specs/features/CEXT-6454-decouple-admin-ui-menu-route.md
+++ b/specs/features/CEXT-6454-decouple-admin-ui-menu-route.md
@@ -2,7 +2,7 @@
 
 - **Ticket:** [CEXT-6454](https://jira.corp.adobe.com/browse/CEXT-6454)
 - **Created:** 2026-07-13
-- [ ] **Implemented**
+- [x] **Implemented**
 
 ## Summary
 
@@ -29,6 +29,29 @@ combination:
 Both approaches share one cleanup: remove the special `index: true` route variant
 so every extension route uses one `{ path, element }` shape. The single-page
 setup keeps working under either approach.
+
+## Decision and implementation
+
+Approach B was selected on July 17, 2026, with one naming change: the custom
+`createExtensionApp` property is `menu`, not `entry`. The primary use case is an
+Adobe Commerce Admin menu, so the implementation favors that direct name despite
+the Experience Cloud Shell naming drawback discussed below.
+
+The implemented API uses the optional `menu` property for the single page
+rendered at `"/"` and uses `routes` for `{ path, element }` routes. When `menu`
+is present, a root-equivalent route alongside it is a runtime error because it
+declares the same page twice. When `menu` is absent, the app can declare its root
+page in `routes`. The iframe URL and `adminUi.menu` configuration remain
+unchanged.
+
+The six host hooks identified in Approach B return the documented
+`{ data, error }` result union instead of throwing when their host data isn't
+available. This lets the shared `menu` page render a fallback in Experience
+Cloud Shell or when it runs standalone. No Commerce module change is required.
+
+The original option analysis remains below as the record of the design discussion.
+Where it refers to the proposed `entry` property, the implemented property is
+`menu` as resolved above.
 
 ## Motivation
 
@@ -321,6 +344,15 @@ Approach B's degradation half is partly possible today (an app can branch on fra
 detection) but not cleanly, because the hooks throw before the app can branch.
 
 ## Unresolved questions
+
+The implementation resolves the original questions as follows. The discussion
+below remains unchanged as the record of what required alignment.
+
+- The menu keeps the app-root URL, as proposed by Approach B.
+- `createExtensionApp` uses the optional custom `menu` property rather than
+  `entry`; apps without a menu can use a slash-only route.
+- All six named host hooks use the result pattern.
+- `adminUi.menu` configuration remains unchanged, so no `menu.path` is added.
 
 - **The real fork: does the menu get its own path?** A (yes) means routing
   separation plus Commerce-module work — the menu opens a Commerce-specific page.


### PR DESCRIPTION
## Description

Implements option B from the CEXT-6454 Admin UI entry-point specification, using `menu` as the Adobe Commerce Admin menu page declaration.

- Adds the optional `menu` option to `createExtensionApp` and decouples it from additional path-based routes.
- Removes index-route declarations and uses a uniform `{ path, element }` route shape. The root path is reserved only when `menu` is declared.
- Changes the host-dependent browser hooks to return complementary `{ data, error }` results so pages shared with Experience Cloud Shell can handle unavailable Commerce context without crashing.
- Makes the retryable promise cache understand fulfilled error results.
- Updates the Admin UI generator, public usage documentation, tests, and the specification's implementation status.

## Related Issue

[CEXT-6454](https://jira.corp.adobe.com/browse/CEXT-6454)

## Motivation and Context

The Admin menu page was previously represented by the app's index route, which also made it the default Experience Cloud Shell page. Commerce-only hooks throw outside Commerce, so a shared page could crash when loaded by another host.

Declaring the menu page independently makes that intent explicit, while result-returning host hooks let shared pages degrade gracefully or forward the error to an error boundary when desired.

## How Has This Been Tested?

- Admin UI unit and browser tests: 35 files, 218 tests passed.
- Lib App unit and integration tests: 58 files, 949 tests passed.
- Workspace TypeScript typecheck passed.
- Biome checks passed for the affected packages.
- Admin UI ESM and CJS builds completed successfully.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
