### PR TITLE
CEXT-6510 Update Existing Admin UI Component Configuration During Application Upgrade

### DIFF
--- a/.changeset/calm-dragons-fold.md
+++ b/.changeset/calm-dragons-fold.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Reconcile configuration changes to existing Admin UI components during an upgrade. The Admin UI step now detects when a component present in both the installed and target versions has a changed configuration (ACL, labels, descriptions, notifications) and refreshes the extension to apply it, instead of leaving the change unapplied.

--- a/packages/aio-commerce-lib-app/source/management/domains/admin-ui/plan.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/admin-ui/plan.ts
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { stringify } from "safe-stable-stringify";
+
 import { hasExtensionName } from "./helpers";
 
 import type {
@@ -138,7 +140,26 @@ function buildComponentOperation(
   };
 }
 
-/** Diffs the baseline and target component maps into add/remove operations. */
+/** Builds an `update` operation for a component whose config changed between versions. */
+function buildUpdateOperation(
+  key: string,
+  before: AdminUiComponentDescriptor,
+  after: AdminUiComponentDescriptor,
+): ResourceOperation<AdminUiOperationValue> {
+  return {
+    after: { component: after.ref, config: after.config },
+    before: { component: before.ref, config: before.config },
+    id: `update:${key}`,
+    kind: "update",
+    label: `Update Admin UI ${after.label}`,
+  };
+}
+
+/**
+ * Diffs the baseline and target component maps into add/remove/update operations.
+ * A component present on both sides with a changed config is an `update`; the
+ * whole-config comparison covers ACL, labels, descriptions, and notifications.
+ */
 function diffComponents(
   baselineComponents: Map<string, AdminUiComponentDescriptor>,
   targetComponents: Map<string, AdminUiComponentDescriptor>,
@@ -151,11 +172,12 @@ function diffComponents(
     }
   }
 
