### PR TITLE
CEXT-6467: remove temporary plugin_diff_base recovery override

### DIFF
--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -2,14 +2,6 @@ name: Publish Public
 
 on:
   workflow_dispatch:
-    inputs:
-      # TODO: recovery-only for the run-29924129665 incident; remove this input
-      # (and the PLUGIN_DIFF_BASE fallback in promote-skills.ts) once this
-      # release's promotion + back-sync have succeeded.
-      plugin_diff_base:
-        description: "Git ref to diff Commerce plugin versions against (overrides HEAD^1, for recovery only)"
-        required: false
-        type: string
   push:
     branches:
       - release
@@ -33,11 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # TODO: recovery-only for the run-29924129665 incident; drop back to a
-          # plain `2` once plugin_diff_base (see below) is removed. A manual
-          # plugin_diff_base can point further back than a depth-2 shallow
-          # clone reaches, so fetch full history whenever it's set.
-          fetch-depth: ${{ inputs.plugin_diff_base && '0' || '2' }}
+          fetch-depth: 2
 
       - uses: ./.github/actions/setup-release
         with:
@@ -77,7 +65,6 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SOURCE_REPOSITORY_PATH: ${{ github.workspace }}
-          PLUGIN_DIFF_BASE: ${{ inputs.plugin_diff_base }}
         with:
           script: |
             const { detectChangedCommercePluginVersions } = await import('${{ github.workspace }}/scripts/source/ci/release/promote-skills.ts');
@@ -99,7 +86,6 @@ jobs:
         env:
           SOURCE_REPOSITORY_PATH: ${{ github.workspace }}
           SKILLS_REPOSITORY_PATH: ${{ github.workspace }}/adobe-skills
-          PLUGIN_DIFF_BASE: ${{ inputs.plugin_diff_base }}
         with:
           github-token: ${{ secrets.ADOBE_SKILLS_TOKEN }}
           script: |

--- a/scripts/source/ci/release/promote-skills.ts
+++ b/scripts/source/ci/release/promote-skills.ts
@@ -125,12 +125,6 @@ export async function promoteSkills(
   );
 }
 
-// TODO: recovery-only override, see publish-public.yml's plugin_diff_base
-// input — remove both once this incident's recovery is done.
-function getPluginDiffBase() {
-  return process.env.PLUGIN_DIFF_BASE || "HEAD^1";
-}
-
 export async function getChangedPluginPackagePaths(
   exec: AsyncFunctionArguments["exec"],
   sourceRepositoryPath: string,
@@ -142,7 +136,7 @@ export async function getChangedPluginPackagePaths(
       sourceRepositoryPath,
       "diff",
       "--name-only",
-      getPluginDiffBase(),
+      "HEAD^1",
       "HEAD",
       "--",
       "plugins/commerce/*/package.json",
@@ -279,12 +273,7 @@ async function readPreviousPackageJson(
 ) {
   const result = await exec.getExecOutput(
     "git",
-    [
-      "-C",
-      sourceRepositoryPath,
-      "show",
-      `${getPluginDiffBase()}:${packagePath}`,
-    ],
+    ["-C", sourceRepositoryPath, "show", `HEAD^1:${packagePath}`],
     { ignoreReturnCode: true, silent: true },
   );
 


### PR DESCRIPTION
## Description

Removes the temporary `plugin_diff_base` recovery mechanism added in #588 (the `workflow_dispatch` input, its `PLUGIN_DIFF_BASE` env fallback in `promote-skills.ts`, and the conditional `fetch-depth` added in #589 to support it), reverting `publish-public.yml` and `promote-skills.ts` back to their normal, permanent behavior.

## Related Issue

CEXT-6467

## Motivation and Context

This override existed solely to recover one specific incident: release run 29924129665 published npm packages successfully but failed before promoting its Commerce plugin changes to `adobe/skills` and before `back-sync` could merge `release` back into `main`. That recovery has now completed — `adobe/skills` has an open PR from the promotion ([adobe/skills#275](https://github.com/adobe/skills/pull/275)), and `main` has the version-bump commits merged back via `back-sync`. The override was explicitly marked with TODOs for removal once this point was reached.

## How Has This Been Tested?

- `pnpm --filter @aio-commerce-sdk/scripts test` and `pnpm --filter @aio-commerce-sdk/scripts typecheck` both pass.
- YAML validity confirmed via a local parse check.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.