### PR TITLE
CEXT-6467: revert adobe/skills checkout back to nested

### DIFF
--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: adobe/skills
-          path: ../adobe-skills
+          path: adobe-skills
           token: ${{ secrets.ADOBE_SKILLS_TOKEN }}
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SOURCE_REPOSITORY_PATH: ${{ github.workspace }}
-          SKILLS_REPOSITORY_PATH: ${{ github.workspace }}/../adobe-skills
+          SKILLS_REPOSITORY_PATH: ${{ github.workspace }}/adobe-skills
           PLUGIN_DIFF_BASE: ${{ inputs.plugin_diff_base }}
         with:
           github-token: ${{ secrets.ADOBE_SKILLS_TOKEN }}


### PR DESCRIPTION
## Description

Reverts the "Checkout adobe/skills" step and `SKILLS_REPOSITORY_PATH` env var in `publish-public.yml` back to checking out `adobe/skills` nested inside the SDK checkout (`adobe-skills`), instead of as a sibling directory (`../adobe-skills`).

## Related Issue

CEXT-6467

## Motivation and Context

`actions/checkout` unconditionally rejects any `path:` input that resolves outside `$GITHUB_WORKSPACE`, throwing `Repository path '...' is not under '...'`. This was confirmed by an actual failed dispatch run (recovery attempt for the CEXT-6467 incident) — the "Checkout adobe/skills" step failed with exactly that error once the sibling-directory change (introduced in #588) was exercised for real.

That sibling-directory change was never load-bearing for the original biome fix: `pnpm exec`/`replaceInJson` resolve relative to the invoking process's `cwd`, not the target file's location, so nesting vs. sibling never mattered for that fix — it was a separate cleanup that turned out to be unsupported by `actions/checkout`.

## How Has This Been Tested?

- Confirmed via the actual failed CI run that this exact path caused the failure, and that reverting to a workspace-relative path is what `actions/checkout` requires.
- YAML validity confirmed via a local parse check.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.