### PR TITLE
CEXT-6420: apply migration skill feedback (scoped init, pnpm blocked builds, description rewrite)

### DIFF
--- a/.changeset/olive-pandas-tell.md
+++ b/.changeset/olive-pandas-tell.md
@@ -1,0 +1,11 @@
+---
+"@adobe/aio-commerce-plugin-app-migration": minor
+---
+
+Improved the `commerce-app-migrate` skill:
+
+- `init` runs with the scoped package name (`npx --yes @adobe/aio-commerce-lib-app@latest init`) so first runs work without the library installed.
+- pnpm projects get esbuild's build script approved (`onlyBuiltDependencies`) before init, with recovery guidance for `ERR_PNPM_IGNORED_BUILDS`.
+- Descriptions over 255 characters are rewritten into a coherent shorter summary instead of truncated mid-sentence.
+- The original `package.json` description is restored if `init` writes back the shortened config value.
+- The migration summary opens with a one-line TL;DR.

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/SKILL.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/SKILL.md
@@ -303,8 +303,18 @@ export default defineConfig({
   Max 50 chars.
 - `version`: Use `package.json` `version`. Default: `"1.0.0"`.
 - `description`: Use `package.json` `description` if present.
-  If the description exceeds 255 characters, truncate it to 252 characters and append `"..."`.
-  If absent or empty, check `extension-manifest.json` `description` field (truncate to 255 if needed).
+  If the description exceeds 255 characters, do NOT truncate it mid-sentence.
+  Instead, rewrite it: read the full description and compose a shorter one that
+  fits in 255 characters while preserving the essential meaning — what the app
+  does, which systems it connects, and its key capabilities. Prefer complete
+  sentences; drop secondary detail (deployment notes, exhaustive feature lists)
+  before core purpose. Never end with `"..."` — the rewritten description must
+  read as intentional, not cut off.
+  The rewritten value applies only to the config: the Executor records the original
+  `package.json` description before init and restores it afterwards (init writes the
+  config value back into `package.json`).
+  If absent or empty, check `extension-manifest.json` `description` field (apply the
+  same rewrite rule).
   If neither has a description: `"Commerce App Builder application"`.
 
 **productDependencies comment:**

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
@@ -532,7 +532,8 @@ both files and pick the first matching rule:
 
 3.  Else, if `pnpm-workspace.yaml` exists: add a top-level list there —
 
-    onlyBuiltDependencies: - esbuild
+        onlyBuiltDependencies:
+          - esbuild
 
 4.  Else (neither location holds pnpm settings): add the `pnpm` section to
     `package.json` as in rule 2. Do not create `pnpm-workspace.yaml` on a project
@@ -571,14 +572,13 @@ structure from `app.commerce.config.ts` in one step.
 **If the init command is denied or blocked (permission error, sandbox rejection,
 or non-zero exit with no network output):**
 
-Do NOT retry. Record the failure and emit the following manual instruction in Step 8:
+Do NOT retry. Record the failure and emit the following manual instruction in Step 8,
+substituting the command matching the project's package manager from the table above:
 
     ✗ aio-commerce-lib-app init BLOCKED (Claude Code sandbox restriction)
 
     Run this manually in your terminal before continuing:
         npx --yes @adobe/aio-commerce-lib-app@latest init
-
-    Then update app.config.yaml and install.yaml per the Next steps section.
 
 Continue to Step 5a even if init failed.
 
@@ -1084,7 +1084,8 @@ constraints, Next steps) when in doc-scan-only mode.
 
     ── Files written ──────────────────────────────────────────────────
       ✓  app.commerce.config.ts                          new
-      ✓  install.yaml                                    new / updated
+      [✓  install.yaml                                   new / updated]
+         ← omit if init failed →
       [✓  scripts/<name>.js                              migrated → defineCustomInstallationStep]
          ← one line per migrated script; omit section if none were migrated →
 
@@ -1148,7 +1149,7 @@ constraints, Next steps) when in doc-scan-only mode.
     ← end conditional →
 
     ── Modified ───────────────────────────────────────────────────────
