### PR TITLE
CEXT-6508: implement webhook configuration updates

### DIFF
--- a/.changeset/all-canyons-drum.md
+++ b/.changeset/all-canyons-drum.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Add upgrade planning support for webhook configuration updates: the webhooks step now detects field-level configuration changes (fields, conditions, headers, and other settings) between the installed and target versions for webhooks whose identity is unchanged, and updates only the affected properties without recreating or removing the webhook.

--- a/.changeset/all-canyons-drum.md
+++ b/.changeset/all-canyons-drum.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-lib-app": minor
 ---
 
-Add upgrade planning support for webhook configuration updates: the webhooks step now detects field-level configuration changes (fields, conditions, headers, and other settings) between the installed and target versions for webhooks whose identity is unchanged, and updates only the affected properties without recreating or removing the webhook.
+Apply webhook configuration changes during upgrades when fields, conditions, headers, or other mutable settings change without changing webhook identity.

--- a/.changeset/dry-buses-marry.md
+++ b/.changeset/dry-buses-marry.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-migration": patch
+---
+
+Document the allowed values for Commerce webhook types and HTTP methods.

--- a/.changeset/shaky-dodos-bet.md
+++ b/.changeset/shaky-dodos-bet.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Reject webhook configurations with unsupported webhook types or HTTP methods.

--- a/.changeset/shiny-moles-nail.md
+++ b/.changeset/shiny-moles-nail.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-management": patch
+---
+
+Document the allowed values for Commerce webhook types and HTTP methods.

