### PR TITLE
CEXT-6573: ship production React build for Admin UI SDK apps (gate StrictMode to development)

### DIFF
--- a/.changeset/strict-mode-development-only.md
+++ b/.changeset/strict-mode-development-only.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-admin-ui": patch
+---
+
+StrictMode is now applied only in development builds.

--- a/.changeset/strict-mode-lib-auth-env-cwd.md
+++ b/.changeset/strict-mode-lib-auth-env-cwd.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-auth": patch
+---
+
+Resolve the project `.env` from the project root when syncing IMS credentials, so `sync-ims-credentials` works when run from a subdirectory.

--- a/.changeset/strict-mode-production-build.md
+++ b/.changeset/strict-mode-production-build.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+The app build hooks now set `NODE_ENV` in the project `.env` so the web bundler builds for the correct environment (production on build, development on dev and run).

--- a/.changeset/strict-mode-production-build.md
+++ b/.changeset/strict-mode-production-build.md
@@ -1,5 +1,5 @@
 ---
-"@adobe/aio-commerce-lib-app": minor
+"@adobe/aio-commerce-lib-app": patch
 ---
 
 The app build hooks now set `NODE_ENV` in the project `.env` so the web bundler builds for the correct environment (production on build, development on dev and run).

--- a/.changeset/strict-mode-scripting-utils.md
+++ b/.changeset/strict-mode-scripting-utils.md
@@ -1,0 +1,5 @@
+---
+"@aio-commerce-sdk/scripting-utils": patch
+---
+
+Resolve the project `.env` from the project root in the environment helpers (walking up from the given `cwd`), so they work regardless of which subdirectory a command runs from. Also adds `setNodeEnv` for writing `NODE_ENV` to the project `.env`.

--- a/.changeset/strict-mode-skill-docs.md
+++ b/.changeset/strict-mode-skill-docs.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-management": patch
+---
+
+Update the Admin UI skill guidance so it reflects that StrictMode runs only in development builds and is stripped from production.

--- a/packages-private/scripting-utils/source/env.ts
+++ b/packages-private/scripting-utils/source/env.ts
@@ -87,6 +87,19 @@ function resolveEnvPath() {
   return path.resolve(envPath);
 }
 
