### PR TITLE
CEXT-6338: suggest Spectrum S2 migration in Admin UI skills

### DIFF
--- a/.changeset/admin-ui-spectrum-s2-suggestion.md
+++ b/.changeset/admin-ui-spectrum-s2-suggestion.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-management": minor
+---
+
+commerce-app-admin-ui now detects existing `web-src` frontends still on classic React Spectrum (v3) and suggests upgrading to Spectrum 2, pointing to the `commerce-app-migrate` skill to run the actual migration.

--- a/.changeset/admin-ui-spectrum-s2-suggestion.md
+++ b/.changeset/admin-ui-spectrum-s2-suggestion.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-plugin-app-management": minor
 ---
 
-commerce-app-admin-ui now detects existing `web-src` frontends still on classic React Spectrum (v3) and suggests upgrading to Spectrum 2, pointing to the `commerce-app-migrate` skill to run the actual migration.
+commerce-app-admin-ui now detects existing `web-src` frontends still on classic React Spectrum (v3) and suggests upgrading to Spectrum 2.

--- a/.changeset/migrate-spectrum-s2-reference.md
+++ b/.changeset/migrate-spectrum-s2-reference.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-migration": minor
+---
+
+`commerce-app-migrate` gains a `spectrum-s2-upgrade` reference so the migration executor can detect classic React Spectrum (v3) in a project's Admin UI `web-src` and offer to run the S1-to-S2 migration for the user.

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -119,6 +119,14 @@ The build derives the extension's `ext.config.yaml` from your `adminUi` config: 
 
 When a `view` operation is present, init/generate also scaffolds the web frontend automatically (skipped if `web-src/index.html` already exists). It generates `src/commerce-backend-ui-2/web-src/` — `index.html`, `src/app.jsx`, `src/pages/main-page.jsx`, `src/components/welcome.jsx` (`.tsx` plus a `tsconfig.json` when the app config is TypeScript) — adds the `#web/*` import alias to `package.json`, and declares and installs pinned versions of `react`, `react-dom`, `@react-spectrum/s2`, and `@adobe/aio-commerce-lib-admin-ui` (React and Spectrum S2 are optional peer dependencies of the admin-ui library), plus some `devDependencies` for proper TypeScript support/config. Do not hand-pick different versions of these dependencies; the scaffold fails if incompatible versions are already installed.
 
+If the scaffold is skipped because `web-src` already exists, check its `package.json` for classic React Spectrum (`@adobe/react-spectrum` or `@react-spectrum/<component>` without `s2`) instead of `@react-spectrum/s2`. The two are compatible, but S2 is the version Adobe recommends moving to and the one this scaffold targets — suggest upgrading. This skill only configures the Admin UI extension, it doesn't drive the upgrade itself, so point the user to the `commerce-app-migrate` skill for the actual migration:
+
+```sh
+npx skills add adobe/skills --skill commerce-app-migrate
+```
+
+Do not install it or perform the upgrade yourself unless the user asks.
+
 ## Step 4 — Implement the handlers
 
 What you implement depends on the variant. Examples below are in TypeScript; if the project uses JavaScript, omit type imports and annotations.

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 0,
       "name": "order-grid-column",