-         ← omit app.config.yaml line if init failed →
+         ← omit the next two lines if init failed →
       app.config.yaml    added extensions block
       package.json       added postinstall hook
       [package.json      description restored — init wrote the shortened config value back;

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
@@ -26,8 +26,8 @@ Triggered when the orchestrating skill detects an already-migrated project.
 
 - **Skip:** Steps 1–3 (no branch, no file writes, no script migration)
 - **Run:** Step 3a with modified inputs (see Step 3a for details)
-- **Skip:** Steps 4–9
-- **Run:** Step 10 with a restricted output (documentation recommendations only)
+- **Skip:** Steps 4–7
+- **Run:** Step 8 with a restricted output (documentation recommendations only)
 
 In doc-scan-only mode the `assembled config` parameter is `null`. When Step 3a
 reads the config to build migration context, it reads the **existing config file**
@@ -41,7 +41,7 @@ from disk — `app.commerce.config.ts` if it exists, otherwise `app.commerce.con
   and extract the quoted string value as a script path. If none found, use `[]`
 - `convertedYamlFiles`: `[]` (no YAML conversion happened in this mode)
 
-The Step 10 report header is also modified for doc-scan-only mode — see Step 10.
+The Step 8 report header is also modified for doc-scan-only mode — see Step 8.
 
 ---
 
@@ -178,7 +178,7 @@ If the script reads a data file via `fs.readFileSync` (e.g. a YAML or JSON confi
   The `require()` string must be a **static literal** (not a variable) so webpack can
   analyse it at build time.
 
-  **Bookkeeping for Step 10:** Each time you create a `.json` sibling for a `.yaml`
+  **Bookkeeping for Step 8:** Each time you create a `.json` sibling for a `.yaml`
   file, record the original YAML path in an internal list called `convertedYamlFiles`.
   For example, converting `shipping-carriers.yaml` → add `"shipping-carriers.yaml"` to
   `convertedYamlFiles`. This list is used to populate the "Files that can be safely
@@ -435,36 +435,36 @@ Private helpers (e.g. `formatErrorMessage`) are removed — errors now throw dir
 
 **Run this step immediately after Step 3, before init.** Both Category C and
 Category D analyze static files that exist before any install command. Computing them
-now ensures the recommendations are always available in Step 10 regardless of whether
+now ensures the recommendations are always available in Step 8 regardless of whether
 Step 4 succeeds, times out, or is blocked.
 
 In **doc-scan-only mode**, run this step using the modified inputs described in the
 "Operating Modes" section above. Skip Steps 1–3 entirely and begin here.
 
-Apply all computation rules defined below in Step 10 (Categories A, B, C, D). Those rules
-are written in Step 10 for readability but execute here, before npm install.
+Apply all computation rules defined below in Step 8 (Categories A, B, C, D). Those rules
+are written in Step 8 for readability but execute here, before npm install.
 
 - `convertedYamlFiles` for Category B is the list built during Step 3
   (empty `[]` in doc-scan-only mode)
 - All other inputs are drawn from the assembled config and `ProjectSnapshot`
-  as described in Step 10
+  as described in Step 8
 
 Store all results in memory, then:
 
 - **Normal mode:** also print the "Documentation recommendations" block **immediately now**,
-  before Steps 4–9 run. Use the same format as defined in Step 10's
+  before Steps 4–7 run. Use the same format as defined in Step 8's
   "── Documentation recommendations" section. Prefix the block with:
 
       ── Documentation recommendations (computed before install) ────────
 
   This ensures recommendations are visible if a later step (init, commit)
-  blocks, hangs, or fails. Step 10 includes the same block again — that is intentional.
+  blocks, hangs, or fails. Step 8 includes the same block again — that is intentional.
 
 - **Doc-scan-only mode:** store results only. Do **not** print here. There are no risky
-  commands between Step 3a and Step 10, so printing twice would be pure noise. Print once
-  in Step 10's abbreviated report.
+  commands between Step 3a and Step 8, so printing twice would be pure noise. Print once
+  in Step 8's abbreviated report.
 
-Proceed to Step 4 (or Step 10 in doc-scan-only mode) after storing.
+Proceed to Step 4 (or Step 8 in doc-scan-only mode) after storing.
 
 ---
 
@@ -541,7 +541,7 @@ both files and pick the first matching rule:
 If `esbuild` is already present in the list, make no change.
 
 Record which file was modified (or that no change was needed) — it is reported in
-Step 10's "Modified" section.
+Step 8's "Modified" section.
 
 ### Run init
 
@@ -571,7 +571,7 @@ structure from `app.commerce.config.ts` in one step.
 **If the init command is denied or blocked (permission error, sandbox rejection,
 or non-zero exit with no network output):**
 
-Do NOT retry. Record the failure and emit the following manual instruction in Step 10:
+Do NOT retry. Record the failure and emit the following manual instruction in Step 8:
 
     ✗ aio-commerce-lib-app init BLOCKED (Claude Code sandbox restriction)
 
@@ -587,7 +587,7 @@ Continue to Step 5a even if init failed.
 If the command exits with an error, inspect the output:
 
 1.  **"CLI was not built!"** — The installed package is missing its compiled `dist/`
-    directory (packaging defect). Record this specific error. In Step 10, emit:
+    directory (packaging defect). Record this specific error. In Step 8, emit:
 
         ✗ aio-commerce-lib-app init FAILED: CLI was not built! (dist/ missing from aio-commerce-lib-app)
 
@@ -605,7 +605,7 @@ If the command exits with an error, inspect the output:
     approval (the pre-flight above covers `esbuild`; a different package may be
     named). Add the named package to the same `onlyBuiltDependencies` list the
     pre-flight wrote, then re-run init **once**. If it still fails, record the
-    failure and emit in Step 10:
+    failure and emit in Step 8:
 
         ✗ aio-commerce-lib-app init FAILED: ERR_PNPM_IGNORED_BUILDS (<package> build script blocked)
 
@@ -615,11 +615,11 @@ If the command exits with an error, inspect the output:
              pre-flight chose>, or run: pnpm approve-builds
           2. Re-run: pnpm --allow-build=esbuild dlx @adobe/aio-commerce-lib-app@latest init
 
-3.  **Schema validation errors** — Record the error and report it in Step 10 so
+3.  **Schema validation errors** — Record the error and report it in Step 8 so
     the developer can fix the config and re-run init manually.
 
 4.  **Any other error** — Record the failure message and skip Step 5a.
-    Report the error in Step 10.
+    Report the error in Step 8.
 
 After this command completes successfully, check which directories were created:
 
@@ -805,14 +805,14 @@ Compare `package.json`'s current `description` with the `originalPackageDescript
 recorded in Step 4 — if they differ, restore `originalPackageDescription`. The
 rewritten value belongs only in `app.commerce.config.ts` (App Management's 255-char
 limit); the full description stays in `package.json`. Record whether a restore
-happened — it is reported in Step 10's "Modified" section.
+happened — it is reported in Step 8's "Modified" section.
 
 **Do not modify any other content in `app.config.yaml`, the install file, or
 `package.json`.**
 
 ---
 
-## Step 9: Stage changes and ask to commit
+## Step 7: Stage changes and ask to commit
 
 Stage all migration-related files:
 
@@ -842,15 +842,15 @@ without prompting.
 
       git commit -m "feat: migrate to App Management"
 
-Then proceed to Step 10. Do not wait for the developer to commit before printing the summary.
+Then proceed to Step 8. Do not wait for the developer to commit before printing the summary.
 
 ---
 
-## Step 10: Print migration summary
+## Step 8: Print migration summary
 
 **Use the pre-computed results stored in Step 3a. The computation rules for
 Categories A–D are defined below — they run in Step 3a, not here.
-Step 10 only assembles and prints the report.**
+Step 8 only assembles and prints the report.**
 
 **Category A — Onboarding scripts not in `customInstallationSteps`:**
 
@@ -1077,7 +1077,7 @@ constraints, Next steps) when in doc-scan-only mode.
 
     TL;DR: staged <N> files · init <✓ ok / ✗ failed / ✗ blocked> · <K> manual follow-up(s)
 