--- a/packages/aio-commerce-lib-app/docs/openapi.json
+++ b/packages/aio-commerce-lib-app/docs/openapi.json
@@ -3008,7 +3008,7 @@
           },
           "webhook_type": {
             "type": "string",
-            "minLength": 1
+            "enum": ["before", "after"]
           },
           "batch_name": {
             "type": "string",
@@ -3041,7 +3041,7 @@
           },
           "method": {
             "type": "string",
-            "minLength": 1
+            "enum": ["POST", "PUT", "DELETE", "GET"]
           },
           "fallback_error_message": {
             "type": "string"

--- a/packages/aio-commerce-lib-app/docs/usage.md
+++ b/packages/aio-commerce-lib-app/docs/usage.md
@@ -396,6 +396,8 @@ webhooks: [
 ];
 ```
 
+`webhook_type` must be either `"before"` or `"after"`, and `method` must be `"POST"`, `"PUT"`, `"DELETE"`, or `"GET"`. Other values are rejected before any Commerce changes are applied.
+
 Each webhook entry supports:
 
 - **label**: Display name for the webhook.

--- a/packages/aio-commerce-lib-app/source/config/schema/webhooks.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/webhooks.ts
@@ -50,6 +50,20 @@ const CategorySchema = v.picklist(
   `Webhook category must be one of: ${CATEGORIES.join(", ")}`,
 );
 
+/** Valid Commerce webhook execution phases. */
+const WEBHOOK_TYPES = ["before", "after"] as const;
+const WebhookTypeSchema = v.picklist(
+  WEBHOOK_TYPES,
+  `Webhook type must be one of: ${WEBHOOK_TYPES.join(", ")}`,
+);
+
+/** Supported HTTP methods for Commerce webhook requests. */
+const WEBHOOK_HTTP_METHODS = ["POST", "PUT", "DELETE", "GET"] as const;
+const WebhookHttpMethodSchema = v.picklist(
+  WEBHOOK_HTTP_METHODS,
+  `Webhook HTTP method must be one of: ${WEBHOOK_HTTP_METHODS.join(", ")}`,
+);
+
 /** Schema for the nested webhook payload without url — used when runtimeAction resolves the URL at runtime. */
 const WebhookDefinitionBaseSchema = v.object({
   batch_name: v.pipe(
@@ -76,7 +90,7 @@ const WebhookDefinitionBaseSchema = v.object({
       "hook_name must contain only letters, numbers, and underscores",
     ),
   ),
-  method: nonEmptyStringValueSchema("HTTP method"),
+  method: WebhookHttpMethodSchema,
   priority: v.optional(positiveNumberValueSchema("priority")),
   required: v.optional(booleanValueSchema("required")),
   rules: v.optional(
@@ -86,7 +100,7 @@ const WebhookDefinitionBaseSchema = v.object({
   timeout: v.optional(positiveNumberValueSchema("timeout")),
   ttl: v.optional(positiveNumberValueSchema("ttl")),
   webhook_method: nonEmptyStringValueSchema("webhook_method"),
-  webhook_type: nonEmptyStringValueSchema("webhook_type"),
+  webhook_type: WebhookTypeSchema,
 });
 
 /** Schema for the nested webhook payload with a required url. */

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/apply.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/apply.ts
@@ -25,22 +25,26 @@ import {
   webhookIdentitiesMatch,
 } from "./utils";
 
-import type { WebhookSubscribeParams } from "@adobe/aio-commerce-lib-webhooks/api";
+import type {
+  CommerceWebhook,
+  WebhookSubscribeParams,
+} from "@adobe/aio-commerce-lib-webhooks/api";
 import type { WebhooksConfig } from "#config/schema/webhooks";
 import type {
   ApplyContext,
   ApplyResult,
 } from "#management/common/workflow/resource";
-import type { WebhooksStepContext } from "./context";
+import type { WebhooksExecutionContext, WebhooksStepContext } from "./context";
 import type {
   ResolvedWebhookPayload,
   WebhookDomainPlan,
+  WebhookIdentity,
   WebhookSnapshotData,
 } from "./types";
 
 /**
- * Applies a webhooks domain plan and prunes live app-owned webhooks absent from
- * the target. Aborts on the first failure rather than report partial success.
+ * Applies add, update, and remove operations while pruning live app-owned
+ * webhooks absent from the target. Aborts on the first failure.
  */
 export async function applyWebhookSubscriptions(
   plan: WebhookDomainPlan,
@@ -53,7 +57,6 @@ export async function applyWebhookSubscriptions(
   const { logger, commerceWebhooksClient, params } = context;
 
   const liveWebhooks = await commerceWebhooksClient.getWebhookList();
-  let liveIdentities = liveWebhooks.map(toIdentity);
 
   let subscribedWebhooks: WebhookSubscribeParams[] = [
     ...(context.baseline?.data.subscribedWebhooks ?? []),
@@ -71,23 +74,12 @@ export async function applyWebhookSubscriptions(
     ? resolveDesiredWebhooks(context.targetConfig, env)
     : [];
 
-  const staleWebhooks = liveWebhooks.filter(
-    (webhook) =>
-      isWebhookOwnedByApp(webhook, appConfig.metadata.id) &&
-      !isDesiredWebhook(webhook, desired),
+  let liveIdentities = await pruneStaleWebhooks(
+    liveWebhooks,
+    desired,
+    appConfig.metadata.id,
+    context,
   );
-
-  for (const stale of staleWebhooks) {
-    const identity = toIdentity(stale);
-
-    // biome-ignore lint/performance/noAwaitInLoops: removals must run sequentially so a failure aborts the remaining work
-    await deleteWebhookSubscription(commerceWebhooksClient, identity, identity);
-
-    logger.info(`Unsubscribed webhook: ${getWebhookName(identity)}`);
-    liveIdentities = liveIdentities.filter(
-      (live) => !webhookIdentitiesMatch(live, identity),
-    );
-  }
 
   for (const operation of plan.operations) {
     if (operation.kind === "add") {
@@ -101,13 +93,11 @@ export async function applyWebhookSubscriptions(
           `Webhook already subscribed, skipping: ${getWebhookName(identity)}`,
         );
       } else {
-        const toSubscribe: WebhookSubscribeParams = {
-          ...resolvedWebhook,
-          ...(requiresAdobeAuth && {
-            developer_console_oauth:
-              resolveDeveloperConsoleOAuthCredentials(params),
-          }),
-        };
+        const toSubscribe = createSubscribeParams(
+          resolvedWebhook,
+          requiresAdobeAuth,
+          params,
+        );
 
         // biome-ignore lint/performance/noAwaitInLoops: operations must run sequentially so a failure aborts the remaining ones
         await createWebhookSubscription(commerceWebhooksClient, toSubscribe);
@@ -118,6 +108,42 @@ export async function applyWebhookSubscriptions(
       if (!isWebhookInList(subscribedWebhooks, identity)) {
         subscribedWebhooks.push(resolvedWebhook);
       }
+    } else if (operation.kind === "update") {
+      const identity = toIdentity(operation.before);
+
+      // `after` is always fully resolved for `update` (see planWebhookSubscriptions).
+      const { requiresAdobeAuth, ...resolvedWebhook } =
+        operation.after as ResolvedWebhookPayload;
+
+      // Commerce's subscribe endpoint is a guarded insert, not an upsert — it rejects a
+      // still-live identity, so an update must unsubscribe before it can resubscribe.
+      if (isWebhookInList(liveIdentities, identity)) {
+        await deleteWebhookSubscription(
+          commerceWebhooksClient,
+          identity,
+          identity,
+        );
+        liveIdentities = liveIdentities.filter(
+          (live) => !webhookIdentitiesMatch(live, identity),
+        );
+      }
+
+      const toSubscribe = createSubscribeParams(
+        resolvedWebhook,
+        requiresAdobeAuth,
+        params,
+      );
+
+      await createWebhookSubscription(commerceWebhooksClient, toSubscribe);
+      logger.info(`Updated webhook: ${getWebhookName(identity)}`);
+      liveIdentities = [...liveIdentities, identity];
+
+      subscribedWebhooks = [
+        ...subscribedWebhooks.filter(
+          (subscribed) => !webhookIdentitiesMatch(subscribed, identity),
+        ),
+        resolvedWebhook,
+      ];
     } else if (operation.kind === "remove") {
       const identity = toIdentity(operation.before);
 
@@ -145,5 +171,50 @@ export async function applyWebhookSubscriptions(
 
   return {
     snapshotData: { subscribedWebhooks },
+  };
+}
+
+/** Removes live webhooks owned by this app that are absent from the target. */
+async function pruneStaleWebhooks(
+  liveWebhooks: CommerceWebhook[],
+  desiredWebhooks: readonly WebhookIdentity[],
+  appId: string,
+  context: WebhooksExecutionContext,
+): Promise<WebhookIdentity[]> {
+  const { commerceWebhooksClient, logger } = context;
+  let liveIdentities = liveWebhooks.map(toIdentity);
+  const staleWebhooks = liveWebhooks.filter(
+    (webhook) =>
+      isWebhookOwnedByApp(webhook, appId) &&
+      !isDesiredWebhook(webhook, desiredWebhooks),
+  );
+
+  for (const stale of staleWebhooks) {
+    const identity = toIdentity(stale);
+
+    // biome-ignore lint/performance/noAwaitInLoops: removals must run sequentially so a failure aborts the remaining work
+    await deleteWebhookSubscription(commerceWebhooksClient, identity, identity);
+
+    logger.info(`Unsubscribed webhook: ${getWebhookName(identity)}`);
+    liveIdentities = liveIdentities.filter(
+      (live) => !webhookIdentitiesMatch(live, identity),
+    );
+  }
+  return liveIdentities;
+}
+
+/** Attaches Developer Console credentials when the webhook requires Adobe authentication. */
+function createSubscribeParams(
+  webhook: WebhookSubscribeParams,
+  requiresAdobeAuth: boolean,
+  params: Record<string, unknown>,
+): WebhookSubscribeParams {
+  if (!requiresAdobeAuth) {
+    return webhook;
+  }
+
+  return {
+    ...webhook,
+    developer_console_oauth: resolveDeveloperConsoleOAuthCredentials(params),
   };
 }

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/plan.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/plan.ts
@@ -14,6 +14,7 @@ import { getInstallCommerceEnv } from "#config/lib/environment";
 
 import {
   getWebhookName,
+  hasWebhookConfigChanged,
   isDesiredWebhook,
   resolveDesiredWebhooks,
   toIdentity,
@@ -36,10 +37,10 @@ import type {
 } from "./types";
 
 /**
- * Diffs the target config against the baseline into add/remove operations. Pure —
- * no external reads or writes, since an observation made here could be stale by
- * execution time. Blocks with `WEBHOOK_BASELINE_UNRESOLVED` if a baseline exists
- * but its data couldn't be resolved, rather than guessing.
+ * Diffs the target config against the baseline into add, update, and remove
+ * operations. Pure — no external reads or writes, since an observation made
+ * here could be stale by execution time. Blocks with
+ * `WEBHOOK_BASELINE_UNRESOLVED` if the baseline data cannot be resolved.
  */
 export function planWebhookSubscriptions(
   input: PlanningInput<WebhooksConfig, WebhookSnapshotData>,
@@ -72,6 +73,7 @@ export function planWebhookSubscriptions(
 
   // Removes precede adds (see the concat below) so a rename never briefly double-registers a hook point.
   const addOperations: ResourceOperation<WebhookOperationValue>[] = [];
+  const updateOperations: ResourceOperation<WebhookOperationValue>[] = [];
   const removeOperations: ResourceOperation<WebhookOperationValue>[] = [];
 
   for (const webhook of desired) {
@@ -80,6 +82,16 @@ export function planWebhookSubscriptions(
     );
 
     if (owned) {
+      if (hasWebhookConfigChanged(owned, webhook)) {
+        const identity = toIdentity(webhook);
+        updateOperations.push({
+          after: webhook,
+          before: identity,
+          id: webhookOperationId("update", identity),
+          kind: "update",
+          label: `Update webhook: ${getWebhookName(identity)}`,
+        });
+      }
       continue;
     }
 
@@ -109,7 +121,7 @@ export function planWebhookSubscriptions(
   return Promise.resolve({
     kind: "planned",
     plan: {
-      operations: [...removeOperations, ...addOperations],
+      operations: [...removeOperations, ...updateOperations, ...addOperations],
       path,
     },
   });

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/utils.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/utils.ts
@@ -12,6 +12,7 @@
 
 import { unwrapHttpError } from "@adobe/aio-commerce-lib-api/utils";
 import { resolveImsAuthParams } from "@adobe/aio-commerce-lib-auth";
+import { stringify } from "safe-stable-stringify";
 
 import { appliesToEnv } from "#config/lib/environment";
 
@@ -22,7 +23,31 @@ import type {
 import type { getInstallCommerceEnv } from "#config/lib/environment";
 import type { WebhookEntry } from "#config/schema/webhooks";
 import type { WebhooksExecutionContext } from "./context";
-import type { ResolvedWebhookPayload, WebhookIdentity } from "./types";
+import type {
+  ResolvedWebhookPayload,
+  WebhookIdentity,
+  WebhookOperationValue,
+} from "./types";
+
+/** Mutable (non-identity) scalar fields compared to detect a config change. */
+const MUTABLE_SCALAR_FIELDS = [
+  "url",
+  "priority",
+  "method",
+  "required",
+  "soft_timeout",
+  "timeout",
+  "fallback_error_message",
+  "ttl",
+  "batch_order",
+] as const satisfies (keyof WebhookSubscribeParams)[];
+
+/** Mutable (non-identity) array fields compared to detect a config change. */
+const MUTABLE_ARRAY_FIELDS = [
+  "fields",
+  "rules",
+  "headers",
+] as const satisfies (keyof WebhookSubscribeParams)[];
 
 /** Matches any character that is not a valid identifier character (letter, digit, or underscore). */
 const NON_IDENTIFIER_CHAR_REGEX = /[^a-zA-Z0-9_]/g;
@@ -48,9 +73,9 @@ export function toIdentity<T extends WebhookIdentity>(
   };
 }
 
-/** Builds a stable, human-traceable id for a planned add/remove operation. */
+/** Builds a stable, human-traceable id for a planned add/update/remove operation. */
 export function webhookOperationId(
-  kind: "add" | "remove",
+  kind: "add" | "update" | "remove",
   identity: WebhookIdentity,
 ): string {
   return `${kind}:${identity.webhook_method}:${identity.webhook_type}:${identity.batch_name}:${identity.hook_name}`;
@@ -94,6 +119,42 @@ export function isDesiredWebhook(
   desiredWebhooks: readonly WebhookIdentity[],
 ): boolean {
   return isWebhookInList(desiredWebhooks, webhook);
+}
+
+/** True when two optional arrays contain the same elements, regardless of order. Treats `undefined` and `[]` as equal. */
+function arraysEqualUnordered(
+  a: unknown[] | undefined,
+  b: unknown[] | undefined,
+): boolean {
+  // `stringify` sorts object keys, so equal elements serialize identically regardless of key order.
+  const normalizedA = (a ?? []).map((item) => stringify(item) ?? "").sort();
+  const normalizedB = (b ?? []).map((item) => stringify(item) ?? "").sort();
+  return (
+    normalizedA.length === normalizedB.length &&
+    normalizedA.every((value, index) => value === normalizedB[index])
+  );
+}
+
+/**
+ * True when any mutable (non-identity) field differs between a baseline webhook and
+ * its desired target payload. `batch_name`/`hook_name`/`webhook_method`/`webhook_type`
+ * are identity fields — a change there is a rename (remove+add), not a config update.
+ */
+export function hasWebhookConfigChanged(
+  before: WebhookSubscribeParams,
+  after: WebhookOperationValue,
+): boolean {
+  const scalarChanged = MUTABLE_SCALAR_FIELDS.some(
+    (field) => before[field] !== after[field],
+  );
+
+  if (scalarChanged) {
+    return true;
+  }
+
+  return MUTABLE_ARRAY_FIELDS.some(
+    (field) => !arraysEqualUnordered(before[field], after[field]),
+  );
 }
 
 /** Strips the `.magento` segment Commerce drops when persisting plugin webhook methods. */

--- a/packages/aio-commerce-lib-app/test/integration/management/webhooks.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/management/webhooks.test.ts
@@ -315,4 +315,112 @@ describe("webhooks upgrade planning integration", () => {
     });
     expect(applyResult.snapshotData?.subscribedWebhooks).toEqual([]);
   });
+
+  test("plans and applies an update for a webhook whose config changed", async () => {
+    vi.stubEnv("__OW_NAMESPACE", "test-namespace");
+
+    const [subscribedWebhook] = configWithWebhooks.webhooks;
+    const baselineWebhook = {
+      batch_name: "test_app_webhooks_default",
+      hook_name: "test_app_webhooks_order_created",
+      method: subscribedWebhook.webhook.method,
+      url: "https://test-namespace.adobeioruntime.net/api/v1/web/my-package/handle-webhook",
+      webhook_method: subscribedWebhook.webhook.webhook_method,
+      webhook_type: subscribedWebhook.webhook.webhook_type,
+    };
+
+    const targetConfig = {
+      ...configWithWebhooks,
+      webhooks: [
+        {
+          ...configWithWebhooks.webhooks[0],
+          webhook: {
+            ...configWithWebhooks.webhooks[0].webhook,
+            fields: [{ name: "sku" }],
+          },
+        },
+      ],
+    };
+
+    const capture = {
+      subscribeBody: null as Record<string, unknown> | null,
+      unsubscribeBody: null as Record<string, unknown> | null,
+    };
+
+    apiServer.use(
+      http.get(`${COMMERCE_BASE_URL}/webhooks/list`, () =>
+        HttpResponse.json([baselineWebhook]),
+      ),
+      http.post(
+        `${COMMERCE_BASE_URL}/webhooks/unsubscribe`,
+        async ({ request }) => {
+          capture.unsubscribeBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+
+          return HttpResponse.json({});
+        },
+      ),
+      http.post(
+        `${COMMERCE_BASE_URL}/webhooks/subscribe`,
+        async ({ request }) => {
+          capture.subscribeBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const lifecycleContext = createMockInstallationContext();
+    const context = {
+      ...lifecycleContext,
+      ...createWebhooksStepContext(lifecycleContext),
+    };
+    const baseline = {
+      config: configWithWebhooks,
+      data: { subscribedWebhooks: [baselineWebhook] },
+    };
+
+    const planResult = await planWebhookSubscriptions(
+      {
+        baseline,
+        path: UPGRADE_PATH,
+        targetConfig,
+      },
+      context,
+    );
+
+    expect.assert(planResult.kind === "planned");
+    expect(planResult.plan.operations).toEqual([
+      expect.objectContaining({ kind: "update" }),
+    ]);
+
+    const applyResult = await applyWebhookSubscriptions(planResult.plan, {
+      ...context,
+      attemptId: "attempt-1",
+      baseline,
+      targetConfig,
+    });
+
+    expect(capture.unsubscribeBody).toEqual({
+      webhook: expect.objectContaining({
+        batch_name: "test_app_webhooks_default",
+        hook_name: "test_app_webhooks_order_created",
+      }),
+    });
+    expect(capture.subscribeBody).toMatchObject({
+      webhook: expect.objectContaining({
+        batch_name: "test_app_webhooks_default",
+        fields: [{ name: "sku" }],
+        hook_name: "test_app_webhooks_order_created",
+      }),
+    });
+    expect(applyResult.snapshotData?.subscribedWebhooks).toEqual([
+      expect.objectContaining({ fields: [{ name: "sku" }] }),
+    ]);
+  });
 });

--- a/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
@@ -1321,6 +1321,27 @@ describe("validateConfigDomain", () => {
       label: "Test Webhook",
     };
 
+    const createRuntimeWebhookConfig = (
+      webhook: Partial<typeof baseWebhookDefinition> = {},
+    ) => ({
+      metadata: {
+        description: "Test",
+        displayName: "Test",
+        id: "test-app",
+        version: "1.0.0",
+      },
+      webhooks: [
+        {
+          ...baseWebhookEntry,
+          runtimeAction: "my-package/handle-webhook",
+          webhook: {
+            ...baseWebhookDefinition,
+            ...webhook,
+          },
+        },
+      ],
+    });
+
     test("should accept entry with runtimeAction and no url", () => {
       const config = {
         metadata: {
@@ -1361,6 +1382,33 @@ describe("validateConfigDomain", () => {
       };
 
       expect(() => validateCommerceAppConfig(config)).not.toThrow();
+    });
+
+    test("should accept a before webhook type", () => {
+      const config = createRuntimeWebhookConfig({ webhook_type: "before" });
+
+      expect(() => validateCommerceAppConfig(config)).not.toThrow();
+    });
+
+    test("should reject an unsupported webhook type", () => {
+      const config = createRuntimeWebhookConfig({ webhook_type: "blabla" });
+
+      expect(() => validateCommerceAppConfig(config)).toThrow();
+    });
+
+    test.each(["POST", "PUT", "DELETE", "GET"])(
+      "should accept the %s webhook HTTP method",
+      (method) => {
+        const config = createRuntimeWebhookConfig({ method });
+
+        expect(() => validateCommerceAppConfig(config)).not.toThrow();
+      },
+    );
+
+    test("should reject an unsupported webhook HTTP method", () => {
+      const config = createRuntimeWebhookConfig({ method: "PATCH" });
+
+      expect(() => validateCommerceAppConfig(config)).toThrow();
     });
 
     test("should reject entry with neither runtimeAction nor url", () => {

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
@@ -46,7 +46,7 @@ const DEFAULT_RESOLVED_IDENTITY = {
   batch_name: "test_app_webhooks_default",
   hook_name: "test_app_webhooks_order_created",
   webhook_method: "plugin.order.api.order_created",
-  webhook_type: "after",
+  webhook_type: "after" as const,
 };
 describe("applyWebhookSubscriptions", () => {
   beforeEach(() => {
@@ -218,7 +218,7 @@ describe("applyWebhookSubscriptions", () => {
               batch_name: "products",
               hook_name: "validate",
               webhook_method: addWebhook.webhook_method,
-              webhook_type: addWebhook.webhook_type,
+              webhook_type: "after",
             },
           }),
         ],

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
@@ -375,10 +375,9 @@ describe("applyWebhookSubscriptions", () => {
       callOrder.push("unsubscribe");
     });
     const getWebhookList = vi.fn().mockResolvedValue([retainedWebhook]);
-    const context = makeApplyContext(
-      subscribeWebhook,
-      getWebhookList,
-      unsubscribeWebhook,
+    const context = withBaseline(
+      makeApplyContext(subscribeWebhook, getWebhookList, unsubscribeWebhook),
+      [retainedWebhook],
     );
 
     const renamedWebhook = createMockResolvedWebhook({
@@ -407,5 +406,119 @@ describe("applyWebhookSubscriptions", () => {
     await applyWebhookSubscriptions(plan, context);
 
     expect(callOrder).toEqual(["unsubscribe", "subscribe"]);
+  });
+
+  const updatedWebhook = createMockResolvedWebhook({
+    ...DEFAULT_RESOLVED_IDENTITY,
+    fields: [{ name: "sku" }],
+  });
+
+  test("applies an update by unsubscribing the live identity then subscribing the new payload", async () => {
+    const callOrder: string[] = [];
+    const subscribeWebhook = vi.fn().mockImplementation(async () => {
+      callOrder.push("subscribe");
+    });
+    const unsubscribeWebhook = vi.fn().mockImplementation(async () => {
+      callOrder.push("unsubscribe");
+    });
+    const getWebhookList = vi.fn().mockResolvedValue([retainedWebhook]);
+    const context = makeApplyContext(
+      subscribeWebhook,
+      getWebhookList,
+      unsubscribeWebhook,
+    );
+
+    const plan = {
+      operations: [
+        {
+          after: updatedWebhook,
+          before: retainedWebhook,
+          id: "op-1",
+          kind: "update" as const,
+          label: "Update",
+        },
+      ],
+      path: UPGRADE_PATH,
+    };
+
+    const result = await applyWebhookSubscriptions(plan, context);
+
+    expect(callOrder).toEqual(["unsubscribe", "subscribe"]);
+    expect(unsubscribeWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ batch_name: retainedWebhook.batch_name }),
+    );
+    expect(subscribeWebhook).toHaveBeenCalledWith(updatedWebhook);
+    expect(result.snapshotData?.subscribedWebhooks).toEqual([updatedWebhook]);
+  });
+
+  test("applies an update by subscribing directly when the identity isn't currently live", async () => {
+    const subscribeWebhook = vi.fn().mockResolvedValue(null);
+    const unsubscribeWebhook = vi.fn();
+    const getWebhookList = vi.fn().mockResolvedValue([]);
+    const context = withBaseline(
+      makeApplyContext(subscribeWebhook, getWebhookList, unsubscribeWebhook),
+      [retainedWebhook],
+    );
+
+    const plan = {
+      operations: [
+        {
+          after: updatedWebhook,
+          before: retainedWebhook,
+          id: "op-1",
+          kind: "update" as const,
+          label: "Update",
+        },
+      ],
+      path: UPGRADE_PATH,
+    };
+
+    await applyWebhookSubscriptions(plan, context);
+
+    expect(unsubscribeWebhook).not.toHaveBeenCalled();
+    expect(subscribeWebhook).toHaveBeenCalledWith(updatedWebhook);
+  });
+
+  test("aborts on the first update failure without processing remaining operations", async () => {
+    const unsubscribeWebhook = vi
+      .fn()
+      .mockRejectedValue(new Error("Commerce API error"));
+    const subscribeWebhook = vi.fn();
+    const getWebhookList = vi.fn().mockResolvedValue([retainedWebhook]);
+    const context = withBaseline(
+      makeApplyContext(subscribeWebhook, getWebhookList, unsubscribeWebhook),
+      [retainedWebhook],
+    );
+
+    const secondUpdate = createMockResolvedWebhook({
+      batch_name: "test_app_webhooks_second",
+      hook_name: "test_app_webhooks_second",
+      webhook_method: "observer.catalog_product_save_before",
+      webhook_type: "before",
+    });
+
+    const plan = {
+      operations: [
+        {
+          after: updatedWebhook,
+          before: retainedWebhook,
+          id: "op-1",
+          kind: "update" as const,
+          label: "Update",
+        },
+        {
+          after: secondUpdate,
+          before: secondUpdate,
+          id: "op-2",
+          kind: "update" as const,
+          label: "Update",
+        },
+      ],
+      path: UPGRADE_PATH,
+    };
+
+    await expect(applyWebhookSubscriptions(plan, context)).rejects.toThrow();
+    expect(subscribeWebhook).not.toHaveBeenCalled();
+    expect(unsubscribeWebhook).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/helpers.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/helpers.test.ts
@@ -905,10 +905,10 @@ describe("deleteWebhookSubscriptions", () => {
           webhook: {
             batch_name: "default",
             hook_name: "order_created",
-            method: "POST",
+            method: "POST" as const,
             url: "https://example.com/first",
             webhook_method: "plugin.order.api.order_created",
-            webhook_type: "after",
+            webhook_type: "after" as const,
           },
         },
         {
@@ -919,10 +919,10 @@ describe("deleteWebhookSubscriptions", () => {
           webhook: {
             batch_name: "products",
             hook_name: "validate",
-            method: "POST",
+            method: "POST" as const,
             url: "https://example.com/second",
             webhook_method: "observer.catalog_product_save_after",
-            webhook_type: "after",
+            webhook_type: "after" as const,
           },
         },
       ],
@@ -976,10 +976,10 @@ describe("deleteWebhookSubscriptions", () => {
           webhook: {
             batch_name: "products",
             hook_name: "validate",
-            method: "POST",
+            method: "POST" as const,
             url: "https://example.com/hook",
             webhook_method: "observer.catalog_product_save_after",
-            webhook_type: "after",
+            webhook_type: "after" as const,
           },
         },
       ],

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/plan.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/plan.test.ts
@@ -52,6 +52,11 @@ const DEFAULT_RESOLVED_IDENTITY = {
   webhook_method: "plugin.order.api.order_created",
   webhook_type: "after",
 };
+
+/** Resolved URL of configWithWebhooks' default (runtimeAction-based) entry, given the stubbed namespace. */
+const DEFAULT_RESOLVED_URL =
+  "https://test-namespace.adobeioruntime.net/api/v1/web/my-package/handle-webhook";
+
 describe("planWebhookSubscriptions", () => {
   beforeEach(() => {
     vi.stubEnv("__OW_NAMESPACE", "test-namespace");
@@ -166,9 +171,10 @@ describe("planWebhookSubscriptions", () => {
 
   test("retains desired webhooks already present in the baseline and proposes no operations", async () => {
     const config = createDefaultWebhooksConfig();
-    const baselineWebhook = createMockResolvedWebhook(
-      DEFAULT_RESOLVED_IDENTITY,
-    );
+    const baselineWebhook = createMockResolvedWebhook({
+      ...DEFAULT_RESOLVED_IDENTITY,
+      url: DEFAULT_RESOLVED_URL,
+    });
 
     const result = await planWebhookSubscriptions(
       {
@@ -271,9 +277,10 @@ describe("planWebhookSubscriptions", () => {
         }),
       ],
     });
-    const baselineWebhook = createMockResolvedWebhook(
-      DEFAULT_RESOLVED_IDENTITY,
-    );
+    const baselineWebhook = createMockResolvedWebhook({
+      ...DEFAULT_RESOLVED_IDENTITY,
+      url: DEFAULT_RESOLVED_URL,
+    });
 
     const result = await planWebhookSubscriptions(
       {
@@ -342,5 +349,147 @@ describe("planWebhookSubscriptions", () => {
     expect(getWebhookList).not.toHaveBeenCalled();
     expect(subscribeWebhook).not.toHaveBeenCalled();
     expect(unsubscribeWebhook).not.toHaveBeenCalled();
+  });
+
+  test("plans an update when a matched webhook's config differs from the target", async () => {
+    const targetConfig = createMockWebhooksConfig({
+      webhooks: [
+        createMockRuntimeWebhookEntry({
+          webhook: { fields: [{ name: "sku" }] },
+        }),
+      ],
+    });
+    const baselineWebhook = createMockResolvedWebhook({
+      ...DEFAULT_RESOLVED_IDENTITY,
+      url: DEFAULT_RESOLVED_URL,
+    });
+
+    const result = await planWebhookSubscriptions(
+      {
+        baseline: {
+          config: createDefaultWebhooksConfig(),
+          data: { subscribedWebhooks: [baselineWebhook] },
+        },
+        path: UPGRADE_PATH,
+        targetConfig,
+      },
+      makeContext(),
+    );
+
+    expect.assert(result.kind === "planned");
+    expect(result.plan.operations).toHaveLength(1);
+    expect(result.plan.operations[0]).toMatchObject({
+      after: expect.objectContaining({ fields: [{ name: "sku" }] }),
+      before: expect.objectContaining(DEFAULT_RESOLVED_IDENTITY),
+      kind: "update",
+    });
+  });
+
+  test("does not plan an update when a mutable array is only equivalently empty (undefined vs. [])", async () => {
+    const targetConfig = createMockWebhooksConfig({
+      webhooks: [createMockRuntimeWebhookEntry({ webhook: { fields: [] } })],
+    });
+    const baselineWebhook = createMockResolvedWebhook({
+      ...DEFAULT_RESOLVED_IDENTITY,
+      url: DEFAULT_RESOLVED_URL,
+    });
+
+    const result = await planWebhookSubscriptions(
+      {
+        baseline: {
+          config: createDefaultWebhooksConfig(),
+          data: { subscribedWebhooks: [baselineWebhook] },
+        },
+        path: UPGRADE_PATH,
+        targetConfig,
+      },
+      makeContext(),
+    );
+
+    expect.assert(result.kind === "planned");
+    expect(result.plan.operations).toHaveLength(0);
+  });
+
+  test("does not plan an update when a mutable array only differs in element order", async () => {
+    const rules = [
+      { field: "status", operator: "eq", value: "processing" },
+      { field: "total", operator: "gt", value: "100" },
+    ];
+    const targetConfig = createMockWebhooksConfig({
+      webhooks: [
+        createMockRuntimeWebhookEntry({
+          webhook: { rules: [rules[1], rules[0]] },
+        }),
+      ],
+    });
+    const baselineWebhook = createMockResolvedWebhook({
+      ...DEFAULT_RESOLVED_IDENTITY,
+      rules: [rules[0], rules[1]],
+      url: DEFAULT_RESOLVED_URL,
+    });
+
+    const result = await planWebhookSubscriptions(
+      {
+        baseline: {
+          config: createDefaultWebhooksConfig(),
+          data: { subscribedWebhooks: [baselineWebhook] },
+        },
+        path: UPGRADE_PATH,
+        targetConfig,
+      },
+      makeContext(),
+    );
+
+    expect.assert(result.kind === "planned");
+    expect(result.plan.operations).toHaveLength(0);
+  });
+
+  test("orders update operations between removes and adds", async () => {
+    const updatedBaselineWebhook = createMockResolvedWebhook({
+      ...DEFAULT_RESOLVED_IDENTITY,
+      url: DEFAULT_RESOLVED_URL,
+    });
+    const staleBaselineWebhook = createMockResolvedWebhook({
+      batch_name: "test_app_webhooks_stale",
+      hook_name: "test_app_webhooks_stale",
+      webhook_method: "observer.catalog_product_save_before",
+      webhook_type: "before",
+    });
+
+    const targetConfig = createMockWebhooksConfig({
+      webhooks: [
+        createMockRuntimeWebhookEntry({
+          webhook: { fields: [{ name: "sku" }] },
+        }),
+        createMockRuntimeWebhookEntry({
+          webhook: {
+            batch_name: "new",
+            hook_name: "new_hook",
+            webhook_method: "observer.catalog_product_save_after",
+          },
+        }),
+      ],
+    });
+
+    const result = await planWebhookSubscriptions(
+      {
+        baseline: {
+          config: createDefaultWebhooksConfig(),
+          data: {
+            subscribedWebhooks: [updatedBaselineWebhook, staleBaselineWebhook],
+          },
+        },
+        path: UPGRADE_PATH,
+        targetConfig,
+      },
+      makeContext(),
+    );
+
+    expect.assert(result.kind === "planned");
+    expect(result.plan.operations.map((op) => op.kind)).toEqual([
+      "remove",
+      "update",
+      "add",
+    ]);
   });
 });

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/plan.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/plan.test.ts
@@ -50,7 +50,7 @@ const DEFAULT_RESOLVED_IDENTITY = {
   batch_name: "test_app_webhooks_default",
   hook_name: "test_app_webhooks_order_created",
   webhook_method: "plugin.order.api.order_created",
-  webhook_type: "after",
+  webhook_type: "after" as const,
 };
 
 /** Resolved URL of configWithWebhooks' default (runtimeAction-based) entry, given the stubbed namespace. */

--- a/plugins/commerce/app-management/skills/commerce-app-webhooks/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-webhooks/SKILL.md
@@ -50,7 +50,8 @@ Apply the following validation rules before writing. Surface any issues to the u
 | `webhook.url`              | Must be a valid absolute URL (`https://...`); mutually exclusive with `runtimeAction` |
 | `label`                    | Required, non-empty                                                                   |
 | `description`              | Required, non-empty                                                                   |
-| `method`                   | Required HTTP method (e.g., `POST`)                                                   |
+| `webhook_type`             | Required; must be `before` or `after`                                                 |
+| `method`                   | Required; must be `POST`, `PUT`, `DELETE`, or `GET`                                   |
 | `timeout` / `soft_timeout` | Optional; positive integer (milliseconds)                                             |
 | `priority` / `batch_order` | Optional; positive integer                                                            |
 

--- a/plugins/commerce/app-management/skills/commerce-app-webhooks/assets/webhooks-config.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-webhooks/assets/webhooks-config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       webhook: {
         batch_name: "my_app", // [a-zA-Z0-9_]+ only — no hyphens or dots
         hook_name: "validate_product_save", // [a-zA-Z0-9_]+ only — no hyphens or dots
-        method: "POST", // HTTP method
+        method: "POST", // "POST", "PUT", "DELETE", or "GET"
         webhook_method: "plugin.magento.catalog_product.save", // Commerce operation to intercept
         webhook_type: "before", // "before" or "after"
         // timeout: 5000,                  // optional: max ms to wait (positive integer)

--- a/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/webhooks.md
+++ b/plugins/commerce/app-migration/skills/commerce-app-migrate/agents/webhooks.md
@@ -37,6 +37,10 @@ An action that passes all three tests is a Commerce webhook handler candidate. F
 to determine the webhook type (see detection rules below), then emit one entry
 in the `webhooks` array.
 
+Always set `webhook.webhook_type` to `"before"` or `"after"` and
+`webhook.method` to `"POST"`, `"PUT"`, `"DELETE"`, or `"GET"`. Never emit other
+values.
+
 ### Webhook type detection
 
 **OOPE Shipping Carrier**


### PR DESCRIPTION
## Description

Extends webhook upgrade planning to detect configuration changes when a webhook keeps the same identity. Changes to fields, conditions, headers, URLs, priorities, timeouts, and other mutable settings now produce an update operation.

Commerce treats webhook subscription as a guarded insert rather than an upsert, so apply unsubscribes the current live registration and subscribes the target payload. The resulting snapshot contains the target configuration, while OAuth credentials are sent only to Commerce and are not persisted.

## Related Issue

CEXT-6508

## Motivation and Context

Previously, webhooks matched by identity were carried forward even when their configuration changed, so config-only changes between app versions were not applied.

## How Has This Been Tested?

Added unit coverage for changed and equivalent configurations, update execution, retry behavior, and credential handling, plus integration coverage for the Commerce unsubscribe-and-subscribe flow. Ran the full repository test suite, typecheck, lint, build, OpenAPI lint, and package validation.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
