### PR TITLE
CEXT-6467: fix biome spawn ENOENT in Commerce plugin promotion

### DIFF
--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -2,6 +2,14 @@ name: Publish Public
 
 on:
   workflow_dispatch:
+    inputs:
+      # TODO: recovery-only for the run-29924129665 incident; remove this input
+      # (and the PLUGIN_DIFF_BASE fallback in promote-skills.ts) once this
+      # release's promotion + back-sync have succeeded.
+      plugin_diff_base:
+        description: "Git ref to diff Commerce plugin versions against (overrides HEAD^1, for recovery only)"
+        required: false
+        type: string
   push:
     branches:
       - release
@@ -65,6 +73,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SOURCE_REPOSITORY_PATH: ${{ github.workspace }}
+          PLUGIN_DIFF_BASE: ${{ inputs.plugin_diff_base }}
         with:
           script: |
             const { detectChangedCommercePluginVersions } = await import('${{ github.workspace }}/scripts/source/ci/release/promote-skills.ts');
@@ -75,7 +84,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: adobe/skills
-          path: adobe-skills
+          path: ../adobe-skills
           token: ${{ secrets.ADOBE_SKILLS_TOKEN }}
           fetch-depth: 0
 
@@ -85,7 +94,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SOURCE_REPOSITORY_PATH: ${{ github.workspace }}
-          SKILLS_REPOSITORY_PATH: ${{ github.workspace }}/adobe-skills
+          SKILLS_REPOSITORY_PATH: ${{ github.workspace }}/../adobe-skills
+          PLUGIN_DIFF_BASE: ${{ inputs.plugin_diff_base }}
         with:
           github-token: ${{ secrets.ADOBE_SKILLS_TOKEN }}
           script: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,9 @@ importers:
       '@aio-commerce-sdk/scripting-utils':
         specifier: workspace:*
         version: link:../packages-private/scripting-utils
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
 
   turbo/generators:
     dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -39,7 +39,8 @@
     "@actions/github": "^9.0.0",
     "@aio-commerce-sdk/config-typescript": "workspace:*",
     "@aio-commerce-sdk/config-vitest": "workspace:*",
-    "@aio-commerce-sdk/scripting-utils": "workspace:*"
+    "@aio-commerce-sdk/scripting-utils": "workspace:*",
+    "jsonc-parser": "^3.3.1"
   },
   "sideEffects": false
 }

--- a/scripts/source/ci/release/promote-skills.ts
+++ b/scripts/source/ci/release/promote-skills.ts
@@ -13,7 +13,7 @@
 import { cp, mkdir, readFile, rm } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
-import { readJson, runGitHubScript, writeJson } from "./utils.ts";
+import { readJson, replaceInJson, runGitHubScript } from "./utils.ts";
 
 import type { AsyncFunctionArguments } from "./types.ts";
 
@@ -125,6 +125,12 @@ export async function promoteSkills(
   );
 }
 