-      "prompt": "I've got a base Commerce app scaffolded with the aio-commerce-sdk (app.commerce.config.ts exists and the project is initialized). I need to add a 'Fulfillment' column to the Admin order grid — the value for each order comes from our warehouse API. Wire up the config and the runtime action handler.",
+      "prompt": "I've got a base Commerce app scaffolded with the aio-commerce-sdk (app.commerce.config.ts exists and the project is initialized). I need to add a 'Fulfillment' column to the Admin order grid \u2014 the value for each order comes from our warehouse API. Wire up the config and the runtime action handler.",
       "expected_output": "adminUi.order.gridColumns declared in app.commerce.config.ts with a single column (id, label, type, align) and a runtimeAction in <package>/<action> form. A handler under src/commerce-backend-ui-2/actions/ using parseGridRequest + okGridResponse/errorGridResponse from @adobe/aio-commerce-sdk/admin-ui/grid-columns, with row keys matching the column id. The action registered under runtimeManifest in src/commerce-backend-ui-2/ext.config.yaml with function: actions/<action>/index.js, require-adobe-auth: true, and final: true. Uses the v2 adminUi schema, does not use adminUiSdk.registration or commerce/backend-ui/1, and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
       "files": [],
       "assertions": [
@@ -93,7 +93,7 @@
       "assertions": [
         "Declares adminUi.menu (single object) with id, label, and description",
         "Sets parentMenu to MENU_SALES imported from @adobe/aio-commerce-sdk/admin-ui/menu",
-        "Menu id uses only valid characters (letters, digits, /, :, _) — no hyphens or spaces",
+        "Menu id uses only valid characters (letters, digits, /, :, _) \u2014 no hyphens or spaces",
         "Recognizes the menu has no runtime action handler; does not scaffold a menu-specific action under src/commerce-backend-ui-2/actions/",
         "Declares adminUi.order.viewButtons with a type: \"worker\" entry containing id, label, and runtimeAction",
         "View button handler imports parseOrderViewButtonRequest and okOrderViewButtonResponse/orderViewButtonErrorResponse from @adobe/aio-commerce-sdk/admin-ui/order-view-buttons",
@@ -138,6 +138,34 @@
         "Both worker action sources live under src/commerce-backend-ui-2/actions/<action>/index.ts",
         "Both worker actions are registered under runtimeManifest with function paths, require-adobe-auth: true, and final: true",
         "Notes mention running npx @adobe/aio-commerce-lib-app init and aio app build"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "existing-web-src-classic-react-spectrum-suggestion",
+      "prompt": "My initialized Commerce app already has an adminUi.menu entry wired up (commerce/backend-ui/2), with src/commerce-backend-ui-2/web-src/ already scaffolded. Its package.json lists \"@adobe/react-spectrum\": \"^3.34.2\" as a dependency (no @react-spectrum/s2). Add a new order view button 'Sync inventory' as a view (iframe) variant.",
+      "expected_output": "The order view button is added to app.commerce.config.ts (adminUi.order.viewButtons) as a type: \"view\" entry with a path, and a new placeholder page plus route are added to the existing web-src without touching the existing menu page/route. Separately, the agent notices the existing web-src's package.json depends on classic React Spectrum (@adobe/react-spectrum) instead of @react-spectrum/s2, explains the two are compatible but S2 is the version Adobe recommends moving to, and suggests installing/using the commerce-app-migrate skill (npx skills add adobe/skills --skill commerce-app-migrate) to run the upgrade \u2014 offering to help but not installing packages or rewriting components itself unless asked.",
+      "files": [
+        {
+          "path": "app.commerce.config.ts",
+          "content": "import { defineConfig } from \"@adobe/aio-commerce-lib-app/config\";\nimport { MENU_SALES } from \"@adobe/aio-commerce-sdk/admin-ui/menu\";\n\nexport default defineConfig({\n  adminUi: {\n    menu: {\n      id: \"acme_dashboard\",\n      label: \"Acme Dashboard\",\n      description: \"Acme app dashboard.\",\n      parentMenu: MENU_SALES,\n    },\n  },\n});\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-2/web-src/package.json",
+          "content": "{\n  \"name\": \"acme-web-src\",\n  \"dependencies\": {\n    \"react\": \"^18.2.0\",\n    \"react-dom\": \"^18.2.0\",\n    \"@adobe/react-spectrum\": \"^3.34.2\",\n    \"@adobe/aio-commerce-lib-admin-ui\": \"^1.0.0\"\n  }\n}\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-2/web-src/src/app.jsx",
+          "content": "import { createExtensionApp } from \"@adobe/aio-commerce-lib-admin-ui/web\";\nimport \"@react-spectrum/s2/page.css\";\n\nimport config from \"#app.commerce.config\";\nimport { MainPage } from \"#web/pages/main-page.jsx\";\n\ncreateExtensionApp({\n  metadata: { extensionId: config.metadata.id },\n  routes: [{ index: true, element: <MainPage /> }],\n});\n"
+        }
+      ],
+      "assertions": [
+        "Adds adminUi.order.viewButtons with a type: \"view\" entry (id, label, path) without touching the existing adminUi.menu entry",
+        "Creates a new placeholder page under web-src/src/pages/ and registers its route in app.jsx as the exact path string from the config, keeping the existing index route and menu page/route untouched",
+        "Detects that web-src's package.json depends on @adobe/react-spectrum (classic React Spectrum) rather than @react-spectrum/s2",
+        "States classic React Spectrum and S2 are compatible, but recommends moving to S2 without claiming classic React Spectrum is unmaintained",
+        "Suggests installing/using the commerce-app-migrate skill (e.g. npx skills add adobe/skills --skill commerce-app-migrate) to run the S1-to-S2 migration, offering to help",
+        "Does not run the codemod, install packages, or rewrite Spectrum components itself unless the user explicitly asks it to proceed"
       ]
     }
   ]

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 0,
       "name": "order-grid-column",