-       ← N = number of files staged in Step 9; K = total count of items requiring
+       ← N = number of files staged in Step 7; K = total count of items requiring
           developer action across "Safe to delete", "Removable files",
           "Documentation recommendations" (Category C + D entries), and any failed
           command that must be re-run manually. Print "no manual follow-ups" if K is 0 →

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
@@ -475,7 +475,7 @@ Proceed to Step 4 (or Step 8 in doc-scan-only mode) after storing.
 ### Node version detection
 
 Before running init, detect the Node.js runtime version to use when scaffolding action
-handlers in Step 5a. Apply in order — first match wins:
+handlers in Step 5. Apply in order — first match wins:
 
 1. Scan all `ext.config.yaml` files in the project for a `runtime: nodejs:XX` declaration
    in any action definition. Use the value found (e.g. `nodejs:24`).
@@ -485,7 +485,7 @@ handlers in Step 5a. Apply in order — first match wins:
    Format as `nodejs:<major>`.
 4. Default: `nodejs:24`
 
-Store as `detectedNodeRuntime`. Used only in Step 5a.
+Store as `detectedNodeRuntime`. Used only in Step 5.
 
 ### Pre-flight: ensure `.env` exists
 
@@ -580,7 +580,7 @@ substituting the command matching the project's package manager from the table a
     Run this manually in your terminal before continuing:
         npx --yes @adobe/aio-commerce-lib-app@latest init
 
