### PR TITLE
Rework snapshot publishing: alpha vs beta workflows

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,17 +1,11 @@
-name: Publish Preview
+name: Publish Alpha
 
 on:
   issue_comment:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to publish preview packages for"
-        required: true
-        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.inputs.pr_number }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
@@ -19,16 +13,15 @@ jobs:
     name: Resolve PR
     if: |
       github.repository == 'adobe/aio-commerce-sdk' &&
-      (
-        (github.event_name == 'workflow_dispatch') ||
-        (github.event.issue.pull_request && github.event.comment.user.type != 'Bot' && contains(github.event.comment.body, '/snapshot'))
-      )
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '/snapshot')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     outputs:
-      pr_number: ${{ steps.pr.outputs.number }}
+      pr_number: ${{ github.event.issue.number }}
       head_sha: ${{ steps.pr_details.outputs.head_sha }}
 
     steps:
@@ -46,23 +39,11 @@ jobs:
               core.setFailed(`@${context.actor} does not have admin permission on this repository (actual: ${data.permission}).`);
             }
 
-      - name: Get PR number
-        id: pr
-        env:
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          else
-            echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
-          fi
-
       - name: Get PR details
         id: pr_details
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -71,29 +52,15 @@ jobs:
               pull_number: Number(process.env.PR_NUMBER),
             });
 
+            if (pr.data.head.ref === 'main') {
+              core.setFailed("Publish Alpha can't snapshot a PR whose head branch is main. Use Publish Beta to snapshot main directly.");
+              return;
+            }
+
             core.setOutput('head_sha', pr.data.head.sha);
-            core.setOutput('base_ref', pr.data.base.ref);
-
-      - name: Checkout PR head
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ steps.pr_details.outputs.head_sha }}
-
-      - name: Verify PR contains new changesets
-        env:
-          BASE_REF: ${{ steps.pr_details.outputs.base_ref }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git fetch origin "$BASE_REF" --depth=1
-          NEW_CHANGESETS=$(git diff --name-only --diff-filter=A "origin/$BASE_REF" HEAD -- '.changeset/' | grep '\.md$' | grep -v 'README.md' || true)
-          if [ -z "$NEW_CHANGESETS" ]; then
-            gh pr comment "$PR_NUMBER" --body "No new changesets found in this PR. Run \`pnpm changeset add\` before requesting a snapshot."
-            exit 1
-          fi
 
   release:
-    name: Publish Preview Packages
+    name: Release Alpha
     needs: prepare
     runs-on: ubuntu-latest
     outputs:
@@ -142,7 +109,7 @@ jobs:
             ).join('\n');
 
             const body = [
-              '### 📦 Snapshot packages published',
+              '### 📦 Alpha packages published',
               '',
               '| Package | Version |',
               '| ------- | ------- |',

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,4 +1,4 @@
-name: Publish Internal
+name: Publish Beta
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Release Internal
+    name: Release Beta
     if: github.repository == 'adobe/aio-commerce-sdk'
     runs-on: ubuntu-latest
     permissions:
@@ -21,6 +21,12 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Ensure running from main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Publish Beta should only be run from main (triggered from ${{ github.ref }}). Use Publish Alpha to snapshot other branches."
+          exit 1
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup-release

--- a/scripts/source/ci/release/announce.ts
+++ b/scripts/source/ci/release/announce.ts
@@ -105,7 +105,10 @@ function formatMarkdownAnnouncement(
     return a.name.localeCompare(b.name);
   });
 
-  let announcement = `:rocket: New public (NPM) packages for <${REPOSITORY_URL}|Adobe Commerce SDK for App Builder>\n\n`;
+  const isBetaRelease = publishedPackages.some((pkg) =>
+    pkg.version.includes("beta"),
+  );
+  let announcement = `:rocket: New ${isBetaRelease ? "beta" : "stable"} NPM packages for <${REPOSITORY_URL}|Adobe Commerce SDK for App Builder>\n\n`;
 
   for (const pkg of publishedPackages) {
     const pkgRelease = `${pkg.name}@${pkg.version}`;

--- a/scripts/test/unit/ci/release/announce.test.ts
+++ b/scripts/test/unit/ci/release/announce.test.ts
@@ -69,7 +69,7 @@ describe("release/announce.ts", () => {
     const payload = announce(asCore(core));
     const { text } = payload;
 
-    expect(text).toContain("public (NPM)");
+    expect(text).toContain("stable NPM packages");
     expect(text).toContain(
       `${PUBLIC_PACKAGE_BASE_URL}/@adobe/aio-commerce-sdk`,
     );
@@ -92,7 +92,7 @@ describe("release/announce.ts", () => {
     const { text } = payload;
 
     expect(core.setFailed).not.toHaveBeenCalled();
-    expect(text).toContain("public (NPM)");
+    expect(text).toContain("beta NPM packages");
     expect(text).toContain(
       `${INTERNAL_PACKAGE_BASE_URL}@adobe/aio-commerce-sdk`,
     );


### PR DESCRIPTION
## Description

Renamed `publish-preview.yml` / `publish-internal.yml` to `publish-alpha.yml` / `publish-beta.yml` and tightened what each one is allowed to do:

- `publish-alpha` (PR previews via `/snapshot`) no longer requires a new changeset in the PR — some changes (e.g. fixing an unreleased change) don't need one, and maintainers should still be able to get a snapshot.
- `publish-alpha` now fails fast if the target PR's head branch is `main` (use `publish-beta` for that instead).
- `publish-beta` now fails fast if it's run from anything other than `main`, instead of silently publishing from whatever branch was selected.
- Slack release announcements now say "beta" or "stable" based on the published version instead of a generic "public (NPM)" label.

## Related Issue

None.

## Motivation and Context

The changeset gate on PR previews was blocking snapshots for PRs that legitimately don't need a version bump. Separately, `publish-internal` allowed picking any branch via the manual dispatch UI and would silently tag it `beta`, even though `beta` is meant to represent `main`. Splitting into two clearly-scoped, correctly-named workflows removes both footguns without merging unrelated release channels together.

## How Has This Been Tested?

- `pnpm lint`, `pnpm --filter @aio-commerce-sdk/scripts typecheck`, and `pnpm --filter @aio-commerce-sdk/scripts test` all pass.
- Updated the two `announce.test.ts` assertions that depended on the old wording.
- Workflow YAML validated for syntax; no way to dry-run GitHub Actions triggers locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.