### PR TITLE
CEXT-6081: add package manager command helpers

### DIFF
--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -295,6 +295,25 @@ const DEV_DEPENDENCY_INSTALL_FLAGS = {
 export type PackageManager = (typeof VALID_PACKAGE_MANAGERS)[number];
 
 /**
+ * Append a command to an existing `&&` command chain without duplicating it.
+ * @param existingCommand Existing command chain.
+ * @param command Command to append.
+ */
+export function appendCommand(
+  existingCommand: string | undefined,
+  command: string,
+) {
+  const existing = existingCommand?.trim();
+  if (!existing) {
+    return command;
+  }
+
+  return existing.split(" && ").includes(command)
+    ? existing
+    : `${existing} && ${command}`;
+}
+
+/**
  * Type guard asserting that a value is a supported `PackageManager`.
  * @param value - The value to check
  */
@@ -342,6 +361,44 @@ export function getExecCommand(packageManager: PackageManager): string {
   }
 
   return [resolved.command, ...resolved.args].filter(Boolean).join(" ");
+}
+
+/**
+ * Get the command that runs a package script.
+ * @param packageManager The detected package manager.
+ * @param scriptName Package script name.
+ */
+export function getRunScriptCommand(
+  packageManager: PackageManager,
+  scriptName: string,
+) {
+  return `${packageManager} run ${scriptName}`;
+}
+
+/**
+ * Get the command that executes a package without adding it to the project.
+ * @param packageManager - The detected package manager.
+ * @param args - Package specifier followed by arguments for its binary.
+ * @param options - Package execution options.
+ * @param options.allowBuild - Package whose build script pnpm may execute.
+ */
+export function getPackageExecutionCommand(
+  packageManager: PackageManager,
+  args: string[],
+  options: { allowBuild?: string } = {},
+): { command: string; args: string[] } {
+  const resolved = resolveCommand(packageManager, "execute", args);
+  const command = resolved?.command ?? "npx";
+  let resolvedArgs = resolved?.args.filter(Boolean) ?? args;
+
+  if (packageManager === "pnpm" && options.allowBuild !== undefined) {
+    resolvedArgs = [`--allow-build=${options.allowBuild}`, ...resolvedArgs];
+  }
+
+  return {
+    args: command === "npx" ? ["--yes", ...resolvedArgs] : resolvedArgs,
+    command,
+  };
 }
 
 /**

--- a/packages-private/scripting-utils/source/yaml/codegen.ts
+++ b/packages-private/scripting-utils/source/yaml/codegen.ts
@@ -14,7 +14,7 @@ import { writeFile } from "node:fs/promises";
 
 import { Document, isMap, YAMLMap, YAMLSeq } from "yaml";
 
-import { detectPackageManager, getExecCommand } from "#project";
+import { appendCommand, detectPackageManager, getExecCommand } from "#project";
 import {
   getExistingInputs,
   getExistingString,
@@ -279,11 +279,7 @@ async function buildHooks(extConfig: Document, hooks: Record<string, string>) {
       );
     }
 
-    if (prevValue !== "" && !prevValue.includes(fullCommand)) {
-      hooksMap.set(name, `${prevValue} && ${fullCommand}`);
-    } else if (prevValue === "") {
-      hooksMap.set(name, fullCommand);
-    }
+    hooksMap.set(name, appendCommand(prevValue || undefined, fullCommand));
   }
 }
 

--- a/packages-private/scripting-utils/test/project.test.ts
+++ b/packages-private/scripting-utils/test/project.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { withTempFiles } from "#filesystem/temp";
 import {
+  appendCommand,
   detectPackageManager,
   findNearestPackageJson,
   findUp,
@@ -25,14 +26,34 @@ import {
   getInstallCommand,
   getInstalledPackageVersion,
   getPackageDependencyInstallPlan,
+  getPackageExecutionCommand,
   getProjectInstallCommand,
   getProjectRootDirectory,
+  getRunScriptCommand,
   isESM,
   loadPackageJson,
   makeOutputDirFor,
   mergePackageJsonDependencies,
   readPackageJson,
 } from "#project";
+
+describe("appendCommand", () => {
+  test("returns the command when no existing command is present", () => {
+    expect(appendCommand(undefined, "npm run build")).toBe("npm run build");
+  });
+
+  test("appends a command to an existing command chain", () => {
+    expect(appendCommand("eslint .", "npm run build")).toBe(
+      "eslint . && npm run build",
+    );
+  });
+
+  test("does not append a duplicate command", () => {
+    expect(appendCommand("eslint . && npm run build", "npm run build")).toBe(
+      "eslint . && npm run build",
+    );
+  });
+});
 
 describe("findUp", () => {
   test("should find a file in the current directory", async () => {
@@ -617,6 +638,17 @@ describe("getExecCommand", () => {
     expect(getExecCommand("npm")).toBe("npx");
   });
 
+  describe("getRunScriptCommand", () => {
+    test.each(["npm", "pnpm", "yarn", "bun"] as const)(
+      "returns the package script command for %s",
+      (packageManager) => {
+        expect(getRunScriptCommand(packageManager, "typecheck")).toBe(
+          `${packageManager} run typecheck`,
+        );
+      },
+    );
+  });
+
   test("should return pnpm exec for pnpm", () => {
     expect(getExecCommand("pnpm")).toBe("pnpm exec");
   });
@@ -627,6 +659,60 @@ describe("getExecCommand", () => {
 
   test("should return bun x for bun", () => {
     expect(getExecCommand("bun")).toBe("bun x");
+  });
+});
+
+describe("getPackageExecutionCommand", () => {
+  test.each([
+    {
+      expected: {
+        args: ["--yes", "esbuild@0.28.0", "--version"],
+        command: "npx",
+      },
+      packageManager: "npm" as const,
+    },
+    {
+      expected: {
+        args: ["dlx", "esbuild@0.28.0", "--version"],
+        command: "pnpm",
+      },
+      packageManager: "pnpm" as const,
+    },
+    {
+      expected: {
+        args: ["--yes", "esbuild@0.28.0", "--version"],
+        command: "npx",
+      },
+      packageManager: "yarn" as const,
+    },
+    {
+      expected: {
+        args: ["x", "esbuild@0.28.0", "--version"],
+        command: "bun",
+      },
+      packageManager: "bun" as const,
+    },
+  ])(
+    "returns the one-shot package command for $packageManager",
+    ({ expected, packageManager }) => {
+      expect(
+        getPackageExecutionCommand(packageManager, [
+          "esbuild@0.28.0",
+          "--version",
+        ]),
+      ).toEqual(expected);
+    },
+  );
+
+  test("allows a pnpm package build during one-shot execution", () => {
+    expect(
+      getPackageExecutionCommand("pnpm", ["esbuild@0.28.0", "--version"], {
+        allowBuild: "esbuild",
+      }),
+    ).toEqual({
+      args: ["--allow-build=esbuild", "dlx", "esbuild@0.28.0", "--version"],
+      command: "pnpm",
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Add package-manager-aware helpers for composing scripts and running one-shot packages with npm, pnpm, Yarn, or Bun.

## Related Issue

CEXT-6081

## Motivation and Context

The TypeScript generation layers need a shared way to preserve existing scripts and invoke temporary tooling consistently across supported package managers.

## How Has This Been Tested?

- Scripting utilities test suite
- Repository typecheck

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