-Continue to Step 5a even if init failed.
+Continue to Step 5 even if init failed.
 
 **Diagnosing init failures:**
 
@@ -618,7 +618,7 @@ If the command exits with an error, inspect the output:
 3.  **Schema validation errors** — Record the error and report it in Step 8 so
     the developer can fix the config and re-run init manually.
 
-4.  **Any other error** — Record the failure message and skip Step 5a.
+4.  **Any other error** — Record the failure message and skip Step 5.
     Report the error in Step 8.
 
 After this command completes successfully, check which directories were created:
@@ -630,11 +630,11 @@ After this command completes successfully, check which directories were created:
   it also contains a generated `web-src/` frontend (mounted with `createExtensionApp`
   from `@adobe/aio-commerce-lib-admin-ui/web`), plus additional dependencies installed (if not already present and compatible) needed by the frontend (`react`, `react-dom`, `@react-spectrum/s2`, and some `devDependencies` needed for proper TypeScript support/config).
 
-Note which directories exist — you will need this in Steps 5a and 6.
+Note which directories exist — you will need this in Steps 5 and 6.
 
 ---
 
-## Step 5a: Scaffold Admin UI SDK handlers
+## Step 5: Scaffold Admin UI SDK handlers
 
 Runs immediately after Step 4 init succeeds and `src/commerce-backend-ui-2/` exists.
 Skip this step entirely if the assembled config has no `adminUi` section.

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/executor.md
@@ -500,16 +500,70 @@ Before running init, check whether `.env` exists at the project root:
 This is required because the init CLI unconditionally reads `.env` during
 the configuration-schema generation sub-step.
 
+### Pre-flight: record the original package.json description
+
+Read `package.json` and store its `description` value as `originalPackageDescription`
+(may be absent). `init` writes the config's `metadata.description` back into
+`package.json` — if that value was rewritten during config assembly to fit the
+255-char limit, the original description would be silently replaced. Step 6
+restores it.
+
+### Pre-flight (pnpm only): approve the esbuild build script
+
+pnpm 10 blocks dependency build scripts by default. `init` runs `pnpm add` inside
+the project to install its dependencies, and the `--allow-build` flag on the outer
+`dlx` command does **not** carry over to that inner install — without persistent
+approval it fails with `ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: esbuild@...`.
+
+Before running init on a pnpm project, approve esbuild persistently. Write the
+approval **where the project already keeps its pnpm configuration** — inspect
+both files and pick the first matching rule:
+
+1.  If either file already has an `onlyBuiltDependencies` list (`pnpm.onlyBuiltDependencies`
+    in `package.json`, or top-level `onlyBuiltDependencies` in `pnpm-workspace.yaml`):
+    merge `esbuild` into **that existing list**. Never create a second list in the
+    other file — pnpm reads only one of them, and a duplicate misleads.
+2.  Else, if `package.json` has a `pnpm` section: add the list there —
+
+        "pnpm": { "onlyBuiltDependencies": ["esbuild"] }
+
+    (This mirrors pnpm's own `approve-builds` behavior: when pnpm settings live in
+    `package.json`, it keeps writing them there.)
+
+3.  Else, if `pnpm-workspace.yaml` exists: add a top-level list there —
+
+    onlyBuiltDependencies: - esbuild
+
+4.  Else (neither location holds pnpm settings): add the `pnpm` section to
+    `package.json` as in rule 2. Do not create `pnpm-workspace.yaml` on a project
+    that does not already have one — its presence declares a pnpm workspace.
+
+If `esbuild` is already present in the list, make no change.
+
+Record which file was modified (or that no change was needed) — it is reported in
+Step 10's "Modified" section.
+
 ### Run init
 
 Run the appropriate command for the `packageManager` from `ProjectSnapshot`:
 