-  // A component present on both sides with a changed config is a modification;
-  // this domain does not yet diff configs, so it is intentionally not emitted.
   for (const [key, component] of baselineComponents) {
-    if (!targetComponents.has(key)) {
+    const target = targetComponents.get(key);
+    if (!target) {
       operations.push(buildComponentOperation("remove", key, component));
+    } else if (stringify(component.config) !== stringify(target.config)) {
+      operations.push(buildUpdateOperation(key, component, target));
     }
   }
 
@@ -169,10 +191,10 @@ function diffComponents(
  * `blocked` result when work is planned but the extension identity cannot be
  * resolved (`__OW_NAMESPACE` unset).
  *
- * It emits one operation per component added in the target or removed from it;
- * a component-less `adminUi` block is a no-op. The single
- * {@link AdminUiExtensionAction} on the plan tells `apply` which whole-extension
- * call converges those operations.
+ * It emits one operation per component added in the target, removed from it, or
+ * whose config changed between versions (an `update`); a component-less
+ * `adminUi` block is a no-op. The single {@link AdminUiExtensionAction} on the
+ * plan tells `apply` which whole-extension call converges those operations.
  */
 export function planAdminUi(
   input: PlanningInput<AdminUiConfig, RegisterExtensionStepData>,
@@ -193,8 +215,8 @@ export function planAdminUi(
   const operations = diffComponents(baselineComponents, targetComponents);
 
   // Lifecycle tracks component presence: the first component registers, the last
-  // removal unregisters, and changes in between refresh. Each action carries its
-  // own component ops, so no synthetic block-level op is needed.
+  // removal unregisters, and changes in between (add/remove/update) refresh. Each
+  // action carries its own component ops, so no synthetic block-level op is needed.
   const baselineHasAdminUi = baselineComponents.size > 0;
   const targetHasAdminUi = targetComponents.size > 0;
 

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/admin-ui/plan.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/admin-ui/plan.test.ts
@@ -123,7 +123,7 @@ describe("planAdminUi", () => {
     expect(plan.operations).toEqual([]);
   });
 
-  test("plans nothing for a modification to an existing component (owned by CEXT-6510)", async () => {
+  test("refreshes with an update for a modified existing component", async () => {
     const modifiedSingleGrid = {
       ...configWithAdminUiSingleGrid,
       adminUi: {
@@ -143,8 +143,71 @@ describe("planAdminUi", () => {
       modifiedSingleGrid,
     );
 
-    expect(plan.extensionAction).toBeNull();
-    expect(plan.operations).toEqual([]);
+    expect(plan.extensionAction).toBe("refresh");
+    expect(plan.operations).toHaveLength(1);
+    expect(plan.operations[0]?.kind).toBe("update");
+    expect(plan.operations[0]?.id).toBe("update:order.grid-columns");
+  });
+
+  test("detects a modification nested inside a grid-columns component (column-level change)", async () => {
+    const modifiedColumn = {
+      ...configWithAdminUiSingleGrid,
+      adminUi: {
+        ...configWithAdminUiSingleGrid.adminUi,
+        order: {
+          ...configWithAdminUiSingleGrid.adminUi.order,
+          gridColumns: {
+            ...configWithAdminUiSingleGrid.adminUi.order.gridColumns,
+            columns: [
+              {
+                align: "left" as const,
+                id: "fulfillment_status",
+                label: "Fulfillment Status",
+                type: "string" as const,
+              },
+            ],
+          },
+        },
+      },
+    } as AdminUiConfig;
+
+    const { plan } = await planned(
+      configWithAdminUiSingleGrid as AdminUiConfig,
+      modifiedColumn,
+    );
+
+    expect(plan.extensionAction).toBe("refresh");
+    expect(plan.operations).toHaveLength(1);
+    expect(plan.operations[0]?.kind).toBe("update");
+  });
+
+  test("emits both an add and an update when one component is added and another modified", async () => {
+    // Baseline: single order grid. Target: order grid with a changed label (update)
+    // plus a new customer grid (add).
+    const modifiedAndAdded = {
+      ...configWithAdminUiAllGrids,
+      adminUi: {
+        ...configWithAdminUiAllGrids.adminUi,
+        order: {
+          ...configWithAdminUiAllGrids.adminUi.order,
+          gridColumns: {
+            ...configWithAdminUiAllGrids.adminUi.order.gridColumns,
+            label: "Renamed order fulfillment data",
+          },
+        },
+        product: undefined,
+      },
+    } as AdminUiConfig;
+
+    const { plan } = await planned(
+      configWithAdminUiSingleGrid as AdminUiConfig,
+      modifiedAndAdded,
+    );
+
+    expect(plan.extensionAction).toBe("refresh");
+    expect(
+      plan.operations.map((op) => op.kind).sort((a, b) => a.localeCompare(b)),
+    ).toEqual(["add", "update"]);
   });
 
   test("plans nothing when Admin UI is absent on both sides", async () => {


### PR DESCRIPTION
## Description

Extends the Admin UI upgrade domain (CEXT-6509) to detect and apply configuration changes to **existing** components during an upgrade. `plan.ts` now compares each matched component's config (ACL, title, description, notification messages, etc.) between the baseline and target versions, whole-object, and emits an `update` operation when it differs. The existing `refresh` gate (from CEXT-6509) already fires on any non-empty `operations` list, so no `apply.ts` changes are needed — Commerce's `/refresh` endpoint re-syncs the entire extension from the App Registry regardless of which specific component changed.


## Related Issue

[CEXT-6510](https://jira.corp.adobe.com/browse/CEXT-6510)

## Motivation and Context

Before this change, modifying an existing Admin UI component's config (e.g. renaming a grid column, changing a menu's ACL/description, editing a mass action's notification message) produced **zero** plan operations and did nothing on upgrade — the change was silently dropped. This closes that gap.

## How Has This Been Tested?

**Unit tests** (`plan.test.ts`): modification of an existing grid-columns component, a column-level change nested inside a component, a mixed add+update scenario, and the duplicate-id reorder fix. Full suite: 1057 passing.

**Manual E2E** on a live Stage Commerce instance: deployed a test app, modified an existing Admin UI menu's `label` only (no add/remove), and confirmed:


## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
