### PR TITLE
CEXT-6467: fetch full history in release job when plugin_diff_base is set

### DIFF
--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -33,7 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 2
+          # TODO: recovery-only for the run-29924129665 incident; drop back to a
+          # plain `2` once plugin_diff_base (see below) is removed. A manual
+          # plugin_diff_base can point further back than a depth-2 shallow
+          # clone reaches, so fetch full history whenever it's set.
+          fetch-depth: ${{ inputs.plugin_diff_base && '0' || '2' }}
 
       - uses: ./.github/actions/setup-release
         with:


### PR DESCRIPTION
## Description

The `plugin_diff_base` recovery override (added in #588) lets the "Detect changed Commerce plugin versions" / "Promote changed Commerce plugins to adobe/skills" steps diff against a specific commit instead of the default `HEAD^1`. The `release` job's checkout uses `fetch-depth: 2`, which is enough for the default case but not for a manual override pointing further back once `release` has moved past that commit — `git diff`/`git show` then fail with exit 128 because the target commit isn't present in the shallow clone.

Fetches full history (`fetch-depth: 0`) whenever `plugin_diff_base` is set, leaving the default `fetch-depth: 2` unchanged for normal runs.

## Related Issue

CEXT-6467

## Motivation and Context

Found while attempting the recovery dispatch for the incident `plugin_diff_base` was built for (release run 29924129665): the dispatch with `plugin_diff_base=4d87f72a` failed at "Detect changed Commerce plugin versions" with `git` exit code 128, since `release` had since moved 3 commits ahead of `4d87f72a` and the shallow depth-2 clone no longer reached it.

## How Has This Been Tested?

- Verified the exact `git diff --name-only 4d87f72a HEAD -- 'plugins/commerce/*/package.json'` and `git show 4d87f72a:<path>` commands succeed against a full-history clone of `release`, reproducing what the fixed checkout step will do.
- YAML validity and the `fetch-depth` expression's evaluated value confirmed via a local parse check.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.