+// TODO: recovery-only override, see publish-public.yml's plugin_diff_base
+// input — remove both once this incident's recovery is done.
+function getPluginDiffBase() {
+  return process.env.PLUGIN_DIFF_BASE || "HEAD^1";
+}
+
 export async function getChangedPluginPackagePaths(
   exec: AsyncFunctionArguments["exec"],
   sourceRepositoryPath: string,
@@ -136,7 +142,7 @@ export async function getChangedPluginPackagePaths(
       sourceRepositoryPath,
       "diff",
       "--name-only",
-      "HEAD^1",
+      getPluginDiffBase(),
       "HEAD",
       "--",
       "plugins/commerce/*/package.json",
@@ -273,7 +279,12 @@ async function readPreviousPackageJson(
 ) {
   const result = await exec.getExecOutput(
     "git",
-    ["-C", sourceRepositoryPath, "show", `HEAD^1:${packagePath}`],
+    [
+      "-C",
+      sourceRepositoryPath,
+      "show",
+      `${getPluginDiffBase()}:${packagePath}`,
+    ],
     { ignoreReturnCode: true, silent: true },
   );
 
@@ -294,8 +305,7 @@ async function rewritePluginRepository(targetPath: string) {
     );
   }
 
-  pluginJson.repository = TARGET_REPOSITORY_URL;
-  await writeJson(pluginJsonPath, pluginJson);
+  await replaceInJson(pluginJsonPath, { repository: TARGET_REPOSITORY_URL });
 }
 
 // @changesets/release-utils ships an equivalent getChangelogEntry, but it's

--- a/scripts/source/ci/release/utils.ts
+++ b/scripts/source/ci/release/utils.ts
@@ -10,13 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import { execFile } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
-import { promisify } from "node:util";
 
+import { applyEdits, modify } from "jsonc-parser";
+
+import type { JSONPath } from "jsonc-parser";
 import type { AsyncFunctionArguments } from "./types.ts";
-
-const execFileAsync = promisify(execFile);
 
 /** Runs the given action in a safe way and returns the result. */
 export function runGitHubScript<T>(
@@ -36,18 +35,44 @@ export async function readJson<T>(path: string) {
   return JSON.parse(await readFile(path, "utf-8")) as T;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type JsonReplacement = { path: JSONPath; value: unknown };
+
+/** Flattens a (possibly nested) replacement value into a list of leaf paths. */
+function collectReplacements(
+  value: Record<string, unknown>,
+  path: JSONPath,
+): JsonReplacement[] {
+  return Object.entries(value).flatMap(([key, fieldValue]) => {
+    const fieldPath = [...path, key];
+
+    return isPlainObject(fieldValue)
+      ? collectReplacements(fieldValue, fieldPath)
+      : [{ path: fieldPath, value: fieldValue }];
+  });
+}
+
 /**
- * Serializes and writes a value as a JSON file, then formats it with Biome so the
- * result always matches this repo's formatting rules (e.g. array wrapping), which
- * plain `JSON.stringify` output does not.
+ * Replaces the given keys' values in a JSON file, recursing into nested plain
+ * objects. Only the matching keys' values change — the rest of the file's
+ * existing formatting (indentation, key order, array layout) is preserved,
+ * since this edits the source text directly instead of reserializing it.
  */
-export async function writeJson(path: string, value: unknown) {
-  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
-  await execFileAsync("biome", [
-    "check",
-    "--write",
-    "--no-errors-on-unmatched",
-    "--files-ignore-unknown=true",
-    path,
-  ]);
+export async function replaceInJson(
+  path: string,
+  value: Record<string, unknown>,
+) {
+  const original = await readFile(path, "utf-8");
+  const replacements = collectReplacements(value, []);
+
+  const edits = replacements.flatMap(({ path: fieldPath, value: fieldValue }) =>
+    modify(original, fieldPath, fieldValue, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    }),
+  );
+
+  await writeFile(path, applyEdits(original, edits));
 }

--- a/scripts/source/sync-plugin-version.ts
+++ b/scripts/source/sync-plugin-version.ts
@@ -15,10 +15,9 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import { readJson, writeJson } from "./ci/release/utils.ts";
+import { readJson, replaceInJson } from "./ci/release/utils.ts";
 
 type PackageJson = { version: string };
-type VersionedManifest = { version: string; [key: string]: unknown };
 
 /** Syncs a Commerce plugin's .tessl-plugin/plugin.json and .claude-plugin/plugin.json versions to its package.json version. */
 export default async function main() {
@@ -35,11 +34,9 @@ export default async function main() {
   ].filter((manifestPath) => existsSync(manifestPath));
 
   await Promise.all(
-    manifestPaths.map(async (manifestPath) => {
-      const manifest = await readJson<VersionedManifest>(manifestPath);
-      manifest.version = packageJson.version;
-      await writeJson(manifestPath, manifest);
-    }),
+    manifestPaths.map((manifestPath) =>
+      replaceInJson(manifestPath, { version: packageJson.version }),
+    ),
   );
 }
 

--- a/scripts/test/unit/ci/release/utils.test.ts
+++ b/scripts/test/unit/ci/release/utils.test.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 import { withTempFiles } from "@aio-commerce-sdk/scripting-utils/filesystem";
 import { describe, expect, test } from "vitest";
 
-import { readJson, runGitHubScript, writeJson } from "#ci/release/utils";
+import { readJson, replaceInJson, runGitHubScript } from "#ci/release/utils";
 import { asCore, createCoreMock } from "#test/fixtures/release";
 
 describe("release/utils.ts", () => {
@@ -85,25 +85,63 @@ describe("release/utils.ts", () => {
     });
   });
 
-  describe("writeJson", () => {
-    test("writes a value as formatted JSON with a trailing newline", async () => {
-      await withTempFiles({}, async (tempDir) => {
+  describe("replaceInJson", () => {
+    test("replaces a top-level key's value, preserving everything else", async () => {
+      const original =
+        '{\n  "name": "test",\n  "version": "1.0.0",\n  "keywords": ["commerce", "adobe"]\n}\n';
+
+      await withTempFiles({ "data.json": original }, async (tempDir) => {
         const path = join(tempDir, "data.json");
-        await writeJson(path, { name: "test", version: "1.0.0" });
+        await replaceInJson(path, { version: "2.0.0" });
 
         await expect(readFile(path, "utf-8")).resolves.toBe(
-          '{\n  "name": "test",\n  "version": "1.0.0"\n}\n',
+          '{\n  "name": "test",\n  "version": "2.0.0",\n  "keywords": ["commerce", "adobe"]\n}\n',
         );
       });
     });
 
-    test("formats the output with Biome, collapsing short arrays onto one line", async () => {
-      await withTempFiles({}, async (tempDir) => {
+    test("recurses into nested plain objects", async () => {
+      const original =
+        '{\n  "name": "test",\n  "nested": {\n    "keep": "as-is",\n    "meta": {\n      "author": "Adobe"\n    }\n  }\n}\n';
+
+      await withTempFiles({ "data.json": original }, async (tempDir) => {
         const path = join(tempDir, "data.json");
-        await writeJson(path, { keywords: ["commerce", "adobe"] });
+        await replaceInJson(path, {
+          nested: { meta: { author: "Someone Else" } },
+        });
 
         await expect(readFile(path, "utf-8")).resolves.toBe(
-          '{\n  "keywords": ["commerce", "adobe"]\n}\n',
+          '{\n  "name": "test",\n  "nested": {\n    "keep": "as-is",\n    "meta": {\n      "author": "Someone Else"\n    }\n  }\n}\n',
+        );
+      });
+    });
+
+    test("applies multiple top-level and nested replacements in a single call", async () => {
+      const original =
+        '{\n  "name": "test",\n  "version": "1.0.0",\n  "nested": {\n    "author": "Adobe"\n  }\n}\n';
+
+      await withTempFiles({ "data.json": original }, async (tempDir) => {
+        const path = join(tempDir, "data.json");
+        await replaceInJson(path, {
+          nested: { author: "Someone Else" },
+          version: "2.0.0",
+        });
+
+        await expect(readFile(path, "utf-8")).resolves.toBe(
+          '{\n  "name": "test",\n  "version": "2.0.0",\n  "nested": {\n    "author": "Someone Else"\n  }\n}\n',
+        );
+      });
+    });
+
+    test("leaves keys not present in the replacement value untouched", async () => {
+      const original = '{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}\n';
+
+      await withTempFiles({ "data.json": original }, async (tempDir) => {
+        const path = join(tempDir, "data.json");
+        await replaceInJson(path, { b: 20 });
+
+        await expect(readFile(path, "utf-8")).resolves.toBe(
+          '{\n  "a": 1,\n  "b": 20,\n  "c": 3\n}\n',
         );
       });
     });


### PR DESCRIPTION
## Description

Fixes `writeJson` in `scripts/source/ci/release/utils.ts`, which serialized a whole object and reformatted it by spawning `biome` via `execFile` — a raw OS spawn with no shell/PATH resolution of `node_modules/.bin`. On CI runners, where Biome is only a local devDependency, this fails with `ENOENT`.

Rather than fix the spawn call, replaces it with `replaceInJson`, which edits the source JSON text directly via `jsonc-parser` (the library VS Code uses for the same problem) instead of reserializing the whole object. It computes an edit per replaced key — recursing into nested plain objects — and applies them all in one batch, so it only touches the specific values being replaced; the rest of the file's formatting is preserved without needing a formatter at all. Both real call sites (`promote-skills.ts`, `sync-plugin-version.ts`) only ever replace a single existing scalar field, so this fully covers their needs while removing the whole subprocess-spawn problem class (including a secondary issue found along the way: Biome's own cold start is several seconds on this CI runner, well past vitest's default test timeout, regardless of how it's invoked).

Also clones `adobe/skills` as a sibling directory in the release workflow instead of nesting it inside the SDK checkout, and adds a temporary `plugin_diff_base` override (a `workflow_dispatch` input plus an env fallback in `promote-skills.ts`) so the specific release that failed before this fix landed can have its Commerce plugin promotion and back-sync completed. That override is marked with TODOs and will be removed in a follow-up PR once that recovery completes.

## Related Issue

CEXT-6467

## Motivation and Context

Release run [29924129665](https://github.com/adobe/aio-commerce-sdk/actions/runs/29924129665/job/88936802627) published all packages to npm successfully, but then failed at the "Promote changed Commerce plugins to adobe/skills" step with the `ENOENT` above. Because that step failed, the workflow's `back-sync` job (which merges the release branch back into `main`) was also skipped. This PR fixes the root cause and provides the one-time mechanism needed to recover that specific release.

## How Has This Been Tested?

- `pnpm --filter @aio-commerce-sdk/scripts test` and `pnpm --filter @aio-commerce-sdk/scripts typecheck` both pass.
- Added `replaceInJson` tests covering top-level replacement, nested recursion, multiple simultaneous replacements, and that untouched keys are preserved.
- CI (Turbo Tasks, Node 22 and 24) passes on this branch.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.