+/**
+ * Sets the `NODE_ENV` environment variable in the app `.env` file, so the web
+ * bundler (Parcel) ships the matching React build. Creates the `.env` if absent.
+ * @param mode - The environment mode to write into `NODE_ENV`.
+ */
+export function setNodeEnv(mode: "development" | "production") {
+  const envPath = resolveEnvPath();
+  if (!existsSync(envPath)) {
+    writeFileSync(envPath, "", "utf8");
+  }
+  replaceEnvVar(envPath, "NODE_ENV", mode);
+}
+
 /** Resolves the IMS server to server context from the project workspace credentials. */
 function resolveImsS2SContext(): Promise<ImsContext | null> {
   const credentials: WorkspaceCredentials[] =

--- a/packages-private/scripting-utils/source/env.ts
+++ b/packages-private/scripting-utils/source/env.ts
@@ -23,6 +23,8 @@ import config from "@adobe/aio-lib-core-config";
 import aioIms from "@adobe/aio-lib-ims";
 import dotenv from "dotenv";
 
+import { getProjectRootDirectory } from "#project";
+
 const { context } = aioIms;
 const IMS_KEYS = {
   client_id: "AIO_COMMERCE_AUTH_IMS_CLIENT_ID",
@@ -79,24 +81,27 @@ export function replaceEnvVar(filePath: string, key: string, value: string) {
 }
 
 /**
- * Returns the path to the .env file.
- * @param cwd - The directory holding the `.env`. Defaults to the current working directory.
+ * Returns the path to the project's `.env` file, resolved from the project root
+ * (the nearest `package.json` walking up from `cwd`), so it is found regardless
+ * of which subdirectory a command is invoked from.
+ * @param cwd - A directory within the project. Defaults to the current working directory.
  */
-function resolveEnvPath(cwd = process.cwd()) {
-  return path.resolve(cwd, ".env");
+async function resolveEnvPath(cwd = process.cwd()) {
+  const projectRoot = await getProjectRootDirectory(cwd);
+  return path.join(projectRoot, ".env");
 }
 
 /**
  * Sets the `NODE_ENV` environment variable in the app `.env` file, so the web
  * bundler (Parcel) ships the matching React build. Creates the `.env` if absent.
  * @param mode - The environment mode to write into `NODE_ENV`.
- * @param cwd - The directory holding the `.env`. Defaults to the resolved project directory.
+ * @param cwd - A directory within the project. Defaults to the current working directory.
  */
-export function setNodeEnv(
+export async function setNodeEnv(
   mode: "development" | "production",
   cwd = process.cwd(),
 ) {
-  const envPath = resolveEnvPath(cwd);
+  const envPath = await resolveEnvPath(cwd);
   if (!existsSync(envPath)) {
     writeFileSync(envPath, "", "utf8");
   }
@@ -128,12 +133,12 @@ export type SyncImsCredentialsResult =
 /**
  * Syncs the IMS credentials environment variables from the configured IMS context in
  * the .env file, in a way that is compatible with `@adobe/aio-commerce-lib-auth`.
- * @param cwd - The directory holding the `.env`. Defaults to the current working directory.
+ * @param cwd - A directory within the project. Defaults to the current working directory.
  */
 export async function syncImsCredentials(
   cwd = process.cwd(),
 ): Promise<SyncImsCredentialsResult> {
-  const envPath = resolveEnvPath(cwd);
+  const envPath = await resolveEnvPath(cwd);
 
   if (!existsSync(envPath)) {
     return { ok: false, reason: "missing-env" };

--- a/packages-private/scripting-utils/source/env.ts
+++ b/packages-private/scripting-utils/source/env.ts
@@ -78,22 +78,25 @@ export function replaceEnvVar(filePath: string, key: string, value: string) {
   writeFileSync(envPath, updatedLines.join("\n"), "utf8");
 }
 
-/** Returns the path to the .env file. */
-function resolveEnvPath() {
-  const envPath = process.env.INIT_CWD
-    ? `${process.env.INIT_CWD}/.env`
-    : ".env";
-
-  return path.resolve(envPath);
+/**
+ * Returns the path to the .env file.
+ * @param cwd - The directory holding the `.env`. Defaults to the current working directory.
+ */
+function resolveEnvPath(cwd = process.cwd()) {
+  return path.resolve(cwd, ".env");
 }
 
 /**
  * Sets the `NODE_ENV` environment variable in the app `.env` file, so the web
  * bundler (Parcel) ships the matching React build. Creates the `.env` if absent.
  * @param mode - The environment mode to write into `NODE_ENV`.
+ * @param cwd - The directory holding the `.env`. Defaults to the resolved project directory.
  */
-export function setNodeEnv(mode: "development" | "production") {
-  const envPath = resolveEnvPath();
+export function setNodeEnv(
+  mode: "development" | "production",
+  cwd = process.cwd(),
+) {
+  const envPath = resolveEnvPath(cwd);
   if (!existsSync(envPath)) {
     writeFileSync(envPath, "", "utf8");
   }
@@ -125,9 +128,12 @@ export type SyncImsCredentialsResult =
 /**
  * Syncs the IMS credentials environment variables from the configured IMS context in
  * the .env file, in a way that is compatible with `@adobe/aio-commerce-lib-auth`.
+ * @param cwd - The directory holding the `.env`. Defaults to the current working directory.
  */
-export async function syncImsCredentials(): Promise<SyncImsCredentialsResult> {
-  const envPath = resolveEnvPath();
+export async function syncImsCredentials(
+  cwd = process.cwd(),
+): Promise<SyncImsCredentialsResult> {
+  const envPath = resolveEnvPath(cwd);
 
   if (!existsSync(envPath)) {
     return { ok: false, reason: "missing-env" };

--- a/packages-private/scripting-utils/test/env.test.ts
+++ b/packages-private/scripting-utils/test/env.test.ts
@@ -42,8 +42,6 @@ const { context } = aioIms;
 describe("syncImsCredentials", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    delete process.env.INIT_CWD;
   });
 
   test("should do nothing when .env file does not exist", async () => {
@@ -56,8 +54,7 @@ describe("syncImsCredentials", () => {
     });
 
     await withTempFiles({}, async (tempDir) => {
-      process.env.INIT_CWD = tempDir;
-      const result = await syncImsCredentials();
+      const result = await syncImsCredentials(tempDir);
       expect(result).toEqual({ ok: false, reason: "missing-env" });
       expect(existsSync(join(tempDir, ".env"))).toBe(false);
     });
@@ -70,8 +67,7 @@ describe("syncImsCredentials", () => {
         ".env": "SOME_VAR=value\n",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        const result = await syncImsCredentials();
+        const result = await syncImsCredentials(tempDir);
 
         expect(result).toEqual({ ok: false, reason: "no-ims-context" });
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
@@ -90,8 +86,7 @@ describe("syncImsCredentials", () => {
         ".env": "SOME_VAR=value\n",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        const result = await syncImsCredentials();
+        const result = await syncImsCredentials(tempDir);
 
         expect(result).toEqual({ ok: false, reason: "no-ims-context" });
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
@@ -119,8 +114,7 @@ describe("syncImsCredentials", () => {
         ".env": "EXISTING_VAR=existing\n",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain("EXISTING_VAR=existing");
@@ -154,8 +148,7 @@ describe("syncImsCredentials", () => {
         ".env": "AIO_COMMERCE_AUTH_IMS_CLIENT_ID=old-client-id\n",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain(
@@ -184,8 +177,7 @@ describe("syncImsCredentials", () => {
         ".env": originalEnv,
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         // Content should be identical (no unnecessary writes)
@@ -213,8 +205,7 @@ describe("syncImsCredentials", () => {
         ".env": "",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain(
@@ -244,8 +235,7 @@ describe("syncImsCredentials", () => {
         ".env": "# This is a comment\nEXISTING=value\n",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain("# This is a comment");
@@ -274,8 +264,7 @@ describe("syncImsCredentials", () => {
         ".env": "",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain(
@@ -307,8 +296,7 @@ describe("syncImsCredentials", () => {
         ".env": "",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain(
@@ -350,8 +338,7 @@ describe("syncImsCredentials", () => {
         ".env": "",
       },
       async (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        await syncImsCredentials();
+        await syncImsCredentials(tempDir);
 
         expect(context.get).toHaveBeenCalledWith("first-s2s");
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
@@ -364,16 +351,9 @@ describe("syncImsCredentials", () => {
 });
 
 describe("setNodeEnv", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    delete process.env.INIT_CWD;
-  });
-
   test("should create the .env file when it does not exist", async () => {
     await withTempFiles({}, (tempDir) => {
-      process.env.INIT_CWD = tempDir;
-      setNodeEnv("production");
+      setNodeEnv("production", tempDir);
 
       const envPath = join(tempDir, ".env");
       expect(existsSync(envPath)).toBe(true);
@@ -387,8 +367,7 @@ describe("setNodeEnv", () => {
         ".env": "EXISTING_VAR=existing\n",
       },
       (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        setNodeEnv("development");
+        setNodeEnv("development", tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain("EXISTING_VAR=existing");
@@ -403,8 +382,7 @@ describe("setNodeEnv", () => {
         ".env": "NODE_ENV=development\n",
       },
       (tempDir) => {
-        process.env.INIT_CWD = tempDir;
-        setNodeEnv("production");
+        setNodeEnv("production", tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain("NODE_ENV=production");

--- a/packages-private/scripting-utils/test/env.test.ts
+++ b/packages-private/scripting-utils/test/env.test.ts
@@ -53,7 +53,7 @@ describe("syncImsCredentials", () => {
       name: "my-s2s-context",
     });
 
-    await withTempFiles({}, async (tempDir) => {
+    await withTempFiles({ "package.json": "{}" }, async (tempDir) => {
       const result = await syncImsCredentials(tempDir);
       expect(result).toEqual({ ok: false, reason: "missing-env" });
       expect(existsSync(join(tempDir, ".env"))).toBe(false);
@@ -65,6 +65,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "SOME_VAR=value\n",
+        "package.json": "{}",
       },
       async (tempDir) => {
         const result = await syncImsCredentials(tempDir);
@@ -84,6 +85,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "SOME_VAR=value\n",
+        "package.json": "{}",
       },
       async (tempDir) => {
         const result = await syncImsCredentials(tempDir);
@@ -112,6 +114,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "EXISTING_VAR=existing\n",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -146,6 +149,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "AIO_COMMERCE_AUTH_IMS_CLIENT_ID=old-client-id\n",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -175,6 +179,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": originalEnv,
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -203,6 +208,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -233,6 +239,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "# This is a comment\nEXISTING=value\n",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -262,6 +269,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -294,6 +302,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -336,6 +345,7 @@ describe("syncImsCredentials", () => {
     await withTempFiles(
       {
         ".env": "",
+        "package.json": "{}",
       },
       async (tempDir) => {
         await syncImsCredentials(tempDir);
@@ -352,8 +362,8 @@ describe("syncImsCredentials", () => {
 
 describe("setNodeEnv", () => {
   test("should create the .env file when it does not exist", async () => {
-    await withTempFiles({}, (tempDir) => {
-      setNodeEnv("production", tempDir);
+    await withTempFiles({ "package.json": "{}" }, async (tempDir) => {
+      await setNodeEnv("production", tempDir);
 
       const envPath = join(tempDir, ".env");
       expect(existsSync(envPath)).toBe(true);
@@ -365,9 +375,10 @@ describe("setNodeEnv", () => {
     await withTempFiles(
       {
         ".env": "EXISTING_VAR=existing\n",
+        "package.json": "{}",
       },
-      (tempDir) => {
-        setNodeEnv("development", tempDir);
+      async (tempDir) => {
+        await setNodeEnv("development", tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain("EXISTING_VAR=existing");
@@ -380,9 +391,10 @@ describe("setNodeEnv", () => {
     await withTempFiles(
       {
         ".env": "NODE_ENV=development\n",
+        "package.json": "{}",
       },
-      (tempDir) => {
-        setNodeEnv("production", tempDir);
+      async (tempDir) => {
+        await setNodeEnv("production", tempDir);
 
         const envContent = readFileSync(join(tempDir, ".env"), "utf8");
         expect(envContent).toContain("NODE_ENV=production");

--- a/packages-private/scripting-utils/test/env.test.ts
+++ b/packages-private/scripting-utils/test/env.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { syncImsCredentials } from "#env";
+import { setNodeEnv, syncImsCredentials } from "#env";
 import { withTempFiles } from "#filesystem/temp";
 
 // Mock the external dependencies
@@ -358,6 +358,57 @@ describe("syncImsCredentials", () => {
         expect(envContent).toContain(
           "AIO_COMMERCE_AUTH_IMS_CLIENT_ID=first-client-id",
         );
+      },
+    );
+  });
+});
+
+describe("setNodeEnv", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    delete process.env.INIT_CWD;
+  });
+
+  test("should create the .env file when it does not exist", async () => {
+    await withTempFiles({}, (tempDir) => {
+      process.env.INIT_CWD = tempDir;
+      setNodeEnv("production");
+
+      const envPath = join(tempDir, ".env");
+      expect(existsSync(envPath)).toBe(true);
+      expect(readFileSync(envPath, "utf8")).toContain("NODE_ENV=production");
+    });
+  });
+
+  test("should add NODE_ENV when absent from an existing .env file", async () => {
+    await withTempFiles(
+      {
+        ".env": "EXISTING_VAR=existing\n",
+      },
+      (tempDir) => {
+        process.env.INIT_CWD = tempDir;
+        setNodeEnv("development");
+
+        const envContent = readFileSync(join(tempDir, ".env"), "utf8");
+        expect(envContent).toContain("EXISTING_VAR=existing");
+        expect(envContent).toContain("NODE_ENV=development");
+      },
+    );
+  });
+
+  test("should upsert NODE_ENV when already present", async () => {
+    await withTempFiles(
+      {
+        ".env": "NODE_ENV=development\n",
+      },
+      (tempDir) => {
+        process.env.INIT_CWD = tempDir;
+        setNodeEnv("production");
+
+        const envContent = readFileSync(join(tempDir, ".env"), "utf8");
+        expect(envContent).toContain("NODE_ENV=production");
+        expect(envContent).not.toContain("NODE_ENV=development");
       },
     );
   });

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -502,7 +502,7 @@ createExtensionApp({
 
 When you provide `menu`, it owns the root route. Don't also add a root-equivalent path such as `"/"` or `"#/"` to `routes`; `createExtensionApp` reports that duplicate declaration as an error. When your app doesn't have a menu, omit `menu` and declare the root page in `routes` instead.
 
-The whole app is wrapped in React's [`<StrictMode>`](https://react.dev/reference/react/StrictMode). When running locally with `aio app dev` or `aio app run` (which serve React's development build), StrictMode runs its extra development-only checks: components render twice, and effects run an extra setup + cleanup cycle on mount. Duplicated renders, effect runs, or requests fired from effects during development are therefore expected — not a bug — and surface unsafe side effects early. These checks do not run in production builds, where StrictMode has no effect.
+In development builds (`process.env.NODE_ENV !== "production"`), the app is wrapped in React's [`<StrictMode>`](https://react.dev/reference/react/StrictMode), which runs its extra development-only checks: components render twice, and effects run an extra setup + cleanup cycle on mount. Duplicated renders, effect runs, or requests fired from effects during development are therefore expected — not a bug — and surface unsafe side effects early. Production builds (`process.env.NODE_ENV === "production"`) render without `<StrictMode>`, so it is stripped from the production bundle.
 
 #### Handling hook errors
 

--- a/packages/aio-commerce-lib-admin-ui/source/web/react/extension/create-app.tsx
+++ b/packages/aio-commerce-lib-admin-ui/source/web/react/extension/create-app.tsx
@@ -50,9 +50,11 @@ export type CreateExtensionAppOptions = {
  * Mounts a Commerce Admin UI iframe app and handles Experience Cloud Shell, UIX
  * registration, shared-context attachment, routing, and Spectrum setup.
  *
- * The app is wrapped in React's `<StrictMode>`, so in development builds (e.g. when
- * served via `aio app dev` or `aio app run`) components render twice and effects run
- * an extra setup + cleanup cycle on mount. Production builds are unaffected.
+ * The app is wrapped in React's `<StrictMode>` only in development builds
+ * (`process.env.NODE_ENV !== "production"`), so components render twice and effects
+ * run an extra setup + cleanup cycle on mount. Production builds
+ * (`process.env.NODE_ENV === "production"`) render without `<StrictMode>`, so it is
+ * stripped from the production bundle.
  *
  * @param options - App bootstrap options.
  *
@@ -104,10 +106,13 @@ export function createExtensionApp({
       menu === undefined ? routes : [{ element: menu, path: "/" }, ...routes],
     );
 
+    const tree = <RouterProvider router={router} />;
     root.render(
-      <StrictMode>
-        <RouterProvider router={router} />
-      </StrictMode>,
+      process.env.NODE_ENV === "production" ? (
+        tree
+      ) : (
+        <StrictMode>{tree}</StrictMode>
+      ),
     );
   };
 

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/config.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/config.ts
@@ -254,6 +254,10 @@ export function buildAdminUiV2ExtConfig(
     hooks: {
       "pre-app-build":
         "EXTENSION=backend-ui/2 $packageExec aio-commerce-lib-app hooks pre-app-build",
+      "pre-app-dev":
+        "EXTENSION=backend-ui/2 $packageExec aio-commerce-lib-app hooks pre-app-dev",
+      "pre-app-run":
+        "EXTENSION=backend-ui/2 $packageExec aio-commerce-lib-app hooks pre-app-run",
     },
     operations: {
       ...(requiresWeb && {

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
@@ -46,9 +46,14 @@ type Extension = "extensibility/1" | "configuration/1" | "backend-ui/2";
 /**
  * Runs the pre-app-build hook for the given extension.
  * @param extension - The extension to run the hook for.
+ * @param cwd - The project directory. Defaults to the current working directory.
  * @param templatesDir - The directory to load templates from, for testing purposes. Defaults to the generated actions template root.
  */
-export async function run(extension: Extension, templatesDir = TEMPLATES_DIR) {
+export async function run(
+  extension: Extension,
+  cwd = process.cwd(),
+  templatesDir = TEMPLATES_DIR,
+) {
   const appManifest = await loadAppManifest();
   await prepareRuntimeAppConfigModule(appManifest);
 
@@ -69,7 +74,7 @@ export async function run(extension: Extension, templatesDir = TEMPLATES_DIR) {
     );
 
     consola.info("Syncing IMS credentials...");
-    await syncImsCredentials();
+    await syncImsCredentials(cwd);
 
     return;
   }
@@ -109,7 +114,7 @@ export async function run(extension: Extension, templatesDir = TEMPLATES_DIR) {
         );
 
         // Ship React's production build for the deployed web bundle.
-        setNodeEnv("production");
+        setNodeEnv("production", cwd);
       }
     }
     return;

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
@@ -11,7 +11,10 @@
  */
 
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
-import { syncImsCredentials } from "@aio-commerce-sdk/scripting-utils/env";
+import {
+  setNodeEnv,
+  syncImsCredentials,
+} from "@aio-commerce-sdk/scripting-utils/env";
 import consola from "consola";
 
 import {
@@ -104,6 +107,9 @@ export async function run(extension: Extension, templatesDir = TEMPLATES_DIR) {
           appManifest.metadata.displayName,
           templatesDir,
         );
+
+        // Ship React's production build for the deployed web bundle.
+        setNodeEnv("production");
       }
     }
     return;

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
@@ -114,7 +114,7 @@ export async function run(
         );
 
         // Ship React's production build for the deployed web bundle.
-        setNodeEnv("production", cwd);
+        await setNodeEnv("production", cwd);
       }
     }
     return;

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
@@ -10,11 +10,30 @@
  * governing permissions and limitations under the License.
  */
 
+import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
 import consola from "consola";
 
-/** Runs the pre-app-dev hook, resetting the web build back to development. */
+/**
+ * Resets the web build back to development by writing `NODE_ENV` to the project `.env`.
+ * @param cwd - The project directory. Defaults to the current working directory.
+ */
+export function run(cwd = process.cwd()) {
+  setNodeEnv("development", cwd);
+}
+
+/** Runs the pre-app-dev hook. */
 export async function exec() {
   consola.debug("Running lib-app pre-app-dev hook");
-  setNodeEnv("development");
+
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof CommerceSdkValidationError) {
+      consola.error(error.display());
+    } else {
+      consola.error(error);
+    }
+    process.exit(1);
+  }
 }

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
@@ -18,8 +18,8 @@ import consola from "consola";
  * Resets the web build back to development by writing `NODE_ENV` to the project `.env`.
  * @param cwd - The project directory. Defaults to the current working directory.
  */
-export function run(cwd = process.cwd()) {
-  setNodeEnv("development", cwd);
+export async function run(cwd = process.cwd()) {
+  await setNodeEnv("development", cwd);
 }
 
 /** Runs the pre-app-dev hook. */
@@ -27,7 +27,7 @@ export async function exec() {
   consola.debug("Running lib-app pre-app-dev hook");
 
   try {
-    run();
+    await run();
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
+import consola from "consola";
+
+/** Runs the pre-app-dev hook, resetting the web build back to development. */
+export async function exec() {
+  consola.debug("Running lib-app pre-app-dev hook");
+  setNodeEnv("development");
+}

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
@@ -10,11 +10,30 @@
  * governing permissions and limitations under the License.
  */
 
+import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
 import consola from "consola";
 
-/** Runs the pre-app-run hook, resetting the web build back to development. */
+/**
+ * Resets the web build back to development by writing `NODE_ENV` to the project `.env`.
+ * @param cwd - The project directory. Defaults to the current working directory.
+ */
+export function run(cwd = process.cwd()) {
+  setNodeEnv("development", cwd);
+}
+
+/** Runs the pre-app-run hook. */
 export async function exec() {
   consola.debug("Running lib-app pre-app-run hook");
-  setNodeEnv("development");
+
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof CommerceSdkValidationError) {
+      consola.error(error.display());
+    } else {
+      consola.error(error);
+    }
+    process.exit(1);
+  }
 }

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
@@ -18,8 +18,8 @@ import consola from "consola";
  * Resets the web build back to development by writing `NODE_ENV` to the project `.env`.
  * @param cwd - The project directory. Defaults to the current working directory.
  */
-export function run(cwd = process.cwd()) {
-  setNodeEnv("development", cwd);
+export async function run(cwd = process.cwd()) {
+  await setNodeEnv("development", cwd);
 }
 
 /** Runs the pre-app-run hook. */
@@ -27,7 +27,7 @@ export async function exec() {
   consola.debug("Running lib-app pre-app-run hook");
 
   try {
-    run();
+    await run();
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
+import consola from "consola";
+
+/** Runs the pre-app-run hook, resetting the web build back to development. */
+export async function exec() {
+  consola.debug("Running lib-app pre-app-run hook");
+  setNodeEnv("development");
+}

--- a/packages/aio-commerce-lib-app/source/commands/index.ts
+++ b/packages/aio-commerce-lib-app/source/commands/index.ts
@@ -20,6 +20,8 @@ import { exec as generateManifestCommand } from "#commands/generate/manifest/mai
 import { exec as generateSchemaCommand } from "#commands/generate/schema/main";
 import { exec as postinstallHookCommand } from "#commands/hooks/postinstall";
 import { exec as preAppBuildHookCommand } from "#commands/hooks/pre-app-build";
+import { exec as preAppDevHookCommand } from "#commands/hooks/pre-app-dev";
+import { exec as preAppRunHookCommand } from "#commands/hooks/pre-app-run";
 import { exec as initCommand } from "#commands/init/main";
 
 const NAMESPACE = "@adobe/aio-commerce-lib-app";
@@ -70,6 +72,8 @@ const COMMANDS = {
   hooks: {
     postinstall: postinstallHookCommand,
     "pre-app-build": preAppBuildHookCommand,
+    "pre-app-dev": preAppDevHookCommand,
+    "pre-app-run": preAppRunHookCommand,
   },
   init: initCommand,
 } as const;

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -60,6 +60,8 @@ const childProcessMocks = vi.hoisted(() => ({
 const { mockSpawnSync } = childProcessMocks;
 const LEADING_CARET_PATTERN = /^\^/u;
 
+const TS_BUNDLE_TIMEOUT_MS = 30_000;
+
 vi.mock("node:child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:child_process")>();
   const { createSpawnSyncStub } = await import("#test/fixtures/exec");
@@ -277,52 +279,60 @@ describe("commands/generate/actions", () => {
       );
     });
 
-    test("bundles a TypeScript app config for JavaScript actions", async () => {
-      await withTempProject(
-        {
-          "app.commerce.config.ts": dynamicOptionsConfigFileTs,
-          "package.json": JSON.stringify({ type: "module" }),
-          ...makeTemplateFiles(),
-        },
-        async (tempDir) => {
-          await run(configWithDynamicListOptions, tempDir);
+    test(
+      "bundles a TypeScript app config for JavaScript actions",
+      async () => {
+        await withTempProject(
+          {
+            "app.commerce.config.ts": dynamicOptionsConfigFileTs,
+            "package.json": JSON.stringify({ type: "module" }),
+            ...makeTemplateFiles(),
+          },
+          async (tempDir) => {
+            await run(configWithDynamicListOptions, tempDir);
 
-          const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
-          expect(existsSync(runtimeConfigPath)).toBe(true);
+            const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
+            expect(existsSync(runtimeConfigPath)).toBe(true);
 
-          const actionsDir = getActionsDir(
-            tempDir,
-            EXTENSIBILITY_EXTENSION_POINT_ID,
-          );
+            const actionsDir = getActionsDir(
+              tempDir,
+              EXTENSIBILITY_EXTENSION_POINT_ID,
+            );
 
-          expect(existsSync(join(actionsDir, "app-config.js"))).toBe(true);
-          const pkg = JSON.parse(
-            await readFile(join(tempDir, "package.json"), "utf-8"),
-          );
+            expect(existsSync(join(actionsDir, "app-config.js"))).toBe(true);
+            const pkg = JSON.parse(
+              await readFile(join(tempDir, "package.json"), "utf-8"),
+            );
 
-          expect(pkg.imports["#app.commerce.config"]).toBe(
-            "./src/commerce-extensibility-1/.generated/app.commerce.config.js",
-          );
-        },
-      );
-    });
+            expect(pkg.imports["#app.commerce.config"]).toBe(
+              "./src/commerce-extensibility-1/.generated/app.commerce.config.js",
+            );
+          },
+        );
+      },
+      TS_BUNDLE_TIMEOUT_MS,
+    );
 
-    test("reports TypeScript config bundling failures", async () => {
-      mockSpawnSync.mockReturnValueOnce({ status: 1 });
+    test(
+      "reports TypeScript config bundling failures",
+      async () => {
+        mockSpawnSync.mockReturnValueOnce({ status: 1 });
 
-      await withTempProject(
-        {
-          "app.commerce.config.ts": dynamicOptionsConfigFileTs,
-          "package.json": JSON.stringify({ type: "module" }),
-          ...makeTemplateFiles(),
-        },
-        async () => {
-          await expect(run(configWithDynamicListOptions)).rejects.toThrow(
-            "Could not bundle the TypeScript app config with esbuild@",
-          );
-        },
-      );
-    });
+        await withTempProject(
+          {
+            "app.commerce.config.ts": dynamicOptionsConfigFileTs,
+            "package.json": JSON.stringify({ type: "module" }),
+            ...makeTemplateFiles(),
+          },
+          async () => {
+            await expect(run(configWithDynamicListOptions)).rejects.toThrow(
+              "Could not bundle the TypeScript app config with esbuild@",
+            );
+          },
+        );
+      },
+      TS_BUNDLE_TIMEOUT_MS,
+    );
 
     test.each(["ts", "mts", "cts"] as const)(
       "keeps JavaScript actions for a .%s config outside init",

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
@@ -14,6 +14,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
@@ -192,6 +193,7 @@ describe("commands/hooks/pre-app-build", () => {
             "index.html",
           );
           expect(existsSync(webSrcEntrypoint)).toBe(true);
+          expect(setNodeEnv).toHaveBeenCalledWith("production");
         },
       );
     });
@@ -223,6 +225,7 @@ describe("commands/hooks/pre-app-build", () => {
             "web-src",
           );
           expect(existsSync(webSrcDir)).toBe(false);
+          expect(setNodeEnv).not.toHaveBeenCalled();
 
           const pkg = JSON.parse(
             await readFile(join(tempDir, "package.json"), "utf-8"),

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
@@ -55,6 +55,7 @@ vi.mock("node:child_process", () => ({ spawnSync: mockSpawnSync }));
 
 // syncImsCredentials is the external boundary — reads AIO CLI credentials
 vi.mock("@aio-commerce-sdk/scripting-utils/env", () => ({
+  setNodeEnv: vi.fn(),
   syncImsCredentials: vi.fn(),
 }));
 

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
@@ -10,12 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   BACKEND_UI_V2_EXTENSION_POINT_ID,
@@ -54,13 +53,22 @@ const { mockSpawnSync } = vi.hoisted(() => ({
 
 vi.mock("node:child_process", () => ({ spawnSync: mockSpawnSync }));
 
-// syncImsCredentials is the external boundary — reads AIO CLI credentials
-vi.mock("@aio-commerce-sdk/scripting-utils/env", () => ({
-  setNodeEnv: vi.fn(),
+// syncImsCredentials is the external boundary (reads AIO CLI credentials); keep
+// it mocked. setNodeEnv stays real so the tests assert the actual .env it writes.
+vi.mock("@aio-commerce-sdk/scripting-utils/env", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@aio-commerce-sdk/scripting-utils/env")
+  >()),
   syncImsCredentials: vi.fn(),
 }));
 
 describe("commands/hooks/pre-app-build", () => {
+  // setNodeEnv writes to INIT_CWD/.env; neutralize the ambient value so it
+  // targets each test's temp project (its cwd) rather than the real repo.
+  beforeEach(() => {
+    vi.stubEnv("INIT_CWD", "");
+  });
+
   afterEach(() => {
     mockSpawnSync.mockClear();
     vi.clearAllMocks();
@@ -193,7 +201,9 @@ describe("commands/hooks/pre-app-build", () => {
             "index.html",
           );
           expect(existsSync(webSrcEntrypoint)).toBe(true);
-          expect(setNodeEnv).toHaveBeenCalledWith("production");
+
+          const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+          expect(envContents).toContain("NODE_ENV=production");
         },
       );
     });
@@ -225,7 +235,7 @@ describe("commands/hooks/pre-app-build", () => {
             "web-src",
           );
           expect(existsSync(webSrcDir)).toBe(false);
-          expect(setNodeEnv).not.toHaveBeenCalled();
+          expect(existsSync(join(tempDir, ".env"))).toBe(false);
 
           const pkg = JSON.parse(
             await readFile(join(tempDir, "package.json"), "utf-8"),

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
@@ -14,7 +14,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
   BACKEND_UI_V2_EXTENSION_POINT_ID,
@@ -63,12 +63,6 @@ vi.mock("@aio-commerce-sdk/scripting-utils/env", async (importOriginal) => ({
 }));
 
 describe("commands/hooks/pre-app-build", () => {
-  // setNodeEnv writes to INIT_CWD/.env; neutralize the ambient value so it
-  // targets each test's temp project (its cwd) rather than the real repo.
-  beforeEach(() => {
-    vi.stubEnv("INIT_CWD", "");
-  });
-
   afterEach(() => {
     mockSpawnSync.mockClear();
     vi.clearAllMocks();
@@ -179,7 +173,7 @@ describe("commands/hooks/pre-app-build", () => {
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run("backend-ui/2");
+          await run("backend-ui/2", tempDir);
 
           const extConfigPath = join(
             tempDir,

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-dev.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-dev.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { exec } from "#commands/hooks/pre-app-dev";
+import { withTempProject } from "#test/fixtures/project";
+
+describe("commands/hooks/pre-app-dev", () => {
+  // setNodeEnv writes to INIT_CWD/.env; neutralize the ambient value so it
+  // targets each test's temp project (its cwd) rather than the real repo.
+  beforeEach(() => {
+    vi.stubEnv("INIT_CWD", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("resets NODE_ENV to development in an existing .env", async () => {
+    await withTempProject(
+      { ".env": "NODE_ENV=production\n" },
+      async (tempDir) => {
+        await exec();
+
+        const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+        expect(envContents).toContain("NODE_ENV=development");
+        expect(envContents).not.toContain("NODE_ENV=production");
+      },
+    );
+  });
+
+  test("creates the .env with NODE_ENV=development when none exists", async () => {
+    await withTempProject({}, async (tempDir) => {
+      await exec();
+
+      const envPath = join(tempDir, ".env");
+      expect(existsSync(envPath)).toBe(true);
+      expect(readFileSync(envPath, "utf8")).toContain("NODE_ENV=development");
+    });
+  });
+});

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-dev.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-dev.test.ts
@@ -13,38 +13,25 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
-import { exec } from "#commands/hooks/pre-app-dev";
+import { run } from "#commands/hooks/pre-app-dev";
 import { withTempProject } from "#test/fixtures/project";
 
 describe("commands/hooks/pre-app-dev", () => {
-  // setNodeEnv writes to INIT_CWD/.env; neutralize the ambient value so it
-  // targets each test's temp project (its cwd) rather than the real repo.
-  beforeEach(() => {
-    vi.stubEnv("INIT_CWD", "");
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   test("resets NODE_ENV to development in an existing .env", async () => {
-    await withTempProject(
-      { ".env": "NODE_ENV=production\n" },
-      async (tempDir) => {
-        await exec();
+    await withTempProject({ ".env": "NODE_ENV=production\n" }, (tempDir) => {
+      run(tempDir);
 
-        const envContents = readFileSync(join(tempDir, ".env"), "utf8");
-        expect(envContents).toContain("NODE_ENV=development");
-        expect(envContents).not.toContain("NODE_ENV=production");
-      },
-    );
+      const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+      expect(envContents).toContain("NODE_ENV=development");
+      expect(envContents).not.toContain("NODE_ENV=production");
+    });
   });
 
   test("creates the .env with NODE_ENV=development when none exists", async () => {
-    await withTempProject({}, async (tempDir) => {
-      await exec();
+    await withTempProject({}, (tempDir) => {
+      run(tempDir);
 
       const envPath = join(tempDir, ".env");
       expect(existsSync(envPath)).toBe(true);

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-dev.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-dev.test.ts
@@ -20,18 +20,21 @@ import { withTempProject } from "#test/fixtures/project";
 
 describe("commands/hooks/pre-app-dev", () => {
   test("resets NODE_ENV to development in an existing .env", async () => {
-    await withTempProject({ ".env": "NODE_ENV=production\n" }, (tempDir) => {
-      run(tempDir);
+    await withTempProject(
+      { ".env": "NODE_ENV=production\n", "package.json": "{}" },
+      async (tempDir) => {
+        await run(tempDir);
 
-      const envContents = readFileSync(join(tempDir, ".env"), "utf8");
-      expect(envContents).toContain("NODE_ENV=development");
-      expect(envContents).not.toContain("NODE_ENV=production");
-    });
+        const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+        expect(envContents).toContain("NODE_ENV=development");
+        expect(envContents).not.toContain("NODE_ENV=production");
+      },
+    );
   });
 
   test("creates the .env with NODE_ENV=development when none exists", async () => {
-    await withTempProject({}, (tempDir) => {
-      run(tempDir);
+    await withTempProject({ "package.json": "{}" }, async (tempDir) => {
+      await run(tempDir);
 
       const envPath = join(tempDir, ".env");
       expect(existsSync(envPath)).toBe(true);

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-run.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-run.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { exec } from "#commands/hooks/pre-app-run";
+import { withTempProject } from "#test/fixtures/project";
+
+describe("commands/hooks/pre-app-run", () => {
+  // setNodeEnv writes to INIT_CWD/.env; neutralize the ambient value so it
+  // targets each test's temp project (its cwd) rather than the real repo.
+  beforeEach(() => {
+    vi.stubEnv("INIT_CWD", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("resets NODE_ENV to development in an existing .env", async () => {
+    await withTempProject(
+      { ".env": "NODE_ENV=production\n" },
+      async (tempDir) => {
+        await exec();
+
+        const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+        expect(envContents).toContain("NODE_ENV=development");
+        expect(envContents).not.toContain("NODE_ENV=production");
+      },
+    );
+  });
+
+  test("creates the .env with NODE_ENV=development when none exists", async () => {
+    await withTempProject({}, async (tempDir) => {
+      await exec();
+
+      const envPath = join(tempDir, ".env");
+      expect(existsSync(envPath)).toBe(true);
+      expect(readFileSync(envPath, "utf8")).toContain("NODE_ENV=development");
+    });
+  });
+});

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-run.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-run.test.ts
@@ -20,18 +20,21 @@ import { withTempProject } from "#test/fixtures/project";
 
 describe("commands/hooks/pre-app-run", () => {
   test("resets NODE_ENV to development in an existing .env", async () => {
-    await withTempProject({ ".env": "NODE_ENV=production\n" }, (tempDir) => {
-      run(tempDir);
+    await withTempProject(
+      { ".env": "NODE_ENV=production\n", "package.json": "{}" },
+      async (tempDir) => {
+        await run(tempDir);
 
-      const envContents = readFileSync(join(tempDir, ".env"), "utf8");
-      expect(envContents).toContain("NODE_ENV=development");
-      expect(envContents).not.toContain("NODE_ENV=production");
-    });
+        const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+        expect(envContents).toContain("NODE_ENV=development");
+        expect(envContents).not.toContain("NODE_ENV=production");
+      },
+    );
   });
 
   test("creates the .env with NODE_ENV=development when none exists", async () => {
-    await withTempProject({}, (tempDir) => {
-      run(tempDir);
+    await withTempProject({ "package.json": "{}" }, async (tempDir) => {
+      await run(tempDir);
 
       const envPath = join(tempDir, ".env");
       expect(existsSync(envPath)).toBe(true);

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-run.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-run.test.ts
@@ -13,38 +13,25 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
-import { exec } from "#commands/hooks/pre-app-run";
+import { run } from "#commands/hooks/pre-app-run";
 import { withTempProject } from "#test/fixtures/project";
 
 describe("commands/hooks/pre-app-run", () => {
-  // setNodeEnv writes to INIT_CWD/.env; neutralize the ambient value so it
-  // targets each test's temp project (its cwd) rather than the real repo.
-  beforeEach(() => {
-    vi.stubEnv("INIT_CWD", "");
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   test("resets NODE_ENV to development in an existing .env", async () => {
-    await withTempProject(
-      { ".env": "NODE_ENV=production\n" },
-      async (tempDir) => {
-        await exec();
+    await withTempProject({ ".env": "NODE_ENV=production\n" }, (tempDir) => {
+      run(tempDir);
 
-        const envContents = readFileSync(join(tempDir, ".env"), "utf8");
-        expect(envContents).toContain("NODE_ENV=development");
-        expect(envContents).not.toContain("NODE_ENV=production");
-      },
-    );
+      const envContents = readFileSync(join(tempDir, ".env"), "utf8");
+      expect(envContents).toContain("NODE_ENV=development");
+      expect(envContents).not.toContain("NODE_ENV=production");
+    });
   });
 
   test("creates the .env with NODE_ENV=development when none exists", async () => {
-    await withTempProject({}, async (tempDir) => {
-      await exec();
+    await withTempProject({}, (tempDir) => {
+      run(tempDir);
 
       const envPath = join(tempDir, ".env");
       expect(existsSync(envPath)).toBe(true);

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -292,7 +292,7 @@ A build failure with a validation error points directly to the offending `adminU
 - **View route `path`**: register the `{ path }` in `src/app.jsx` as the exact same string as the entry's config `path` — copy it verbatim, hash included, so the two line up.
 - **Menu `id` charset**: the menu `id` allows only letters, digits, `/`, `:`, and `_` — no hyphens or spaces.
 - **`defineConfig` not found**: import `defineConfig` from `@adobe/aio-commerce-lib-app/config`.
-- **Double renders/requests in development**: in development builds `createExtensionApp` wraps the app in React `<StrictMode>`, so components render twice and effects run an extra setup + cleanup cycle on mount. Duplicate renders or effect-triggered requests in development are expected StrictMode behavior, not a bug to fix; production builds render without `<StrictMode>` (it is stripped from the production bundle).
+- **Double renders/requests in development**: local builds served by `aio app dev` and `aio app run` are development builds, where `createExtensionApp` wraps the app in React `<StrictMode>` — so components render twice and effects run an extra setup + cleanup cycle on mount. Duplicate renders or effect-triggered requests during local development are expected StrictMode behavior, not a bug to fix. `aio app build` and `aio app deploy` produce production builds, which render without `<StrictMode>` (it is stripped from the bundle).
 
 ## Quality Bar
 

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -292,7 +292,7 @@ A build failure with a validation error points directly to the offending `adminU
 - **View route `path`**: register the `{ path }` in `src/app.jsx` as the exact same string as the entry's config `path` — copy it verbatim, hash included, so the two line up.
 - **Menu `id` charset**: the menu `id` allows only letters, digits, `/`, `:`, and `_` — no hyphens or spaces.
 - **`defineConfig` not found**: import `defineConfig` from `@adobe/aio-commerce-lib-app/config`.
-- **Double renders/requests in development**: `createExtensionApp` wraps the app in React `<StrictMode>`, so under `aio app dev` or `aio app run` components render twice and effects run an extra setup + cleanup cycle on mount. Duplicate renders or effect-triggered requests in development are expected StrictMode behavior, not a bug to fix; production builds are unaffected.
+- **Double renders/requests in development**: in development builds `createExtensionApp` wraps the app in React `<StrictMode>`, so components render twice and effects run an extra setup + cleanup cycle on mount. Duplicate renders or effect-triggered requests in development are expected StrictMode behavior, not a bug to fix; production builds render without `<StrictMode>` (it is stripped from the production bundle).
 
 ## Quality Bar
 


### PR DESCRIPTION
## Description

`aio app build` never sets Parcel's `mode` or `NODE_ENV`, so Admin UI SDK apps ship React's **development** build to production: `<StrictMode>` double-invokes renders/effects and the bundle is ~18% larger and slower. This is an interim, SDK-side fix (works on all current `aio` CLI versions) made of two coordinated changes:

- **`@adobe/aio-commerce-lib-app`** now sets `NODE_ENV` in the app `.env` via its build hooks so the web bundler produces the matching React build:
  - `pre-app-build` (backend-ui/2) writes `NODE_ENV=production`.
  - New `pre-app-dev` / `pre-app-run` hooks reset `NODE_ENV=development`, so `aio app dev` / `aio app run` keep serving the development build (no stale value leaks between commands — verified, since dev/run run a single extension and never re-run `pre-app-build`).
  - Adds a `setNodeEnv` helper to the internal `scripting-utils`.
- **`@adobe/aio-commerce-lib-admin-ui`** gates `<StrictMode>` on `process.env.NODE_ENV !== "production"`, so the wrapper is dead-code-eliminated from production bundles (and retained in development).

The cleaner long-term fix lives upstream in the `aio` build pipeline (aio-lib-web / aio-cli-plugin-app passing Parcel `mode: 'production'` for builds and `'development'` for dev/run), which would set `NODE_ENV` and activate export conditions natively. That only helps after a new `aio` CLI ships, so it is out of scope here.

## Related Issue

- CEXT-6573 (this change)
- Relates to CEXT-6540

## Motivation and Context

Automated systems that build and deploy apps run `aio app build` without `--web-optimize` and without setting `NODE_ENV`, so the deployed browser bundle uses React's development build. That causes StrictMode's double-invocation in production and a materially larger/slower bundle. Making production builds set `NODE_ENV=production` fixes both at once (production React build + StrictMode inert), and the admin-ui gate additionally strips the `<StrictMode>` wrapper from production output.

## How Has This Been Tested?

- **End-to-end Parcel bundle** (driven with the same options `aio-lib-web` uses: `mode` development, `shouldOptimize: false`), against a copy of a real Admin UI SDK app:
  - No `NODE_ENV` (plain `aio app build`) → bundle ships React's dev build and keeps `<StrictMode>`.
  - `.env` `NODE_ENV=production` → bundle ships React's production build (`Minified React error` present, dev-only strings gone) and the `<StrictMode>` wrapper is dead-code-eliminated.
- **Hook write/reset cycle** via the app's `bin/cli.mjs`: `pre-app-build` writes `NODE_ENV=production`; `pre-app-dev` / `pre-app-run` flip it back to `development` in place (no stale leak).
- **Unit tests** added for `setNodeEnv`; `pnpm typecheck` clean across all packages; `scripting-utils` (148), `aio-commerce-lib-app` (1022) and `aio-commerce-lib-admin-ui` (212) test suites pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