-| packageManager | command                               |
-| -------------- | ------------------------------------- |
-| `npm`          | `npx aio-commerce-lib-app init`       |
-| `pnpm`         | `pnpm exec aio-commerce-lib-app init` |
-| `yarn`         | `yarn exec aio-commerce-lib-app init` |
-| `bun`          | `bunx aio-commerce-lib-app init`      |
+| packageManager | command                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| `npm`          | `npx --yes @adobe/aio-commerce-lib-app@latest init`                      |
+| `pnpm`         | `pnpm --allow-build=esbuild dlx @adobe/aio-commerce-lib-app@latest init` |
+| `yarn`         | `yarn dlx @adobe/aio-commerce-lib-app@latest init`                       |
+| `bun`          | `bunx @adobe/aio-commerce-lib-app@latest init`                           |
+
+The scoped package name (`@adobe/aio-commerce-lib-app`) is required: on a project
+where the package is not yet a local dependency, the unscoped bin name
+(`npx aio-commerce-lib-app init`) fails with
+`npm error could not determine executable to run`.
+
+For pnpm, `--allow-build=esbuild` covers the temporary `dlx` install of the CLI
+itself. The flag must come **before** `dlx` — `pnpm dlx --allow-build=...` fails
+with `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` on several pnpm versions.
+The install init runs inside the project is covered by the pre-flight approval
+above, not by this flag.
 
 The `init` command installs required dependencies and generates the full `src/` extension
 structure from `app.commerce.config.ts` in one step.
@@ -522,7 +576,7 @@ Do NOT retry. Record the failure and emit the following manual instruction in St
     ✗ aio-commerce-lib-app init BLOCKED (Claude Code sandbox restriction)
 
     Run this manually in your terminal before continuing:
-        npx aio-commerce-lib-app init
+        npx --yes @adobe/aio-commerce-lib-app@latest init
 
     Then update app.config.yaml and install.yaml per the Next steps section.
 
@@ -543,12 +597,28 @@ If the command exits with an error, inspect the output:
                  npm view @adobe/aio-commerce-lib-app versions --json
           2. Install a newer version that includes dist/:
                  npm install @adobe/aio-commerce-lib-app@<latest>
-          3. Re-run: npx aio-commerce-lib-app init
+          3. Re-run: npx --yes @adobe/aio-commerce-lib-app@latest init
 
-2.  **Schema validation errors** — Record the error and report it in Step 10 so
+2.  **`ERR_PNPM_IGNORED_BUILDS` (pnpm only)** — pnpm 10 blocked a dependency's build
+    script (the output names the package, e.g. `Ignored build scripts: esbuild@...`).
+    This means the blocked package is not covered by the project's persistent
+    approval (the pre-flight above covers `esbuild`; a different package may be
+    named). Add the named package to the same `onlyBuiltDependencies` list the
+    pre-flight wrote, then re-run init **once**. If it still fails, record the
+    failure and emit in Step 10:
+
+        ✗ aio-commerce-lib-app init FAILED: ERR_PNPM_IGNORED_BUILDS (<package> build script blocked)
+
+        pnpm blocks dependency build scripts by default. Approve the build for
+        this project, then re-run init:
+          1. Add <package> to the onlyBuiltDependencies list in <file the
+             pre-flight chose>, or run: pnpm approve-builds
+          2. Re-run: pnpm --allow-build=esbuild dlx @adobe/aio-commerce-lib-app@latest init
+
+3.  **Schema validation errors** — Record the error and report it in Step 10 so
     the developer can fix the config and re-run init manually.
 
-3.  **Any other error** — Record the failure message and skip Step 5a.
+4.  **Any other error** — Record the failure message and skip Step 5a.
     Report the error in Step 10.
 
 After this command completes successfully, check which directories were created:
@@ -727,6 +797,15 @@ is no longer generated by `commerce/backend-ui/2` and the hook will fail the bui
 (`.yml` extension), `init` created a separate `install.yaml` — delete the stale
 `install.yml` (or merge its extra entries into `install.yaml` first) so only one
 install file remains.
+
+**4. Restore the original `package.json` description.**
+`init` writes the config's `metadata.description` back into `package.json`. If the
+config value was rewritten during assembly, this silently replaces the original.
+Compare `package.json`'s current `description` with the `originalPackageDescription`
+recorded in Step 4 — if they differ, restore `originalPackageDescription`. The
+rewritten value belongs only in `app.commerce.config.ts` (App Management's 255-char
+limit); the full description stays in `package.json`. Record whether a restore
+happened — it is reported in Step 10's "Modified" section.
 
 **Do not modify any other content in `app.config.yaml`, the install file, or
 `package.json`.**
