### PR TITLE
CEXT-6467: Publish plugin changelogs to adobe/skills

### DIFF
--- a/.changeset/clear-lions-strive.md
+++ b/.changeset/clear-lions-strive.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-management": patch
+---
+
+Publish this plugin's changelog history alongside its skills.

--- a/.changeset/real-pans-scream.md
+++ b/.changeset/real-pans-scream.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-migration": patch
+---
+
+Publish this plugin's changelog history alongside its skills.

--- a/.changeset/tangy-flowers-matter.md
+++ b/.changeset/tangy-flowers-matter.md
@@ -1,0 +1,5 @@
+---
+"@aio-commerce-sdk/scripts": patch
+---
+
+Plugin promotion now publishes each plugin's `CHANGELOG.md` to `adobe/skills` alongside its skills.

--- a/plugins/commerce/AGENTS.md
+++ b/plugins/commerce/AGENTS.md
@@ -11,6 +11,10 @@ Each plugin is a private pnpm workspace package. Use changesets to express relea
 3. Choose the semver bump for the plugin change.
 4. Write a concise, user-facing changeset message.
 
+The changeset message is published verbatim as a `CHANGELOG.md` entry in `adobe/skills`, not just
+used internally for the promotion PR body — write it as permanent, end-user-facing release
+history from the first patch changeset onward.
+
 Do not manually bump versions in `.tessl-plugin/plugin.json` or `.claude-plugin/plugin.json`. The
 plugin `package.json` is the authoritative version source; release automation syncs that version
 into the plugin manifests.

--- a/plugins/commerce/app-management/README.md
+++ b/plugins/commerce/app-management/README.md
@@ -45,13 +45,13 @@ A developer creating an app that needs events and webhooks would run `commerce-a
 tessl install github:adobe/skills --skills commerce-app-management
 ```
 
-**pnpx skills:**
+**npx skills:**
 
 ```sh
-pnpx skills add adobe/skills --skill commerce-app-init
-pnpx skills add adobe/skills --skill commerce-app-eventing
-pnpx skills add adobe/skills --skill commerce-app-webhooks
-pnpx skills add adobe/skills --skill commerce-app-business-config
-pnpx skills add adobe/skills --skill commerce-app-storage
-pnpx skills add adobe/skills --skill commerce-app-admin-ui
+npx skills add adobe/skills --skill commerce-app-init
+npx skills add adobe/skills --skill commerce-app-eventing
+npx skills add adobe/skills --skill commerce-app-webhooks
+npx skills add adobe/skills --skill commerce-app-business-config
+npx skills add adobe/skills --skill commerce-app-storage
+npx skills add adobe/skills --skill commerce-app-admin-ui
 ```

--- a/scripts/source/ci/release/promote-skills.ts
+++ b/scripts/source/ci/release/promote-skills.ts
@@ -28,6 +28,7 @@ const PROMOTED_ENTRIES = [
   "README.md",
   "skills",
   ".claude-plugin",
+  "CHANGELOG.md",
 ];
 
 type PluginPackageJson = {

--- a/scripts/test/unit/ci/release/promote-skills.test.ts
+++ b/scripts/test/unit/ci/release/promote-skills.test.ts
@@ -215,7 +215,7 @@ describe("release/promote-skills.ts", () => {
     );
   });
 
-  test("copies promotion artifacts and excludes SDK-only files", async () => {
+  test("copies promotion artifacts and excludes package.json", async () => {
     await withTempFiles(
       {
         "skills/plugins/commerce/app-management/package.json": "{}",
@@ -292,8 +292,13 @@ describe("release/promote-skills.ts", () => {
           fileExists(join(targetRoot, "package.json")),
         ).resolves.toBe(false);
         await expect(
-          fileExists(join(targetRoot, "CHANGELOG.md")),
-        ).resolves.toBe(false);
+          readFile(join(targetRoot, "CHANGELOG.md"), "utf-8"),
+        ).resolves.toBe(
+          await readFile(
+            join(sourceRoot, "plugins/commerce/app-management/CHANGELOG.md"),
+            "utf-8",
+          ),
+        );
       },
     );
   });
@@ -312,6 +317,14 @@ describe("release/promote-skills.ts", () => {
             name: "adobe/commerce-app-management",
             version: "1.0.0",
           }),
+        "source/plugins/commerce/app-management/CHANGELOG.md": [
+          "# @adobe/aio-commerce-plugin-app-management",
+          "",
+          "## 1.0.0",
+          "",
+          "- Promote App Management skills.",
+          "",
+        ].join("\n"),
         "source/plugins/commerce/app-management/package.json": JSON.stringify({
           name: "@adobe/aio-commerce-plugin-app-management",
           version: "1.0.0",


### PR DESCRIPTION
## Description

Adds each Commerce plugin's `CHANGELOG.md` to the set of files copied from `adobe/aio-commerce-sdk` into `adobe/skills` during promotion, and retrofits changelog history for the two already-promoted plugins.

## Related Issue

CEXT-6467

## Motivation and Context

`adobe/skills` had no changelog for any Commerce plugin — consumers installing from the stable channel had no way to see what changed between versions. The promotion pipeline previously excluded `CHANGELOG.md` on purpose, treating it as internal to the SDK repo.

## How Has This Been Tested?

- `pnpm --filter @aio-commerce-sdk/scripts test` — updated unit tests cover that `CHANGELOG.md` is now copied to the target path with matching content.
- `pnpm --filter @aio-commerce-sdk/scripts typecheck`
- `pnpm changeset status` — confirms the three patch changesets are picked up correctly.
- The cross-repo promotion behavior itself only runs in CI on merge to `release` (requires `ADOBE_SKILLS_TOKEN`) and can't be exercised locally.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.