-      "prompt": "I've got a base Commerce app scaffolded with the aio-commerce-sdk (app.commerce.config.ts exists and the project is initialized). I need to add a 'Fulfillment' column to the Admin order grid \u2014 the value for each order comes from our warehouse API. Wire up the config and the runtime action handler.",
+      "prompt": "I've got a base Commerce app scaffolded with the aio-commerce-sdk (app.commerce.config.ts exists and the project is initialized). I need to add a 'Fulfillment' column to the Admin order grid, the value for each order comes from our warehouse API. Wire up the config and the runtime action handler.",
       "expected_output": "adminUi.order.gridColumns declared in app.commerce.config.ts with a single column (id, label, type, align) and a runtimeAction in <package>/<action> form. A handler under src/commerce-backend-ui-2/actions/ using parseGridRequest + okGridResponse/errorGridResponse from @adobe/aio-commerce-sdk/admin-ui/grid-columns, with row keys matching the column id. The action registered under runtimeManifest in src/commerce-backend-ui-2/ext.config.yaml with function: actions/<action>/index.js, require-adobe-auth: true, and final: true. Uses the v2 adminUi schema, does not use adminUiSdk.registration or commerce/backend-ui/1, and mentions running npx @adobe/aio-commerce-lib-app init and aio app build.",
       "files": [],
       "assertions": [
@@ -93,7 +93,7 @@
       "assertions": [
         "Declares adminUi.menu (single object) with id, label, and description",
         "Sets parentMenu to MENU_SALES imported from @adobe/aio-commerce-sdk/admin-ui/menu",
-        "Menu id uses only valid characters (letters, digits, /, :, _) \u2014 no hyphens or spaces",
+        "Menu id uses only valid characters (letters, digits, /, :, _), no hyphens or spaces",
         "Recognizes the menu has no runtime action handler; does not scaffold a menu-specific action under src/commerce-backend-ui-2/actions/",
         "Declares adminUi.order.viewButtons with a type: \"worker\" entry containing id, label, and runtimeAction",
         "View button handler imports parseOrderViewButtonRequest and okOrderViewButtonResponse/orderViewButtonErrorResponse from @adobe/aio-commerce-sdk/admin-ui/order-view-buttons",
@@ -144,7 +144,7 @@
       "id": 8,
       "name": "existing-web-src-classic-react-spectrum-suggestion",
       "prompt": "My initialized Commerce app already has an adminUi.menu entry wired up (commerce/backend-ui/2), with src/commerce-backend-ui-2/web-src/ already scaffolded. Its package.json lists \"@adobe/react-spectrum\": \"^3.34.2\" as a dependency (no @react-spectrum/s2). Add a new order view button 'Sync inventory' as a view (iframe) variant.",
-      "expected_output": "The order view button is added to app.commerce.config.ts (adminUi.order.viewButtons) as a type: \"view\" entry with a path, and a new placeholder page plus route are added to the existing web-src without touching the existing menu page/route. Separately, the agent notices the existing web-src's package.json depends on classic React Spectrum (@adobe/react-spectrum) instead of @react-spectrum/s2, explains the two are compatible but S2 is the version Adobe recommends moving to, and suggests installing/using the commerce-app-migrate skill (npx skills add adobe/skills --skill commerce-app-migrate) to run the upgrade \u2014 offering to help but not installing packages or rewriting components itself unless asked.",
+      "expected_output": "The order view button is added to app.commerce.config.ts (adminUi.order.viewButtons) as a type: \"view\" entry with a path, and a new placeholder page plus route are added to the existing web-src without touching the existing menu page/route. Separately, the agent notices the existing web-src's package.json depends on classic React Spectrum (@adobe/react-spectrum) instead of @react-spectrum/s2, explains the two are compatible but S2 is the version Adobe recommends moving to, and suggests installing/using the commerce-app-migrate skill (npx skills add adobe/skills --skill commerce-app-migrate) to run the upgrade, offering to help but not installing packages or rewriting components itself unless asked.",
       "files": [
         {
           "path": "app.commerce.config.ts",

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
@@ -1047,6 +1047,12 @@ constraints, Next steps) when in doc-scan-only mode.
       If adminUi is worker-only (no view entries), react and react-dom are
       removable as well.
 
+      Each `view` entry only gets a placeholder page. Porting the old
+      iframe's UI content into it is out of scope for this migration —
+      suggest it to the user, targeting @react-spectrum/s2 (not
+      @adobe/react-spectrum; see ../references/spectrum-s2-upgrade.md),
+      but do not port it yourself unless the user explicitly asks.
+
       Runtime packages replaced by @adobe/aio-commerce-sdk:
         @adobe/aio-sdk  cloudevents  got  node-fetch  oauth-1.0a  uuid
 

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
@@ -38,7 +38,7 @@
       "id": 1,
       "name": "order-mass-action-view-sandbox",
       "prompt": "I have a Commerce App Builder project using Admin UI SDK v1. The registration at src/commerce-backend-ui-1/registration.js has an iframe mass action on the order grid with a space-separated sandbox string that includes an invalid value. Migrate it to App Management v2.",
-      "expected_output": "adminUi.order.massActions in app.commerce.config.ts with type: \"view\", path kept, sandbox string split into sandboxPermissions array — only valid values retained (allow-downloads, allow-modals, allow-popups). The invalid value allow-scripts is dropped.",
+      "expected_output": "adminUi.order.massActions in app.commerce.config.ts with type: \"view\", path kept, sandbox string split into sandboxPermissions array \u2014 only valid values retained (allow-downloads, allow-modals, allow-popups). The invalid value allow-scripts is dropped.",
       "files": [
         {
           "path": "app.config.yaml",
@@ -57,7 +57,7 @@
         "Produces adminUi.order.massActions with type: \"view\"",
         "Renames actionId to id (value: \"review-orders\")",
         "Keeps path as path (value: \"#/review\")",
-        "Converts sandbox string to sandboxPermissions array [\"allow-downloads\", \"allow-modals\"] — dropping \"allow-scripts\" as an invalid value",
+        "Converts sandbox string to sandboxPermissions array [\"allow-downloads\", \"allow-modals\"] \u2014 dropping \"allow-scripts\" as an invalid value",
         "Does not include runtimeAction on the view entry"
       ]
     },
@@ -264,6 +264,38 @@
         "Converts sandbox string \"allow-popups allow-modals\" to sandboxPermissions array [\"allow-popups\", \"allow-modals\"]",
         "Does not include runtimeAction on the view entry",
         "Does not emit an unresolved question for runtimeAction"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "classic-react-spectrum-upgrade-suggestion",
+      "prompt": "I have a Commerce App Builder project using Admin UI SDK v1. The registration at src/commerce-backend-ui-1/registration.js has a menuItems array with a single non-section item. The project's src/commerce-backend-ui-1/web-src/package.json lists \"@adobe/react-spectrum\": \"^3.34.2\" as a dependency. Migrate it to App Management v2.",
+      "expected_output": "adminUi.menu produced in app.commerce.config.ts from the non-section menu item. The v2 init scaffolds a fresh src/commerce-backend-ui-2/web-src/ pinned to @react-spectrum/s2. The migration report flags @adobe/react-spectrum under v1 frontend packages superseded by the v2 scaffold, notes that porting any existing iframe UI content is a manual follow-up that should target @react-spectrum/s2 rather than reinstalling classic React Spectrum, and offers to help run that S1-to-S2 upgrade \u2014 without actually rewriting UI components unless the user asks.",
+      "files": [
+        {
+          "path": "app.config.yaml",
+          "content": "application:\n  extensions:\n    commerce/backend-ui/1:\n      $include: src/commerce-backend-ui-1/ext.config.yaml\n"
+        },
+        {
+          "path": "package.json",
+          "content": "{\"name\": \"acme-app\", \"version\": \"1.0.0\"}\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-1/registration.js",
+          "content": "module.exports = {\n  menuItems: [\n    {\n      id: 'dashboard',\n      title: 'Dashboard'\n    }\n  ]\n}\n"
+        },
+        {
+          "path": "src/commerce-backend-ui-1/web-src/package.json",
+          "content": "{\n  \"name\": \"acme-web-src\",\n  \"dependencies\": {\n    \"react\": \"^18.2.0\",\n    \"react-dom\": \"^18.2.0\",\n    \"@adobe/react-spectrum\": \"^3.34.2\",\n    \"@adobe/exc-app\": \"^1.0.0\",\n    \"@adobe/uix-guest\": \"^1.0.0\"\n  }\n}\n"
+        }
+      ],
+      "assertions": [
+        "Produces a single adminUi.menu object from the non-section item (id: \"dashboard\")",
+        "Lists @adobe/react-spectrum among v1 frontend packages superseded by the v2 web-src scaffold in the migration report",
+        "States that the v2 scaffold pins @react-spectrum/s2 for the new web-src, not classic React Spectrum",
+        "Notes that porting any existing iframe UI content into the new web-src is a manual follow-up that should target @react-spectrum/s2",
+        "Offers to help run the S1-to-S2 upgrade rather than only describing it",
+        "Does not rewrite or port any UI component code itself without the user explicitly asking"
       ]
     }
   ]

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
@@ -38,7 +38,7 @@
       "id": 1,
       "name": "order-mass-action-view-sandbox",
       "prompt": "I have a Commerce App Builder project using Admin UI SDK v1. The registration at src/commerce-backend-ui-1/registration.js has an iframe mass action on the order grid with a space-separated sandbox string that includes an invalid value. Migrate it to App Management v2.",
-      "expected_output": "adminUi.order.massActions in app.commerce.config.ts with type: \"view\", path kept, sandbox string split into sandboxPermissions array \u2014 only valid values retained (allow-downloads, allow-modals, allow-popups). The invalid value allow-scripts is dropped.",
+      "expected_output": "adminUi.order.massActions in app.commerce.config.ts with type: \"view\", path kept, sandbox string split into sandboxPermissions array, only valid values retained (allow-downloads, allow-modals, allow-popups). The invalid value allow-scripts is dropped.",
       "files": [
         {
           "path": "app.config.yaml",
@@ -57,7 +57,7 @@
         "Produces adminUi.order.massActions with type: \"view\"",
         "Renames actionId to id (value: \"review-orders\")",
         "Keeps path as path (value: \"#/review\")",
-        "Converts sandbox string to sandboxPermissions array [\"allow-downloads\", \"allow-modals\"] \u2014 dropping \"allow-scripts\" as an invalid value",
+        "Converts sandbox string to sandboxPermissions array [\"allow-downloads\", \"allow-modals\"], dropping \"allow-scripts\" as an invalid value",
         "Does not include runtimeAction on the view entry"
       ]
     },
@@ -270,7 +270,7 @@
       "id": 9,
       "name": "classic-react-spectrum-upgrade-suggestion",
       "prompt": "I have a Commerce App Builder project using Admin UI SDK v1. The registration at src/commerce-backend-ui-1/registration.js has a menuItems array with a single non-section item. The project's src/commerce-backend-ui-1/web-src/package.json lists \"@adobe/react-spectrum\": \"^3.34.2\" as a dependency. Migrate it to App Management v2.",
-      "expected_output": "adminUi.menu produced in app.commerce.config.ts from the non-section menu item. The v2 init scaffolds a fresh src/commerce-backend-ui-2/web-src/ pinned to @react-spectrum/s2. The migration report flags @adobe/react-spectrum under v1 frontend packages superseded by the v2 scaffold, notes that porting any existing iframe UI content is a manual follow-up that should target @react-spectrum/s2 rather than reinstalling classic React Spectrum, and offers to help run that S1-to-S2 upgrade \u2014 without actually rewriting UI components unless the user asks.",
+      "expected_output": "adminUi.menu produced in app.commerce.config.ts from the non-section menu item. The v2 init scaffolds a fresh src/commerce-backend-ui-2/web-src/ pinned to @react-spectrum/s2. The migration report flags @adobe/react-spectrum under v1 frontend packages superseded by the v2 scaffold, notes that porting any existing iframe UI content is a manual follow-up that should target @react-spectrum/s2 rather than reinstalling classic React Spectrum, and offers to help run that S1-to-S2 upgrade, without actually rewriting UI components unless the user asks.",
       "files": [
         {
           "path": "app.config.yaml",

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
@@ -11,7 +11,7 @@ Check the app's root `package.json` for:
 - `@adobe/react-spectrum`, or
 - `@react-spectrum/<component>` packages **without** an `s2` in the name (e.g. `@react-spectrum/button`, `@react-spectrum/provider`)
 
-If ONLY `@react-spectrum/s2` is already present instead, no action is needed. The user might also be using a mix of the two.
+If ONLY `@react-spectrum/s2` dependencies are present, no action is needed, but the user might also be using a mix of the two, in which case you should offer to migrate the remaining ones.
 
 To be sure, check also the `import` statements in the source code; some users might have the dependencies but not actually use them.
 

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
@@ -6,13 +6,14 @@ Applies to any Admin UI `web-src` iframe frontend (view mass actions, order view
 
 ## Detecting classic React Spectrum
 
-Check `web-src/package.json` (or the app's root `package.json` if dependencies are hoisted) for:
+Check the app's root `package.json` for:
 
 - `@adobe/react-spectrum`, or
 - `@react-spectrum/<component>` packages **without** an `s2` in the name (e.g. `@react-spectrum/button`, `@react-spectrum/provider`)
 
-If `@react-spectrum/s2` is already present instead, no action is needed.
+If ONLY `@react-spectrum/s2` is already present instead, no action is needed. The user might also be using a mix of the two.
 
+To be sure, check also the `import` statements in the source code; some users might have the dependencies but not actually use them.
 ## Why recommend upgrading
 
 The two are functionally compatible — they can even be mounted together in the same tree (S2's `Provider` must be the inner-most provider if nested). Classic React Spectrum (v3) is still maintained, but S2 is the version Adobe recommends moving to: smaller bundles via atomic/macro-based CSS, ongoing feature work, and the version this scaffold generates all new `web-src` code against. Recommend the upgrade so the extension's UI stays on one consistent system instead of drifting to two.

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
@@ -1,0 +1,38 @@
+# Upgrading `web-src` from React Spectrum (v3) to Spectrum 2 (S2)
+
+Applies to any Admin UI `web-src` iframe frontend (view mass actions, order view buttons, menu) that still uses classic React Spectrum (v3) instead of `@react-spectrum/s2`.
+
+**This is guidance only.** Detect the situation, tell the user what to do next, and offer to help run the migration — do not run the codemod, install packages, or rewrite components yourself unless the user says to go ahead.
+
+## Detecting classic React Spectrum
+
+Check `web-src/package.json` (or the app's root `package.json` if dependencies are hoisted) for:
+
+- `@adobe/react-spectrum`, or
+- `@react-spectrum/<component>` packages **without** an `s2` in the name (e.g. `@react-spectrum/button`, `@react-spectrum/provider`)
+
+If `@react-spectrum/s2` is already present instead, no action is needed.
+
+## Why recommend upgrading
+
+The two are functionally compatible — they can even be mounted together in the same tree (S2's `Provider` must be the inner-most provider if nested). Classic React Spectrum (v3) is still maintained, but S2 is the version Adobe recommends moving to: smaller bundles via atomic/macro-based CSS, ongoing feature work, and the version this scaffold generates all new `web-src` code against. Recommend the upgrade so the extension's UI stays on one consistent system instead of drifting to two.
+
+## Next steps to give the user
+
+Point the user at the official migration guide rather than relying on a list of breaking changes here — it drifts out of date as S2 evolves, while the source stays current: **https://react-spectrum.adobe.com/migrating.md**
+
+That guide documents both ways to migrate:
+
+1. **AI-assisted migration** — install the Agent Skill so an AI tool can drive the migration:
+
+   ```sh
+   npx skills add https://react-spectrum.adobe.com --skill migrate-react-spectrum-v3-to-s2 --skill react-spectrum-s2
+   ```
+
+2. **Automated codemod** — works standalone, without an AI tool:
+
+   ```sh
+   npx @react-spectrum/codemods s1-to-s2
+   ```
+
+Either way, the guide is the source of truth for scope, options (e.g. `--components`, `--dry`, `--agent`), and the component-by-component breaking changes — fetch it (or have the installed skill/codemod surface it) rather than guessing from memory. Offer to run either route for the user, but it's their choice whether to do it now, later, or themselves. After migrating (if done), test the extension's iframe pages for visual and behavioral regressions.

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/references/spectrum-s2-upgrade.md
@@ -14,6 +14,7 @@ Check the app's root `package.json` for:
 If ONLY `@react-spectrum/s2` is already present instead, no action is needed. The user might also be using a mix of the two.
 
 To be sure, check also the `import` statements in the source code; some users might have the dependencies but not actually use them.
+
 ## Why recommend upgrading
 
 The two are functionally compatible — they can even be mounted together in the same tree (S2's `Provider` must be the inner-most provider if nested). Classic React Spectrum (v3) is still maintained, but S2 is the version Adobe recommends moving to: smaller bundles via atomic/macro-based CSS, ongoing feature work, and the version this scaffold generates all new `web-src` code against. Recommend the upgrade so the extension's UI stays on one consistent system instead of drifting to two.


### PR DESCRIPTION
## Summary
- `commerce-app-admin-ui` now detects when an existing Admin UI `web-src` still depends on classic React Spectrum (v3) instead of `@react-spectrum/s2`, and suggests upgrading — pointing to the `commerce-app-migrate` skill to actually run it, rather than performing the upgrade itself.
- `commerce-app-migrate` gains a `spectrum-s2-upgrade` reference the migration executor follows: detect classic Spectrum, explain S2 is compatible and the recommended path forward, and offer to help run the migration (Agent Skill install or codemod) — still gated on the user's go-ahead.
- Added one eval to each skill's `evals.json` covering the new detect-and-suggest behavior.
- Two changesets (minor) for `@adobe/aio-commerce-plugin-app-management` and `@adobe/aio-commerce-plugin-app-migration`.

## Test plan
- [x] `evals.json` files validated as well-formed JSON