@@ -996,6 +1075,13 @@ constraints, Next steps) when in doc-scan-only mode.
     ║             App Management Migration — Complete                  ║
     ╚══════════════════════════════════════════════════════════════════╝
 
+    TL;DR: staged <N> files · init <✓ ok / ✗ failed / ✗ blocked> · <K> manual follow-up(s)
+
+       ← N = number of files staged in Step 9; K = total count of items requiring
+          developer action across "Safe to delete", "Removable files",
+          "Documentation recommendations" (Category C + D entries), and any failed
+          command that must be re-run manually. Print "no manual follow-ups" if K is 0 →
+
     ── Files written ──────────────────────────────────────────────────
       ✓  app.commerce.config.ts                          new
       ✓  install.yaml                                    new / updated
@@ -1065,6 +1151,12 @@ constraints, Next steps) when in doc-scan-only mode.
          ← omit app.config.yaml line if init failed →
       app.config.yaml    added extensions block
       package.json       added postinstall hook
+      [package.json      description restored — init wrote the shortened config value back;
+                         the original full description was kept (see Step 6)]
+         ← include only if Step 6 restored the description →
+      [pnpm-workspace.yaml   approved esbuild build script (onlyBuiltDependencies)]
+      [package.json          approved esbuild build script (pnpm.onlyBuiltDependencies)]
+         ← include only the line matching the file the Step 4 pnpm pre-flight modified →
 
     ── Installation steps ─────────────────────────────────────────────
          ← omit this entire section if no customInstallationSteps →
@@ -1219,7 +1311,7 @@ constraints, Next steps) when in doc-scan-only mode.
     ← end conditional block →
 
     ── Next steps ─────────────────────────────────────────────────────
-      [1. npx aio-commerce-lib-app init]   ← include ONLY if Step 4 failed
+      [1. npx --yes @adobe/aio-commerce-lib-app@latest init]   ← include ONLY if Step 4 failed
        2. Review src/commerce-extensibility-1/.generated/ before deploying
        3. aio app deploy
 

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/evals/evals.json
@@ -265,6 +265,58 @@
         "Does not include runtimeAction on the view entry",
         "Does not emit an unresolved question for runtimeAction"
       ]
+    },
+    {
+      "id": 9,
+      "name": "description-rewrite-preserves-package-json",
+      "prompt": "I have a Commerce App Builder project with a package.json description longer than 255 characters. Migrate it to App Management.",
+      "expected_output": "metadata.description in app.commerce.config.ts is a rewritten summary of the original that fits in 255 characters, reads as complete sentences preserving the app's core purpose (Commerce-to-ERP sync of orders, customers, inventory), and does not end with \"...\" or cut off mid-sentence. The original full description in package.json is preserved: the executor records it before init and restores it if init writes the shortened config value back, reporting the restore in the migration summary.",
+      "files": [
+        {
+          "path": "app.config.yaml",
+          "content": "application:\n  runtimeManifest:\n    packages:\n      acme-app:\n        license: Apache-2.0\n        actions:\n          sync-orders:\n            function: actions/sync-orders/index.js\n            web: \"yes\"\n            runtime: nodejs:22\n"
+        },
+        {
+          "path": "package.json",
+          "content": "{\"name\": \"acme-app\", \"version\": \"1.0.0\", \"description\": \"Acme Commerce integration for Adobe App Builder that synchronizes orders, customers, and product inventory between Adobe Commerce and the Acme ERP platform, including bidirectional event-driven updates, scheduled reconciliation jobs, configurable field mappings, and audit logging for enterprise deployments.\"}\n"
+        },
+        {
+          "path": "actions/sync-orders/index.js",
+          "content": "async function main (params) {\n  return { statusCode: 200, body: { success: true } }\n}\n\nmodule.exports = { main }\n"
+        }
+      ],
+      "assertions": [
+        "metadata.description in app.commerce.config.ts is at most 255 characters",
+        "The description is a coherent rewrite, not a mechanical cut: it does not end with \"...\", does not stop mid-word or mid-sentence, and preserves the core purpose (synchronizing orders, customers, and inventory between Adobe Commerce and the Acme ERP)",
+        "The original full description remains in package.json after migration (restored if init wrote the shortened config value back)",
+        "If the description was restored after init, the migration summary's Modified section mentions the restore"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "init-scoped-package-and-tldr-summary",
+      "prompt": "I have a Commerce App Builder project (npm) that has never used @adobe/aio-commerce-lib-app — it is not a dependency in package.json. Migrate it to App Management with --auto.",
+      "expected_output": "The executor runs init with the scoped package name (npx --yes @adobe/aio-commerce-lib-app@latest init), not the unscoped bin name (npx aio-commerce-lib-app init), which fails with \"could not determine executable to run\" when the package is not installed. The migration summary starts with a one-line TL;DR stating the number of staged files, the init outcome, and the number of manual follow-ups.",
+      "files": [
+        {
+          "path": "app.config.yaml",
+          "content": "application:\n  runtimeManifest:\n    packages:\n      acme-app:\n        license: Apache-2.0\n        actions:\n          sync-orders:\n            function: actions/sync-orders/index.js\n            web: \"yes\"\n            runtime: nodejs:22\n"
+        },
+        {
+          "path": "package.json",
+          "content": "{\"name\": \"acme-app\", \"version\": \"1.0.0\", \"description\": \"Acme order sync app.\", \"dependencies\": {\"@adobe/aio-sdk\": \"^6.0.0\"}}\n"
+        },
+        {
+          "path": "actions/sync-orders/index.js",
+          "content": "async function main (params) {\n  return { statusCode: 200, body: { success: true } }\n}\n\nmodule.exports = { main }\n"
+        }
+      ],
+      "assertions": [
+        "Runs init using the scoped package name: npx --yes @adobe/aio-commerce-lib-app@latest init",
+        "Does not run init with the unscoped bin name (npx aio-commerce-lib-app init)",
+        "The migration summary begins with a one-line TL;DR containing the staged file count, the init outcome, and the manual follow-up count",
+        "The TL;DR appears before the Files written section"
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Applies feedback from a real migration run to the `commerce-app-migrate` skill:

- **Scoped init command** — the executor now runs `npx --yes @adobe/aio-commerce-lib-app@latest init` (and the `dlx`/`bunx` equivalents) instead of the unscoped bin name, which fails with `could not determine executable to run` on projects where the library is not yet a dependency. All manual-instruction blocks that echoed the old command were updated too.
- **pnpm blocked builds** — pnpm 10 blocks dependency build scripts by default, so the inner `pnpm add` that `init` runs fails with `ERR_PNPM_IGNORED_BUILDS` (esbuild). The executor now approves esbuild persistently before init, writing `onlyBuiltDependencies` to wherever the project already keeps its pnpm config (existing list > `pnpm` section in `package.json` > `pnpm-workspace.yaml` > `package.json` fallback), and the dlx install itself uses `pnpm --allow-build=esbuild dlx ...` (flag before `dlx`, per pnpm/pnpm#9719). A new failure-diagnosis entry covers the recovery path.
- **Description rewrite instead of truncation** — descriptions over App Management's 255-char limit are now rewritten into a coherent shorter summary that preserves the app's core purpose, rather than mechanically cut at 252 chars with `...`.
- **`package.json` description preservation** — `init` writes the config description back into `package.json`; the executor records the original before init and restores it afterwards if it was shortened, reporting the restore in the summary.
- **TL;DR summary line** — the migration report now opens with a one-line TL;DR (staged files · init outcome · manual follow-up count).

Includes two new evals (`description-rewrite-preserves-package-json`, `init-scoped-package-and-tldr-summary`) and a `minor` changeset for `@adobe/aio-commerce-plugin-app-migration`.

## Related Issue

CEXT-6420

## Motivation and Context

A migration run on a real pnpm project surfaced these failures: the unscoped init command could not resolve, the init-managed install was blocked by pnpm 10's build-script policy, and a long `package.json` description was silently truncated and written back. This PR makes the skill handle all of these without manual intervention.

## How Has This Been Tested?

- Reproduced the pnpm `ERR_PNPM_IGNORED_BUILDS` failure on a real project and verified the persistent `onlyBuiltDependencies` approval unblocks init.
- `evals.json` validated as parseable JSON; two new eval cases assert the new behaviors.
- Prettier passes on all edited Markdown files.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author