### PR TITLE
Fix generate/actions CWD-race flake; thread explicit project root

### DIFF
--- a/.changeset/dull-hounds-pump.md
+++ b/.changeset/dull-hounds-pump.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Ensure CLI commands find the project root before generating files or updating project configuration.

--- a/packages-private/scripting-utils/source/env.ts
+++ b/packages-private/scripting-utils/source/env.ts
@@ -23,8 +23,6 @@ import config from "@adobe/aio-lib-core-config";
 import aioIms from "@adobe/aio-lib-ims";
 import dotenv from "dotenv";
 
-import { getProjectRootDirectory } from "#project";
-
 const { context } = aioIms;
 const IMS_KEYS = {
   client_id: "AIO_COMMERCE_AUTH_IMS_CLIENT_ID",
@@ -81,27 +79,16 @@ export function replaceEnvVar(filePath: string, key: string, value: string) {
 }
 
 /**
- * Returns the path to the project's `.env` file, resolved from the project root
- * (the nearest `package.json` walking up from `cwd`), so it is found regardless
- * of which subdirectory a command is invoked from.
- * @param cwd - A directory within the project. Defaults to the current working directory.
- */
-async function resolveEnvPath(cwd = process.cwd()) {
-  const projectRoot = await getProjectRootDirectory(cwd);
-  return path.join(projectRoot, ".env");
-}
-
-/**
  * Sets the `NODE_ENV` environment variable in the app `.env` file, so the web
  * bundler (Parcel) ships the matching React build. Creates the `.env` if absent.
  * @param mode - The environment mode to write into `NODE_ENV`.
- * @param cwd - A directory within the project. Defaults to the current working directory.
+ * @param projectRoot - Resolved project root containing the `.env` file.
  */
-export async function setNodeEnv(
+export function setNodeEnv(
   mode: "development" | "production",
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
-  const envPath = await resolveEnvPath(cwd);
+  const envPath = path.join(projectRoot, ".env");
   if (!existsSync(envPath)) {
     writeFileSync(envPath, "", "utf8");
   }
@@ -133,12 +120,12 @@ export type SyncImsCredentialsResult =
 /**
  * Syncs the IMS credentials environment variables from the configured IMS context in
  * the .env file, in a way that is compatible with `@adobe/aio-commerce-lib-auth`.
- * @param cwd - A directory within the project. Defaults to the current working directory.
+ * @param projectRoot - Resolved project root containing the `.env` file.
  */
 export async function syncImsCredentials(
-  cwd = process.cwd(),
+  projectRoot: string,
 ): Promise<SyncImsCredentialsResult> {
-  const envPath = await resolveEnvPath(cwd);
+  const envPath = path.join(projectRoot, ".env");
 
   if (!existsSync(envPath)) {
     return { ok: false, reason: "missing-env" };

--- a/packages-private/scripting-utils/source/filesystem/temp.ts
+++ b/packages-private/scripting-utils/source/filesystem/temp.ts
@@ -52,6 +52,38 @@ export async function withTempFiles<T>(
   }
 }
 
+// Captured once at module load, before any caller mutates the process-global
+// CWD, so it's always a directory that still exists to fall back to.
+const stableRoot = process.cwd();
+
+/**
+ * Reads the current working directory, falling back to a stable root when the
+ * live CWD has been removed (which makes `process.cwd()` itself throw ENOENT).
+ */
+function currentCwd(): string {
+  try {
+    return process.cwd();
+  } catch {
+    return stableRoot;
+  }
+}
+
+/**
+ * Restores the working directory, tolerating a target that no longer exists so
+ * a removed directory can't cascade a failure into unrelated callers.
+ */
+function restoreCwd(target: string) {
+  try {
+    process.chdir(target);
+  } catch {
+    try {
+      process.chdir(stableRoot);
+    } catch {
+      // The stable root is gone too; nothing left to restore to.
+    }
+  }
+}
+
 /**
  * Change the current working directory and execute a callback with the temporary directory path
  * @param tempDir - Temporary directory path
@@ -61,11 +93,11 @@ export async function withChdir<T>(
   tempDir: string,
   callback: () => Promise<T> | T,
 ) {
-  const originalCwd = process.cwd();
+  const originalCwd = currentCwd();
   try {
     process.chdir(tempDir);
     return await callback();
   } finally {
-    process.chdir(originalCwd);
+    restoreCwd(originalCwd);
   }
 }

--- a/packages-private/scripting-utils/source/filesystem/temp.ts
+++ b/packages-private/scripting-utils/source/filesystem/temp.ts
@@ -52,8 +52,8 @@ export async function withTempFiles<T>(
   }
 }
 
-// Captured once at module load, before any caller mutates the process-global
-// CWD, so it's always a directory that still exists to fall back to.
+// Captured before any caller mutates the CWD, so restores have a directory
+// that still exists to fall back to.
 const stableRoot = process.cwd();
 
 /**

--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -271,9 +271,13 @@ export async function getProjectRootDirectory(cwd = process.cwd()) {
 /**
  * Create the output directory for the given file or folder (relative to the project root)
  * @param fileOrFolder - The file or folder to create
+ * @param projectRoot - Project root to resolve against. Defaults to the nearest package.json from the CWD.
  */
-export async function makeOutputDirFor(fileOrFolder: string) {
-  const rootDirectory = await getProjectRootDirectory();
+export async function makeOutputDirFor(
+  fileOrFolder: string,
+  projectRoot?: string,
+) {
+  const rootDirectory = projectRoot ?? (await getProjectRootDirectory());
   const outputDir = join(rootDirectory, fileOrFolder);
 
   if (!existsSync(outputDir)) {

--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -254,8 +254,8 @@ export async function isESM(cwd = process.cwd()) {
 }
 
 /**
- * Get the root directory of the project
- * @param cwd The current working directory
+ * Finds the project root from the nearest ancestor package.json.
+ * @param cwd - Directory from which to search upward.
  */
 export async function getProjectRootDirectory(cwd = process.cwd()) {
   const packageJsonPath = await findNearestPackageJson(cwd);
@@ -269,8 +269,8 @@ export async function getProjectRootDirectory(cwd = process.cwd()) {
 }
 
 /**
- * Create the output directory for the given file or folder (relative to the project root)
- * @param fileOrFolder - The file or folder to create
+ * Creates an output directory relative to the project root.
+ * @param fileOrFolder - Project-relative directory to create.
  * @param projectRoot - Resolved project root.
  */
 export async function makeOutputDirFor(
@@ -331,7 +331,7 @@ function isValidPackageManager(
 
 /**
  * Detect the package manager for a project.
- * @param projectRoot - Resolved project root.
+ * @param projectRoot - Resolved project root containing package-manager metadata.
  */
 export async function detectPackageManager(
   projectRoot: string,

--- a/packages-private/scripting-utils/source/project.ts
+++ b/packages-private/scripting-utils/source/project.ts
@@ -271,14 +271,13 @@ export async function getProjectRootDirectory(cwd = process.cwd()) {
 /**
  * Create the output directory for the given file or folder (relative to the project root)
  * @param fileOrFolder - The file or folder to create
- * @param projectRoot - Project root to resolve against. Defaults to the nearest package.json from the CWD.
+ * @param projectRoot - Resolved project root.
  */
 export async function makeOutputDirFor(
   fileOrFolder: string,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
-  const rootDirectory = projectRoot ?? (await getProjectRootDirectory());
-  const outputDir = join(rootDirectory, fileOrFolder);
+  const outputDir = join(projectRoot, fileOrFolder);
 
   if (!existsSync(outputDir)) {
     await mkdir(outputDir, { recursive: true });
@@ -332,13 +331,12 @@ function isValidPackageManager(
 
 /**
  * Detect the package manager for a project.
- * @param cwd - Directory to start detection from; defaults to `process.cwd()`
+ * @param projectRoot - Resolved project root.
  */
 export async function detectPackageManager(
-  cwd = process.cwd(),
+  projectRoot: string,
 ): Promise<PackageManager> {
-  const rootDirectory = await getProjectRootDirectory(cwd);
-  const result = await detect({ cwd: rootDirectory });
+  const result = await detect({ cwd: projectRoot });
 
   if (isValidPackageManager(result?.name)) {
     return result.name;

--- a/packages-private/scripting-utils/source/yaml/codegen.ts
+++ b/packages-private/scripting-utils/source/yaml/codegen.ts
@@ -14,7 +14,12 @@ import { writeFile } from "node:fs/promises";
 
 import { Document, isMap, YAMLMap, YAMLSeq } from "yaml";
 
-import { appendCommand, detectPackageManager, getExecCommand } from "#project";
+import {
+  appendCommand,
+  detectPackageManager,
+  getExecCommand,
+  getProjectRootDirectory,
+} from "#project";
 import {
   getExistingInputs,
   getExistingString,
@@ -266,7 +271,8 @@ async function buildHooks(extConfig: Document, hooks: Record<string, string>) {
     },
   });
 
-  const packageManager = await detectPackageManager();
+  const projectRoot = await getProjectRootDirectory();
+  const packageManager = await detectPackageManager(projectRoot);
   const execCommand = getExecCommand(packageManager);
 
   for (const [name, command] of Object.entries(hooks)) {

--- a/packages-private/scripting-utils/test/project.test.ts
+++ b/packages-private/scripting-utils/test/project.test.ts
@@ -818,9 +818,9 @@ describe("makeOutputDirFor", () => {
       {
         "package.json": JSON.stringify({ name: "test" }),
       },
-      async () => {
+      async (tempDir) => {
         // Create a new directory that doesn't exist
-        const outputPath = await makeOutputDirFor("newdir");
+        const outputPath = await makeOutputDirFor("newdir", tempDir);
 
         expect(outputPath).toContain("newdir");
         expect(existsSync(outputPath)).toBe(true);
@@ -837,9 +837,9 @@ describe("makeOutputDirFor", () => {
         "dist/file.txt": "test",
         "package.json": JSON.stringify({ name: "test" }),
       },
-      async () => {
+      async (tempDir) => {
         // Create dist directory first
-        const outputPath = await makeOutputDirFor("dist");
+        const outputPath = await makeOutputDirFor("dist", tempDir);
 
         expect(outputPath).toContain("dist");
         expect(existsSync(outputPath)).toBe(true);

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
@@ -17,7 +17,6 @@ import { dirname, extname, join, relative, sep } from "node:path";
 import {
   detectPackageManager,
   getPackageExecutionCommand,
-  getProjectRootDirectory,
   loadPackageJson,
   makeOutputDirFor,
 } from "@aio-commerce-sdk/scripting-utils/project";
@@ -145,10 +144,9 @@ async function writeJavaScriptAppConfigModule(
 async function bundleTypeScriptAppConfigModule(
   configFilePath: string,
   outputPath: string,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
-  const root = projectRoot ?? (await getProjectRootDirectory());
-  const packageManager = await detectPackageManager(root);
+  const packageManager = await detectPackageManager(projectRoot);
 
   const { command, args } = getPackageExecutionCommand(
     packageManager,
@@ -167,7 +165,7 @@ async function bundleTypeScriptAppConfigModule(
   );
 
   const result = spawnSync(command, args, {
-    cwd: root,
+    cwd: projectRoot,
     stdio: "inherit",
   });
 
@@ -187,14 +185,13 @@ async function bundleTypeScriptAppConfigModule(
  * Write an ESM module that re-exports the static app manifest JSON so generated
  * actions can import it via the alias without needing a JSON import attribute.
  */
-async function prepareStaticAppConfigImportAlias(projectRoot?: string) {
-  const root = projectRoot ?? (await getProjectRootDirectory());
+async function prepareStaticAppConfigImportAlias(projectRoot: string) {
   const runtimeConfigPath = getRuntimeAppConfigPath();
-  const outputPath = join(root, runtimeConfigPath);
+  const outputPath = join(projectRoot, runtimeConfigPath);
 
-  await makeOutputDirFor(dirname(runtimeConfigPath), root);
+  await makeOutputDirFor(dirname(runtimeConfigPath), projectRoot);
   await writeJavaScriptAppConfigModule(
-    join(root, getManifestPath()),
+    join(projectRoot, getManifestPath()),
     outputPath,
   );
 }
@@ -209,31 +206,34 @@ async function prepareStaticAppConfigImportAlias(projectRoot?: string) {
  */
 export async function prepareRuntimeAppConfigModule(
   appManifest: CommerceAppConfigOutputModel,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
-  const root = projectRoot ?? (await getProjectRootDirectory());
-  const configFilePath = await resolveCommerceAppConfig(root);
+  const configFilePath = await resolveCommerceAppConfig(projectRoot);
 
-  if (await requiresJavaScriptAppConfig(appManifest, root)) {
+  if (await requiresJavaScriptAppConfig(appManifest, projectRoot)) {
     if (configFilePath === null) {
       throw new Error(
         "Generating a runtime config module requires an app.commerce.config.* file.",
       );
     }
 
-    await makeOutputDirFor(dirname(getRuntimeAppConfigPath()), root);
-    const outputPath = join(root, getRuntimeAppConfigPath());
+    await makeOutputDirFor(dirname(getRuntimeAppConfigPath()), projectRoot);
+    const outputPath = join(projectRoot, getRuntimeAppConfigPath());
 
     if (isTypeScriptConfig(configFilePath)) {
-      await bundleTypeScriptAppConfigModule(configFilePath, outputPath, root);
+      await bundleTypeScriptAppConfigModule(
+        configFilePath,
+        outputPath,
+        projectRoot,
+      );
     } else {
       await writeJavaScriptAppConfigModule(configFilePath, outputPath);
     }
   } else {
-    await prepareStaticAppConfigImportAlias(root);
+    await prepareStaticAppConfigImportAlias(projectRoot);
   }
 
-  await updateAppConfigImportAlias(root, getRuntimeAppConfigPath());
+  await updateAppConfigImportAlias(projectRoot, getRuntimeAppConfigPath());
 }
 
 /**
@@ -242,12 +242,9 @@ export async function prepareRuntimeAppConfigModule(
  */
 export async function readExtConfig(
   extensionPointId: ValidExtensionPointId,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
-  const extConfigPath = join(
-    projectRoot ?? (await getProjectRootDirectory()),
-    getExtConfigPath(extensionPointId),
-  );
+  const extConfigPath = join(projectRoot, getExtConfigPath(extensionPointId));
 
   try {
     return {
@@ -275,15 +272,17 @@ export async function readExtConfig(
 export async function updateExtConfig(
   appConfig: CommerceAppConfigOutputModel,
   extensionPointId: ValidExtensionPointId,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
   consola.info(`Updating ext.config.yaml for ${extensionPointId}...`);
 
-  const root = projectRoot ?? (await getProjectRootDirectory());
-  await makeOutputDirFor(getExtensionPointFolderPath(extensionPointId), root);
+  await makeOutputDirFor(
+    getExtensionPointFolderPath(extensionPointId),
+    projectRoot,
+  );
   const { path: extConfigPath, doc: extConfigDoc } = await readExtConfig(
     extensionPointId,
-    root,
+    projectRoot,
   );
 
   let extConfig: ExtConfig;
@@ -319,12 +318,11 @@ export async function generateActionFiles(
   actions: TemplateAction[],
   extensionPointId: ValidExtensionPointId,
   templatesDir: string,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
   consola.start("Generating runtime actions...");
 
-  const root = projectRoot ?? (await getProjectRootDirectory());
-  await makeOutputDirFor(getActionsDir(extensionPointId), root);
+  await makeOutputDirFor(getActionsDir(extensionPointId), projectRoot);
 
   const outputFiles = await Promise.all(
     actions.map(async (action) => {
@@ -342,19 +340,19 @@ export async function generateActionFiles(
         const scriptsTemplate = await generateCustomScriptsTemplate(
           await readFile(customScriptsTemplatePath, "utf-8"),
           appManifest,
-          root,
+          projectRoot,
         );
 
         template = applyCustomScripts(template, scriptsTemplate);
       }
 
       const actionPath = join(
-        root,
+        projectRoot,
         getActionPath(extensionPointId, action.name),
       );
 
       await writeFile(actionPath, template, "utf-8");
-      return ` ${relative(root, actionPath)}`;
+      return ` ${relative(projectRoot, actionPath)}`;
     }),
   );
 
@@ -397,7 +395,7 @@ export function applyCustomScripts(
 export async function generateCustomScriptsTemplate(
   template: string,
   appManifest: CommerceAppConfigOutputModel,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
   if (!hasCustomInstallationSteps(appManifest)) {
     return null;
@@ -405,9 +403,8 @@ export async function generateCustomScriptsTemplate(
 
   // We need to resolve paths from project root to relative imports from the
   // generated installation action's location.
-  const root = projectRoot ?? (await getProjectRootDirectory());
   const installationActionDir = join(
-    root,
+    projectRoot,
     getActionsDir(EXTENSIBILITY_EXTENSION_POINT_ID),
   );
 
@@ -416,7 +413,7 @@ export async function generateCustomScriptsTemplate(
   const importStatements = customSteps
     .map((step: CustomInstallationStep, index: number) => {
       // step.script is relative to project root (e.g., "./scripts/setup.js")
-      const absoluteScriptPath = join(root, step.script);
+      const absoluteScriptPath = join(projectRoot, step.script);
       let relativeImportPath = relative(
         installationActionDir,
         absoluteScriptPath,

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
@@ -145,9 +145,10 @@ async function writeJavaScriptAppConfigModule(
 async function bundleTypeScriptAppConfigModule(
   configFilePath: string,
   outputPath: string,
+  projectRoot?: string,
 ) {
-  const projectRoot = await getProjectRootDirectory();
-  const packageManager = await detectPackageManager(projectRoot);
+  const root = projectRoot ?? (await getProjectRootDirectory());
+  const packageManager = await detectPackageManager(root);
 
   const { command, args } = getPackageExecutionCommand(
     packageManager,
@@ -166,7 +167,7 @@ async function bundleTypeScriptAppConfigModule(
   );
 
   const result = spawnSync(command, args, {
-    cwd: projectRoot,
+    cwd: root,
     stdio: "inherit",
   });
 
@@ -186,14 +187,14 @@ async function bundleTypeScriptAppConfigModule(
  * Write an ESM module that re-exports the static app manifest JSON so generated
  * actions can import it via the alias without needing a JSON import attribute.
  */
-async function prepareStaticAppConfigImportAlias() {
-  const projectRoot = await getProjectRootDirectory();
+async function prepareStaticAppConfigImportAlias(projectRoot?: string) {
+  const root = projectRoot ?? (await getProjectRootDirectory());
   const runtimeConfigPath = getRuntimeAppConfigPath();
-  const outputPath = join(projectRoot, runtimeConfigPath);
+  const outputPath = join(root, runtimeConfigPath);
 
-  await makeOutputDirFor(dirname(runtimeConfigPath));
+  await makeOutputDirFor(dirname(runtimeConfigPath), root);
   await writeJavaScriptAppConfigModule(
-    join(projectRoot, getManifestPath()),
+    join(root, getManifestPath()),
     outputPath,
   );
 }
@@ -208,39 +209,43 @@ async function prepareStaticAppConfigImportAlias() {
  */
 export async function prepareRuntimeAppConfigModule(
   appManifest: CommerceAppConfigOutputModel,
+  projectRoot?: string,
 ) {
-  const projectRoot = await getProjectRootDirectory();
-  const configFilePath = await resolveCommerceAppConfig(projectRoot);
+  const root = projectRoot ?? (await getProjectRootDirectory());
+  const configFilePath = await resolveCommerceAppConfig(root);
 
-  if (await requiresJavaScriptAppConfig(appManifest)) {
+  if (await requiresJavaScriptAppConfig(appManifest, root)) {
     if (configFilePath === null) {
       throw new Error(
         "Generating a runtime config module requires an app.commerce.config.* file.",
       );
     }
 
-    await makeOutputDirFor(dirname(getRuntimeAppConfigPath()));
-    const outputPath = join(projectRoot, getRuntimeAppConfigPath());
+    await makeOutputDirFor(dirname(getRuntimeAppConfigPath()), root);
+    const outputPath = join(root, getRuntimeAppConfigPath());
 
     if (isTypeScriptConfig(configFilePath)) {
-      await bundleTypeScriptAppConfigModule(configFilePath, outputPath);
+      await bundleTypeScriptAppConfigModule(configFilePath, outputPath, root);
     } else {
       await writeJavaScriptAppConfigModule(configFilePath, outputPath);
     }
   } else {
-    await prepareStaticAppConfigImportAlias();
+    await prepareStaticAppConfigImportAlias(root);
   }
 
-  await updateAppConfigImportAlias(projectRoot, getRuntimeAppConfigPath());
+  await updateAppConfigImportAlias(root, getRuntimeAppConfigPath());
 }
 
 /**
  * Read an extension point's ext.config.yaml file and return it as a JS object.
  * @param extensionPointId - The extension point ID to read the config for.
  */
-export async function readExtConfig(extensionPointId: ValidExtensionPointId) {
+export async function readExtConfig(
+  extensionPointId: ValidExtensionPointId,
+  projectRoot?: string,
+) {
   const extConfigPath = join(
-    await getProjectRootDirectory(),
+    projectRoot ?? (await getProjectRootDirectory()),
     getExtConfigPath(extensionPointId),
   );
 
@@ -270,12 +275,16 @@ export async function readExtConfig(extensionPointId: ValidExtensionPointId) {
 export async function updateExtConfig(
   appConfig: CommerceAppConfigOutputModel,
   extensionPointId: ValidExtensionPointId,
+  projectRoot?: string,
 ) {
   consola.info(`Updating ext.config.yaml for ${extensionPointId}...`);
 
-  await makeOutputDirFor(getExtensionPointFolderPath(extensionPointId));
-  const { path: extConfigPath, doc: extConfigDoc } =
-    await readExtConfig(extensionPointId);
+  const root = projectRoot ?? (await getProjectRootDirectory());
+  await makeOutputDirFor(getExtensionPointFolderPath(extensionPointId), root);
+  const { path: extConfigPath, doc: extConfigDoc } = await readExtConfig(
+    extensionPointId,
+    root,
+  );
 
   let extConfig: ExtConfig;
 
@@ -310,11 +319,12 @@ export async function generateActionFiles(
   actions: TemplateAction[],
   extensionPointId: ValidExtensionPointId,
   templatesDir: string,
+  projectRoot?: string,
 ) {
   consola.start("Generating runtime actions...");
 
-  await makeOutputDirFor(getActionsDir(extensionPointId));
-  const projectRoot = await getProjectRootDirectory();
+  const root = projectRoot ?? (await getProjectRootDirectory());
+  await makeOutputDirFor(getActionsDir(extensionPointId), root);
 
   const outputFiles = await Promise.all(
     actions.map(async (action) => {
@@ -332,18 +342,19 @@ export async function generateActionFiles(
         const scriptsTemplate = await generateCustomScriptsTemplate(
           await readFile(customScriptsTemplatePath, "utf-8"),
           appManifest,
+          root,
         );
 
         template = applyCustomScripts(template, scriptsTemplate);
       }
 
       const actionPath = join(
-        projectRoot,
+        root,
         getActionPath(extensionPointId, action.name),
       );
 
       await writeFile(actionPath, template, "utf-8");
-      return ` ${relative(process.cwd(), actionPath)}`;
+      return ` ${relative(root, actionPath)}`;
     }),
   );
 
@@ -386,6 +397,7 @@ export function applyCustomScripts(
 export async function generateCustomScriptsTemplate(
   template: string,
   appManifest: CommerceAppConfigOutputModel,
+  projectRoot?: string,
 ) {
   if (!hasCustomInstallationSteps(appManifest)) {
     return null;
@@ -393,9 +405,9 @@ export async function generateCustomScriptsTemplate(
 
   // We need to resolve paths from project root to relative imports from the
   // generated installation action's location.
-  const projectRoot = await getProjectRootDirectory();
+  const root = projectRoot ?? (await getProjectRootDirectory());
   const installationActionDir = join(
-    projectRoot,
+    root,
     getActionsDir(EXTENSIBILITY_EXTENSION_POINT_ID),
   );
 
@@ -404,7 +416,7 @@ export async function generateCustomScriptsTemplate(
   const importStatements = customSteps
     .map((step: CustomInstallationStep, index: number) => {
       // step.script is relative to project root (e.g., "./scripts/setup.js")
-      const absoluteScriptPath = join(projectRoot, step.script);
+      const absoluteScriptPath = join(root, step.script);
       let relativeImportPath = relative(
         installationActionDir,
         absoluteScriptPath,

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/lib.ts
@@ -140,7 +140,12 @@ async function writeJavaScriptAppConfigModule(
   );
 }
 
-/** Bundle a TypeScript app config file into runtime-safe ESM. */
+/**
+ * Bundles a TypeScript app config file into runtime-safe ESM.
+ * @param configFilePath - Source TypeScript app config path.
+ * @param outputPath - Generated ESM module path.
+ * @param projectRoot - Resolved project root used to run the bundler.
+ */
 async function bundleTypeScriptAppConfigModule(
   configFilePath: string,
   outputPath: string,
@@ -184,6 +189,7 @@ async function bundleTypeScriptAppConfigModule(
 /**
  * Write an ESM module that re-exports the static app manifest JSON so generated
  * actions can import it via the alias without needing a JSON import attribute.
+ * @param projectRoot - Resolved project root where the module is generated.
  */
 async function prepareStaticAppConfigImportAlias(projectRoot: string) {
   const runtimeConfigPath = getRuntimeAppConfigPath();
@@ -203,6 +209,8 @@ async function prepareStaticAppConfigImportAlias(projectRoot: string) {
  * TypeScript configs are bundled into a generated runtime module. JavaScript
  * configs use a passthrough module, while serializable default-only configs use
  * a re-export of the validated JSON manifest.
+ * @param appManifest - App configuration used to select the module format.
+ * @param projectRoot - Resolved project root where the module is generated.
  */
 export async function prepareRuntimeAppConfigModule(
   appManifest: CommerceAppConfigOutputModel,
@@ -237,8 +245,9 @@ export async function prepareRuntimeAppConfigModule(
 }
 
 /**
- * Read an extension point's ext.config.yaml file and return it as a JS object.
+ * Reads an extension point's ext.config.yaml document and path.
  * @param extensionPointId - The extension point ID to read the config for.
+ * @param projectRoot - Resolved project root containing the extension config.
  */
 export async function readExtConfig(
   extensionPointId: ValidExtensionPointId,
@@ -268,7 +277,12 @@ export async function readExtConfig(
   }
 }
 
-/** Update the ext.config.yaml file */
+/**
+ * Updates an extension point's ext.config.yaml with generated configuration.
+ * @param appConfig - App configuration used to build the extension config.
+ * @param extensionPointId - Extension point whose config is updated.
+ * @param projectRoot - Resolved project root containing the extension config.
+ */
 export async function updateExtConfig(
   appConfig: CommerceAppConfigOutputModel,
   extensionPointId: ValidExtensionPointId,
@@ -312,7 +326,14 @@ export async function updateExtConfig(
   return extConfig;
 }
 
-/** Generate the action files */
+/**
+ * Generates runtime action files from templates.
+ * @param appManifest - App configuration used to populate action templates.
+ * @param actions - Runtime actions to generate.
+ * @param extensionPointId - Extension point receiving the generated actions.
+ * @param templatesDir - Directory containing action templates.
+ * @param projectRoot - Resolved project root where actions are generated.
+ */
 export async function generateActionFiles(
   appManifest: CommerceAppConfigOutputModel,
   actions: TemplateAction[],
@@ -390,7 +411,10 @@ export function applyCustomScripts(
 }
 
 /**
- * Generate the installation template with dynamic custom script imports
+ * Generates installation code that imports configured custom scripts.
+ * @param template - Custom scripts template content.
+ * @param appManifest - App configuration containing custom installation steps.
+ * @param projectRoot - Resolved project root used to resolve script paths.
  */
 export async function generateCustomScriptsTemplate(
   template: string,

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/main.ts
@@ -37,9 +37,10 @@ import {
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
 /**
- * Runs the generate actions command for the given extension point.
- * @param appManifest - The app manifest, used to determine which actions to generate and their content.
- * @param options - Working directory and templates directory overrides.
+ * Generates extension configs, runtime actions, and Admin UI web source for the configured domains.
+ * @param appManifest - App configuration used to determine the generated content.
+ * @param projectRoot - Resolved project root where files are generated.
+ * @param templatesDir - Directory containing generation templates.
  */
 export async function run(
   appManifest: CommerceAppConfigOutputModel,

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/main.ts
@@ -11,6 +11,7 @@
  */
 
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
+import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import { consola } from "consola";
 
 import {
@@ -35,19 +36,30 @@ import {
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
+/** Options for the generate actions command. */
+export type RunOptions = {
+  /** Working directory to resolve the project root from. Defaults to the CWD. */
+  cwd?: string;
+  /** The directory to load templates from, for testing purposes. Defaults to the generated actions template root. */
+  templatesDir?: string;
+};
+
 /**
  * Runs the generate actions command for the given extension point.
  * @param appManifest - The app manifest, used to determine which actions to generate and their content.
- * @param templatesDir - The directory to load templates from, for testing purposes. Defaults to the generated actions template root.
+ * @param options - Working directory and templates directory overrides.
  */
 export async function run(
   appManifest: CommerceAppConfigOutputModel,
-  templatesDir = TEMPLATES_DIR,
+  { cwd = process.cwd(), templatesDir = TEMPLATES_DIR }: RunOptions = {},
 ) {
-  await prepareRuntimeAppConfigModule(appManifest);
+  const projectRoot = await getProjectRootDirectory(cwd);
+
+  await prepareRuntimeAppConfigModule(appManifest, projectRoot);
   const appManagementExtConfig = await updateExtConfig(
     appManifest,
     EXTENSIBILITY_EXTENSION_POINT_ID,
+    projectRoot,
   );
 
   await generateActionFiles(
@@ -55,6 +67,7 @@ export async function run(
     getRuntimeActions(appManagementExtConfig, "app-management"),
     EXTENSIBILITY_EXTENSION_POINT_ID,
     templatesDir,
+    projectRoot,
   );
 
   // If the app has a business configuration schema, generate the business configuration actions and files
@@ -62,6 +75,7 @@ export async function run(
     const businessConfigExtConfig = await updateExtConfig(
       appManifest,
       CONFIGURATION_EXTENSION_POINT_ID,
+      projectRoot,
     );
 
     await generateActionFiles(
@@ -69,6 +83,7 @@ export async function run(
       getRuntimeActions(businessConfigExtConfig, "business-configuration"),
       CONFIGURATION_EXTENSION_POINT_ID,
       templatesDir,
+      projectRoot,
     );
   }
 
@@ -76,14 +91,16 @@ export async function run(
     const extConfig = await updateExtConfig(
       appManifest,
       BACKEND_UI_V2_EXTENSION_POINT_ID,
+      projectRoot,
     );
 
     if (extConfig.operations?.view) {
-      await prepareWebSourceImportAlias(extConfig);
+      await prepareWebSourceImportAlias(extConfig, projectRoot);
       await generateWebSrc(
         extConfig,
         appManifest.metadata.displayName,
         templatesDir,
+        projectRoot,
       );
     }
   }

--- a/packages/aio-commerce-lib-app/source/commands/generate/actions/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/actions/main.ts
@@ -36,14 +36,6 @@ import {
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
-/** Options for the generate actions command. */
-export type RunOptions = {
-  /** Working directory to resolve the project root from. Defaults to the CWD. */
-  cwd?: string;
-  /** The directory to load templates from, for testing purposes. Defaults to the generated actions template root. */
-  templatesDir?: string;
-};
-
 /**
  * Runs the generate actions command for the given extension point.
  * @param appManifest - The app manifest, used to determine which actions to generate and their content.
@@ -51,10 +43,9 @@ export type RunOptions = {
  */
 export async function run(
   appManifest: CommerceAppConfigOutputModel,
-  { cwd = process.cwd(), templatesDir = TEMPLATES_DIR }: RunOptions = {},
+  projectRoot: string,
+  templatesDir = TEMPLATES_DIR,
 ) {
-  const projectRoot = await getProjectRootDirectory(cwd);
-
   await prepareRuntimeAppConfigModule(appManifest, projectRoot);
   const appManagementExtConfig = await updateExtConfig(
     appManifest,
@@ -70,7 +61,6 @@ export async function run(
     projectRoot,
   );
 
-  // If the app has a business configuration schema, generate the business configuration actions and files
   if (hasBusinessConfigSchema(appManifest)) {
     const businessConfigExtConfig = await updateExtConfig(
       appManifest,
@@ -99,8 +89,8 @@ export async function run(
       await generateWebSrc(
         extConfig,
         appManifest.metadata.displayName,
-        templatesDir,
         projectRoot,
+        templatesDir,
       );
     }
   }
@@ -109,8 +99,9 @@ export async function run(
 /** Run the generate actions command */
 export async function exec() {
   try {
-    const appManifest = await loadAppManifest();
-    await run(appManifest);
+    const projectRoot = await getProjectRootDirectory();
+    const appManifest = await loadAppManifest(projectRoot);
+    await run(appManifest, projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/generate/manifest/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/manifest/main.ts
@@ -36,13 +36,11 @@ import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
 export async function run(
   appConfig: CommerceAppConfigOutputModel,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
-  const root = projectRoot ?? (await getProjectRootDirectory());
-
   // Remove stale JSON when generated actions need the source config module.
-  if (await requiresJavaScriptAppConfig(appConfig, root)) {
-    const stalePath = join(root, getManifestPath());
+  if (await requiresJavaScriptAppConfig(appConfig, projectRoot)) {
+    const stalePath = join(projectRoot, getManifestPath());
     const staleExists = await access(stalePath).then(
       () => true,
       () => false,
@@ -61,7 +59,7 @@ export async function run(
   const contents = stringify(appConfig, null, 2);
   const outputDir = await makeOutputDirFor(
     getGeneratedDir(EXTENSIBILITY_EXTENSION_POINT_ID),
-    root,
+    projectRoot,
   );
 
   const manifestPath = join(outputDir, APP_MANIFEST_FILE);
@@ -73,8 +71,9 @@ export async function run(
 /** Run the generate manifest command */
 export async function exec() {
   try {
-    const config = await loadAppManifest();
-    await run(config);
+    const projectRoot = await getProjectRootDirectory();
+    const config = await loadAppManifest(projectRoot);
+    await run(config, projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/generate/manifest/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/manifest/main.ts
@@ -34,10 +34,15 @@ import {
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
-export async function run(appConfig: CommerceAppConfigOutputModel) {
+export async function run(
+  appConfig: CommerceAppConfigOutputModel,
+  projectRoot?: string,
+) {
+  const root = projectRoot ?? (await getProjectRootDirectory());
+
   // Remove stale JSON when generated actions need the source config module.
-  if (await requiresJavaScriptAppConfig(appConfig)) {
-    const stalePath = join(await getProjectRootDirectory(), getManifestPath());
+  if (await requiresJavaScriptAppConfig(appConfig, root)) {
+    const stalePath = join(root, getManifestPath());
     const staleExists = await access(stalePath).then(
       () => true,
       () => false,
@@ -56,6 +61,7 @@ export async function run(appConfig: CommerceAppConfigOutputModel) {
   const contents = stringify(appConfig, null, 2);
   const outputDir = await makeOutputDirFor(
     getGeneratedDir(EXTENSIBILITY_EXTENSION_POINT_ID),
+    root,
   );
 
   const manifestPath = join(outputDir, APP_MANIFEST_FILE);

--- a/packages/aio-commerce-lib-app/source/commands/generate/manifest/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/manifest/main.ts
@@ -34,6 +34,11 @@ import {
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
+/**
+ * Generates or removes the static app manifest as required by the app config.
+ * @param appConfig - Validated app configuration to serialize.
+ * @param projectRoot - Resolved project root where the manifest is generated.
+ */
 export async function run(
   appConfig: CommerceAppConfigOutputModel,
   projectRoot: string,

--- a/packages/aio-commerce-lib-app/source/commands/generate/schema/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/schema/main.ts
@@ -41,7 +41,7 @@ import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
 export async function run(
   appConfig: CommerceAppConfigOutputModel,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
   if (!hasBusinessConfigSchema(appConfig)) {
     consola.debug(
@@ -51,8 +51,7 @@ export async function run(
     return;
   }
 
-  const projectDir = projectRoot ?? (await getProjectRootDirectory());
-  const envPath = join(projectDir, ".env");
+  const envPath = join(projectRoot, ".env");
 
   // Ensure .env file exists to avoid failing when loading it.
   await touch(envPath);
@@ -63,7 +62,7 @@ export async function run(
   );
 
   if (hasPasswordFields) {
-    const packageExec = getExecCommand(await detectPackageManager(projectDir));
+    const packageExec = getExecCommand(await detectPackageManager(projectRoot));
     const hasEncryptionKey =
       "AIO_COMMERCE_CONFIG_ENCRYPTION_KEY" in process.env &&
       String(process.env.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY).trim().length > 0;
@@ -79,7 +78,7 @@ export async function run(
   // the app manifest module. Skip emitting a separate schema file and clean up
   // any stale JSON from a previous static run.
   if (hasDynamicAppConfig(appConfig)) {
-    const stalePath = join(projectDir, getSchemaPath());
+    const stalePath = join(projectRoot, getSchemaPath());
     const staleExists = await access(stalePath).then(
       () => true,
       () => false,
@@ -96,7 +95,7 @@ export async function run(
   consola.info("Generating configuration schema...");
   const outputDir = await makeOutputDirFor(
     getGeneratedDir(CONFIGURATION_EXTENSION_POINT_ID),
-    projectDir,
+    projectRoot,
   );
 
   const contents = stringify(appConfig.businessConfig.schema, null, 2);
@@ -109,8 +108,9 @@ export async function run(
 /** Run the generate schema command */
 export async function exec() {
   try {
-    const config = await loadAppManifest();
-    await run(config);
+    const projectRoot = await getProjectRootDirectory();
+    const config = await loadAppManifest(projectRoot);
+    await run(config, projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/generate/schema/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/schema/main.ts
@@ -39,7 +39,10 @@ import { hasBusinessConfigSchema } from "#config/index";
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
-export async function run(appConfig: CommerceAppConfigOutputModel) {
+export async function run(
+  appConfig: CommerceAppConfigOutputModel,
+  projectRoot?: string,
+) {
   if (!hasBusinessConfigSchema(appConfig)) {
     consola.debug(
       "Business configuration schema not found in application configuration. Nothing to do.",
@@ -48,7 +51,7 @@ export async function run(appConfig: CommerceAppConfigOutputModel) {
     return;
   }
 
-  const projectDir = await getProjectRootDirectory();
+  const projectDir = projectRoot ?? (await getProjectRootDirectory());
   const envPath = join(projectDir, ".env");
 
   // Ensure .env file exists to avoid failing when loading it.
@@ -93,6 +96,7 @@ export async function run(appConfig: CommerceAppConfigOutputModel) {
   consola.info("Generating configuration schema...");
   const outputDir = await makeOutputDirFor(
     getGeneratedDir(CONFIGURATION_EXTENSION_POINT_ID),
+    projectDir,
   );
 
   const contents = stringify(appConfig.businessConfig.schema, null, 2);

--- a/packages/aio-commerce-lib-app/source/commands/generate/schema/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/schema/main.ts
@@ -39,6 +39,11 @@ import { hasBusinessConfigSchema } from "#config/index";
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
+/**
+ * Generates the business configuration schema and prepares encryption when needed.
+ * @param appConfig - Validated app configuration containing the schema.
+ * @param projectRoot - Resolved project root where schema files are managed.
+ */
 export async function run(
   appConfig: CommerceAppConfigOutputModel,
   projectRoot: string,

--- a/packages/aio-commerce-lib-app/source/commands/generate/web-src.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/web-src.ts
@@ -17,7 +17,6 @@ import { dirname, join, relative, sep } from "node:path";
 import {
   detectPackageManager,
   getPackageDependencyInstallPlan,
-  getProjectRootDirectory,
   loadPackageJson,
   mergePackageJsonDependencies,
 } from "@aio-commerce-sdk/scripting-utils/project";
@@ -221,15 +220,14 @@ async function prepareWebSourcePackage(
  */
 export async function prepareWebSourceImportAlias(
   extConfig: ExtConfig,
-  projectRoot?: string,
+  projectRoot: string,
 ) {
   const entrypoint = getWebSourceEntrypoint(extConfig);
   if (entrypoint === null) {
     return;
   }
 
-  const root = projectRoot ?? (await getProjectRootDirectory());
-  const pkg = await loadPackageJson(root);
+  const pkg = await loadPackageJson(projectRoot);
   if (pkg === null) {
     throw new Error("Could not find package.json.");
   }
@@ -346,21 +344,20 @@ async function copyWebSourceTemplates(
 export async function generateWebSrc(
   extConfig: ExtConfig,
   appName: string,
+  projectRoot: string,
   templatesDir = TEMPLATES_DIR,
-  projectRoot?: string,
 ) {
   const entrypoint = getWebSourceEntrypoint(extConfig);
   if (entrypoint === null) {
     return;
   }
 
-  const root = projectRoot ?? (await getProjectRootDirectory());
-  const entrypointPath = join(root, entrypoint);
+  const entrypointPath = join(projectRoot, entrypoint);
 
   if (existsSync(entrypointPath)) {
     consola.info(
       `web-src entrypoint already exists, skipping scaffold: ${relative(
-        root,
+        projectRoot,
         entrypointPath,
       )}`,
     );
@@ -373,24 +370,24 @@ export async function generateWebSrc(
 
   const sourceDir = join(templatesDir, "admin-ui", "web-src");
   const targetDir = dirname(entrypointPath);
-  const extension = await resolveWebSourceExtension(root);
+  const extension = await resolveWebSourceExtension(projectRoot);
 
   const outputFiles = await copyWebSourceTemplates(
     sourceDir,
     targetDir,
     extension,
     appName,
-    root,
+    projectRoot,
   );
 
   if (extension === "tsx") {
     const tsconfigPath = await writeWebSourceTypeScriptConfig(targetDir);
-    outputFiles.push(` ${relative(root, tsconfigPath)}`);
-    await syncWebSourceTypecheckScript(root);
+    outputFiles.push(` ${relative(projectRoot, tsconfigPath)}`);
+    await syncWebSourceTypecheckScript(projectRoot);
   }
 
-  await prepareWebSourcePackage(root, extension);
+  await prepareWebSourcePackage(projectRoot, extension);
 
-  consola.success(`Scaffolded ${relative(root, targetDir)}`);
+  consola.success(`Scaffolded ${relative(projectRoot, targetDir)}`);
   consola.log.raw(formatTree(outputFiles));
 }

--- a/packages/aio-commerce-lib-app/source/commands/generate/web-src.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/web-src.ts
@@ -219,14 +219,17 @@ async function prepareWebSourcePackage(
  * Add the package import alias for an existing or generated web-src.
  * @param extConfig - Extension config containing the view operation.
  */
-export async function prepareWebSourceImportAlias(extConfig: ExtConfig) {
+export async function prepareWebSourceImportAlias(
+  extConfig: ExtConfig,
+  projectRoot?: string,
+) {
   const entrypoint = getWebSourceEntrypoint(extConfig);
   if (entrypoint === null) {
     return;
   }
 
-  const projectRoot = await getProjectRootDirectory();
-  const pkg = await loadPackageJson(projectRoot);
+  const root = projectRoot ?? (await getProjectRootDirectory());
+  const pkg = await loadPackageJson(root);
   if (pkg === null) {
     throw new Error("Could not find package.json.");
   }
@@ -295,6 +298,7 @@ async function copyWebSourceTemplates(
   targetDir: string,
   extension: WebSourceExtension,
   appTitle: string,
+  projectRoot: string,
 ): Promise<string[]> {
   await mkdir(targetDir, { recursive: true });
 
@@ -313,6 +317,7 @@ async function copyWebSourceTemplates(
           targetPath,
           extension,
           appTitle,
+          projectRoot,
         );
       }
 
@@ -330,7 +335,7 @@ async function copyWebSourceTemplates(
       }
 
       await writeFile(targetPath, content, { encoding: "utf-8", flag: "wx" });
-      return ` ${relative(process.cwd(), targetPath)}`;
+      return ` ${relative(projectRoot, targetPath)}`;
     }),
   );
 
@@ -342,19 +347,20 @@ export async function generateWebSrc(
   extConfig: ExtConfig,
   appName: string,
   templatesDir = TEMPLATES_DIR,
+  projectRoot?: string,
 ) {
   const entrypoint = getWebSourceEntrypoint(extConfig);
   if (entrypoint === null) {
     return;
   }
 
-  const projectRoot = await getProjectRootDirectory();
-  const entrypointPath = join(projectRoot, entrypoint);
+  const root = projectRoot ?? (await getProjectRootDirectory());
+  const entrypointPath = join(root, entrypoint);
 
   if (existsSync(entrypointPath)) {
     consola.info(
       `web-src entrypoint already exists, skipping scaffold: ${relative(
-        process.cwd(),
+        root,
         entrypointPath,
       )}`,
     );
@@ -367,23 +373,24 @@ export async function generateWebSrc(
 
   const sourceDir = join(templatesDir, "admin-ui", "web-src");
   const targetDir = dirname(entrypointPath);
-  const extension = await resolveWebSourceExtension(projectRoot);
+  const extension = await resolveWebSourceExtension(root);
 
   const outputFiles = await copyWebSourceTemplates(
     sourceDir,
     targetDir,
     extension,
     appName,
+    root,
   );
 
   if (extension === "tsx") {
     const tsconfigPath = await writeWebSourceTypeScriptConfig(targetDir);
-    outputFiles.push(` ${relative(process.cwd(), tsconfigPath)}`);
-    await syncWebSourceTypecheckScript(projectRoot);
+    outputFiles.push(` ${relative(root, tsconfigPath)}`);
+    await syncWebSourceTypecheckScript(root);
   }
 
-  await prepareWebSourcePackage(projectRoot, extension);
+  await prepareWebSourcePackage(root, extension);
 
-  consola.success(`Scaffolded ${relative(process.cwd(), targetDir)}`);
+  consola.success(`Scaffolded ${relative(root, targetDir)}`);
   consola.log.raw(formatTree(outputFiles));
 }

--- a/packages/aio-commerce-lib-app/source/commands/generate/web-src.ts
+++ b/packages/aio-commerce-lib-app/source/commands/generate/web-src.ts
@@ -117,7 +117,8 @@ function getWebSourceEntrypoint(extConfig: ExtConfig) {
 
 /**
  * Ensure package.json has the dependencies and Parcel config needed by web-src.
- * @param projectRoot - Project root containing the package.json to update.
+ * @param projectRoot - Resolved project root containing package.json.
+ * @param extension - Web source extension whose tooling is configured.
  */
 async function prepareWebSourcePackage(
   projectRoot: string,
@@ -217,6 +218,7 @@ async function prepareWebSourcePackage(
 /**
  * Add the package import alias for an existing or generated web-src.
  * @param extConfig - Extension config containing the view operation.
+ * @param projectRoot - Resolved project root containing package.json.
  */
 export async function prepareWebSourceImportAlias(
   extConfig: ExtConfig,
@@ -290,6 +292,7 @@ function getWebSourceTemplateTargetPath(
  * @param targetDir - Generated web-src directory.
  * @param extension - Web source extension to generate.
  * @param appTitle - Application title used by the entrypoint template.
+ * @param projectRoot - Resolved project root used to format output paths.
  */
 async function copyWebSourceTemplates(
   sourceDir: string,
@@ -340,7 +343,13 @@ async function copyWebSourceTemplates(
   return outputFilesByEntry.flat();
 }
 
-/** Generate the web source scaffold for iframe-based Admin UI extensions. */
+/**
+ * Generates the web source scaffold for an iframe-based Admin UI extension.
+ * @param extConfig - Extension config containing the web entrypoint.
+ * @param appName - Application name inserted into the generated entrypoint.
+ * @param projectRoot - Resolved project root where web source is generated.
+ * @param templatesDir - Directory containing web source templates.
+ */
 export async function generateWebSrc(
   extConfig: ExtConfig,
   appName: string,

--- a/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
@@ -24,7 +24,7 @@ export async function run(
   appManifest: CommerceAppConfigOutputModel,
   templatesDir?: string,
 ) {
-  await generateActionsCommand(appManifest, templatesDir);
+  await generateActionsCommand(appManifest, { templatesDir });
   await generateManifestCommand(appManifest);
   await generateSchemaCommand(appManifest);
 }

--- a/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
@@ -21,6 +21,12 @@ import { loadAppManifest } from "#commands/utils";
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
+/**
+ * Regenerates project artifacts after dependencies are installed.
+ * @param appManifest - Validated app configuration used for generation.
+ * @param projectRoot - Resolved project root where artifacts are generated.
+ * @param templatesDir - Optional directory containing generation templates.
+ */
 export async function run(
   appManifest: CommerceAppConfigOutputModel,
   projectRoot: string,

--- a/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
@@ -11,6 +11,7 @@
  */
 
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
+import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
 import { run as generateActionsCommand } from "#commands/generate/actions/main";
@@ -20,13 +21,22 @@ import { loadAppManifest } from "#commands/utils";
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
+/** Options for the postinstall hook. */
+export type PostinstallOptions = {
+  /** Working directory to resolve the project root from. Defaults to the CWD. */
+  cwd?: string;
+  /** The directory to load templates from, for testing purposes. Defaults to the generated actions template root. */
+  templatesDir?: string;
+};
+
 export async function run(
   appManifest: CommerceAppConfigOutputModel,
-  templatesDir?: string,
+  { cwd = process.cwd(), templatesDir }: PostinstallOptions = {},
 ) {
-  await generateActionsCommand(appManifest, { templatesDir });
-  await generateManifestCommand(appManifest);
-  await generateSchemaCommand(appManifest);
+  const projectRoot = await getProjectRootDirectory(cwd);
+  await generateActionsCommand(appManifest, { cwd: projectRoot, templatesDir });
+  await generateManifestCommand(appManifest, projectRoot);
+  await generateSchemaCommand(appManifest, projectRoot);
 }
 
 /** Runs the postinstall hook */

--- a/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/postinstall.ts
@@ -14,37 +14,30 @@ import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
-import { run as generateActionsCommand } from "#commands/generate/actions/main";
-import { run as generateManifestCommand } from "#commands/generate/manifest/main";
-import { run as generateSchemaCommand } from "#commands/generate/schema/main";
+import { run as generateActions } from "#commands/generate/actions/main";
+import { run as generateManifest } from "#commands/generate/manifest/main";
+import { run as generateSchema } from "#commands/generate/schema/main";
 import { loadAppManifest } from "#commands/utils";
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
-/** Options for the postinstall hook. */
-export type PostinstallOptions = {
-  /** Working directory to resolve the project root from. Defaults to the CWD. */
-  cwd?: string;
-  /** The directory to load templates from, for testing purposes. Defaults to the generated actions template root. */
-  templatesDir?: string;
-};
-
 export async function run(
   appManifest: CommerceAppConfigOutputModel,
-  { cwd = process.cwd(), templatesDir }: PostinstallOptions = {},
+  projectRoot: string,
+  templatesDir?: string,
 ) {
-  const projectRoot = await getProjectRootDirectory(cwd);
-  await generateActionsCommand(appManifest, { cwd: projectRoot, templatesDir });
-  await generateManifestCommand(appManifest, projectRoot);
-  await generateSchemaCommand(appManifest, projectRoot);
+  await generateActions(appManifest, projectRoot, templatesDir);
+  await generateManifest(appManifest, projectRoot);
+  await generateSchema(appManifest, projectRoot);
 }
 
 /** Runs the postinstall hook */
 export async function exec() {
   consola.debug("Running lib-app postinstall hook");
   try {
-    const appManifest = await loadAppManifest();
-    await run(appManifest);
+    const projectRoot = await getProjectRootDirectory();
+    const appManifest = await loadAppManifest(projectRoot);
+    await run(appManifest, projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
@@ -15,6 +15,7 @@ import {
   setNodeEnv,
   syncImsCredentials,
 } from "@aio-commerce-sdk/scripting-utils/env";
+import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
 import {
@@ -43,26 +44,37 @@ import type { ExtConfig } from "@aio-commerce-sdk/scripting-utils/yaml/types";
 
 type Extension = "extensibility/1" | "configuration/1" | "backend-ui/2";
 
+/** Options for the pre-app-build hook. */
+export type PreAppBuildOptions = {
+  /** Working directory to resolve the project root from. Defaults to the CWD. */
+  cwd?: string;
+  /** The directory to load templates from, for testing purposes. Defaults to the generated actions template root. */
+  templatesDir?: string;
+};
+
 /**
  * Runs the pre-app-build hook for the given extension.
  * @param extension - The extension to run the hook for.
- * @param cwd - The project directory. Defaults to the current working directory.
- * @param templatesDir - The directory to load templates from, for testing purposes. Defaults to the generated actions template root.
+ * @param options - Working directory and templates directory overrides.
  */
 export async function run(
   extension: Extension,
-  cwd = process.cwd(),
-  templatesDir = TEMPLATES_DIR,
+  {
+    cwd = process.cwd(),
+    templatesDir = TEMPLATES_DIR,
+  }: PreAppBuildOptions = {},
 ) {
-  const appManifest = await loadAppManifest();
-  await prepareRuntimeAppConfigModule(appManifest);
+  const projectRoot = await getProjectRootDirectory(cwd);
+  const appManifest = await loadAppManifest(projectRoot);
+  await prepareRuntimeAppConfigModule(appManifest, projectRoot);
 
   if (extension === "extensibility/1") {
     const { doc: extensibilityExtConfig } = await readExtConfig(
       EXTENSIBILITY_EXTENSION_POINT_ID,
+      projectRoot,
     );
 
-    await generateManifestCommand(appManifest);
+    await generateManifestCommand(appManifest, projectRoot);
     await generateActionFiles(
       appManifest,
       getRuntimeActions(
@@ -71,10 +83,11 @@ export async function run(
       ),
       EXTENSIBILITY_EXTENSION_POINT_ID,
       templatesDir,
+      projectRoot,
     );
 
     consola.info("Syncing IMS credentials...");
-    await syncImsCredentials(cwd);
+    await syncImsCredentials(projectRoot);
 
     return;
   }
@@ -82,9 +95,10 @@ export async function run(
   if (extension === "configuration/1") {
     const { doc: businessConfigExtConfig } = await readExtConfig(
       CONFIGURATION_EXTENSION_POINT_ID,
+      projectRoot,
     );
 
-    await generateSchemaCommand(appManifest);
+    await generateSchemaCommand(appManifest, projectRoot);
     await generateActionFiles(
       appManifest,
       getRuntimeActions(
@@ -93,6 +107,7 @@ export async function run(
       ),
       CONFIGURATION_EXTENSION_POINT_ID,
       templatesDir,
+      projectRoot,
     );
 
     return;
@@ -103,18 +118,20 @@ export async function run(
       const extConfig = await updateExtConfig(
         appManifest,
         BACKEND_UI_V2_EXTENSION_POINT_ID,
+        projectRoot,
       );
 
       if (extConfig.operations?.view) {
-        await prepareWebSourceImportAlias(extConfig);
+        await prepareWebSourceImportAlias(extConfig, projectRoot);
         await generateWebSrc(
           extConfig,
           appManifest.metadata.displayName,
           templatesDir,
+          projectRoot,
         );
 
         // Ship React's production build for the deployed web bundle.
-        await setNodeEnv("production", cwd);
+        await setNodeEnv("production", projectRoot);
       }
     }
     return;

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
@@ -47,7 +47,7 @@ type Extension = "extensibility/1" | "configuration/1" | "backend-ui/2";
 /**
  * Runs the pre-app-build hook for the given extension.
  * @param extension - The extension to run the hook for.
- * @param projectRoot - Resolved project root.
+ * @param projectRoot - Resolved project root containing extension files.
  * @param templatesDir - Directory containing action templates.
  */
 export async function run(

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-build.ts
@@ -31,8 +31,8 @@ import {
   readExtConfig,
   updateExtConfig,
 } from "#commands/generate/actions/lib";
-import { run as generateManifestCommand } from "#commands/generate/manifest/main";
-import { run as generateSchemaCommand } from "#commands/generate/schema/main";
+import { run as generateManifest } from "#commands/generate/manifest/main";
+import { run as generateSchema } from "#commands/generate/schema/main";
 import {
   generateWebSrc,
   prepareWebSourceImportAlias,
@@ -44,27 +44,17 @@ import type { ExtConfig } from "@aio-commerce-sdk/scripting-utils/yaml/types";
 
 type Extension = "extensibility/1" | "configuration/1" | "backend-ui/2";
 
-/** Options for the pre-app-build hook. */
-export type PreAppBuildOptions = {
-  /** Working directory to resolve the project root from. Defaults to the CWD. */
-  cwd?: string;
-  /** The directory to load templates from, for testing purposes. Defaults to the generated actions template root. */
-  templatesDir?: string;
-};
-
 /**
  * Runs the pre-app-build hook for the given extension.
  * @param extension - The extension to run the hook for.
- * @param options - Working directory and templates directory overrides.
+ * @param projectRoot - Resolved project root.
+ * @param templatesDir - Directory containing action templates.
  */
 export async function run(
   extension: Extension,
-  {
-    cwd = process.cwd(),
-    templatesDir = TEMPLATES_DIR,
-  }: PreAppBuildOptions = {},
+  projectRoot: string,
+  templatesDir = TEMPLATES_DIR,
 ) {
-  const projectRoot = await getProjectRootDirectory(cwd);
   const appManifest = await loadAppManifest(projectRoot);
   await prepareRuntimeAppConfigModule(appManifest, projectRoot);
 
@@ -74,7 +64,7 @@ export async function run(
       projectRoot,
     );
 
-    await generateManifestCommand(appManifest, projectRoot);
+    await generateManifest(appManifest, projectRoot);
     await generateActionFiles(
       appManifest,
       getRuntimeActions(
@@ -98,7 +88,7 @@ export async function run(
       projectRoot,
     );
 
-    await generateSchemaCommand(appManifest, projectRoot);
+    await generateSchema(appManifest, projectRoot);
     await generateActionFiles(
       appManifest,
       getRuntimeActions(
@@ -126,8 +116,8 @@ export async function run(
         await generateWebSrc(
           extConfig,
           appManifest.metadata.displayName,
-          templatesDir,
           projectRoot,
+          templatesDir,
         );
 
         // Ship React's production build for the deployed web bundle.
@@ -150,7 +140,8 @@ export async function exec() {
       throw new Error("EXTENSION environment variable is not set");
     }
 
-    await run(rawExtension as Extension);
+    const projectRoot = await getProjectRootDirectory();
+    await run(rawExtension as Extension, projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-dev.ts
@@ -12,14 +12,15 @@
 
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
+import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
 /**
  * Resets the web build back to development by writing `NODE_ENV` to the project `.env`.
- * @param cwd - The project directory. Defaults to the current working directory.
+ * @param projectRoot - Resolved project root containing the `.env` file.
  */
-export async function run(cwd = process.cwd()) {
-  await setNodeEnv("development", cwd);
+export async function run(projectRoot: string) {
+  await setNodeEnv("development", projectRoot);
 }
 
 /** Runs the pre-app-dev hook. */
@@ -27,7 +28,8 @@ export async function exec() {
   consola.debug("Running lib-app pre-app-dev hook");
 
   try {
-    await run();
+    const projectRoot = await getProjectRootDirectory();
+    await run(projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
+++ b/packages/aio-commerce-lib-app/source/commands/hooks/pre-app-run.ts
@@ -12,14 +12,15 @@
 
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import { setNodeEnv } from "@aio-commerce-sdk/scripting-utils/env";
+import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
 /**
  * Resets the web build back to development by writing `NODE_ENV` to the project `.env`.
- * @param cwd - The project directory. Defaults to the current working directory.
+ * @param projectRoot - Resolved project root containing the `.env` file.
  */
-export async function run(cwd = process.cwd()) {
-  await setNodeEnv("development", cwd);
+export async function run(projectRoot: string) {
+  await setNodeEnv("development", projectRoot);
 }
 
 /** Runs the pre-app-run hook. */
@@ -27,7 +28,8 @@ export async function exec() {
   consola.debug("Running lib-app pre-app-run hook");
 
   try {
-    await run();
+    const projectRoot = await getProjectRootDirectory();
+    await run(projectRoot);
   } catch (error) {
     if (error instanceof CommerceSdkValidationError) {
       consola.error(error.display());

--- a/packages/aio-commerce-lib-app/source/commands/init/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/lib.ts
@@ -30,9 +30,9 @@ import {
   EXTENSIBILITY_EXTENSION_POINT_ID,
   PACKAGE_JSON_FILE,
 } from "#commands/constants";
-import { run as generateActionsCommand } from "#commands/generate/actions/main";
-import { run as generateManifestCommand } from "#commands/generate/manifest/main";
-import { run as generateSchemaCommand } from "#commands/generate/schema/main";
+import { run as generateActions } from "#commands/generate/actions/main";
+import { run as generateManifest } from "#commands/generate/manifest/main";
+import { run as generateSchema } from "#commands/generate/schema/main";
 import { prettierFormat, runInstall } from "#commands/utils";
 import {
   getConfigDomains,
@@ -59,15 +59,15 @@ import type { InitFlags } from "./main";
 
 /** Ensure app.commerce.config file exists, allow creating if it doesn't. When options are provided, prompts are skipped. */
 export async function ensureCommerceAppConfig(
-  cwd = process.cwd(),
+  projectRoot: string,
   formatConfig = true,
   flags?: InitFlags,
 ) {
-  const configFilePath = await resolveCommerceAppConfig(cwd);
+  const configFilePath = await resolveCommerceAppConfig(projectRoot);
 
   if (configFilePath !== null) {
     try {
-      const config = await readCommerceAppConfig(cwd);
+      const config = await readCommerceAppConfig(projectRoot);
       const validatedConfig = validateCommerceAppConfig(config);
       consola.success(
         `${COMMERCE_APP_CONFIG_FILE} found and is valid. Continuing...`,
@@ -108,8 +108,11 @@ export async function ensureCommerceAppConfig(
     : await promptForCommerceAppConfig();
 
   try {
-    const configContent = await getDefaultCommerceAppConfig(cwd, answers);
-    const path = join(await getProjectRootDirectory(cwd), answers.configFile);
+    const configContent = await getDefaultCommerceAppConfig(
+      projectRoot,
+      answers,
+    );
+    const path = join(projectRoot, answers.configFile);
     consola.info(`Creating ${answers.configFile}...`);
 
     if (formatConfig) {
@@ -119,7 +122,7 @@ export async function ensureCommerceAppConfig(
       await writeFile(path, configContent, "utf-8");
     }
 
-    const createdConfig = await parseCommerceAppConfig(cwd);
+    const createdConfig = await parseCommerceAppConfig(projectRoot);
     consola.success(`Created ${answers.configFile}`);
 
     return {
@@ -161,29 +164,29 @@ export async function ensurePackageJson(cwd = process.cwd()) {
     consola.success("Wrote package.json");
   }
 
-  // Detect after writing the skeleton — `detectPackageManager` walks up for a
-  // `package.json`, and the fresh-scaffold path has none until we've written one.
-  const packageManager = await detectPackageManager(cwd);
+  const projectRoot = await getProjectRootDirectory(cwd);
+  const packageManager = await detectPackageManager(projectRoot);
   const execCommand = getExecCommand(packageManager);
 
   return {
     execCommand,
     packageJson,
     packageManager,
+    projectRoot,
   };
 }
 
 /**
  * Register the `hooks postinstall` script in package.json.
  * @param execCommand - Prefix for running local binaries (e.g. `pnpm exec`, `npx`)
- * @param cwd - Directory containing the package.json to update
+ * @param projectRoot - Resolved project root containing the package.json to update
  */
 export async function writePostinstallHook(
   execCommand: string,
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
   const postinstallScript = `${execCommand} aio-commerce-lib-app hooks postinstall`;
-  const pkg = await loadPackageJson(cwd);
+  const pkg = await loadPackageJson(projectRoot);
   if (pkg === null) {
     throw new Error("Could not find package.json.");
   }
@@ -219,14 +222,12 @@ export async function writePostinstallHook(
 /** Ensure app.config.yaml has the extension reference */
 export async function ensureAppConfig(
   domains: Set<CommerceAppConfigDomain>,
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
-  const rootDirectory = await getProjectRootDirectory(cwd);
-
   if (domains.has("businessConfig.schema")) {
     await addExtensionPointToAppConfig(
       CONFIGURATION_EXTENSION_POINT_ID,
-      rootDirectory,
+      projectRoot,
       " This extension is required for business configuration. Do not remove.",
     );
   }
@@ -234,7 +235,7 @@ export async function ensureAppConfig(
   if (domains.has("adminUi")) {
     await addExtensionPointToAppConfig(
       BACKEND_UI_V2_EXTENSION_POINT_ID,
-      rootDirectory,
+      projectRoot,
       " This extension is required for Admin UI. Do not remove.",
     );
   }
@@ -242,7 +243,7 @@ export async function ensureAppConfig(
   // This is always needed (to get the app config at least)
   await addExtensionPointToAppConfig(
     EXTENSIBILITY_EXTENSION_POINT_ID,
-    rootDirectory,
+    projectRoot,
     " This extension is required for app management. Do not remove.",
   );
 }
@@ -251,12 +252,12 @@ export async function ensureAppConfig(
  * Install the domain-specific dependencies derived from the selected domains.
  * @param packageManager - The detected package manager
  * @param domains - Domains enabled in the commerce app config
- * @param cwd - Working directory for the install command
+ * @param projectRoot - Resolved project root for the install command
  */
 export function installDependencies(
   packageManager: PackageManager,
   domains: Set<CommerceAppConfigDomain>,
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
   const packages: string[] = [];
 
@@ -269,20 +270,19 @@ export function installDependencies(
     return;
   }
 
-  runInstall(packageManager, packages, cwd);
+  runInstall(packageManager, packages, projectRoot);
 }
 
 /** Run the generation command */
 export async function runGeneration(
   appConfig: CommerceAppConfigOutputModel,
   execCommand: string,
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
   try {
-    const projectRoot = await getProjectRootDirectory(cwd);
-    await generateActionsCommand(appConfig, { cwd: projectRoot });
-    await generateManifestCommand(appConfig, projectRoot);
-    await generateSchemaCommand(appConfig, projectRoot);
+    await generateActions(appConfig, projectRoot);
+    await generateManifest(appConfig, projectRoot);
+    await generateSchema(appConfig, projectRoot);
   } catch (error) {
     throw new Error(
       `Failed to run generation command. Please run manually: ${execCommand} aio-commerce-lib-app generate all`,
@@ -296,14 +296,12 @@ export async function runGeneration(
 /** Ensure install.yaml has the extension reference */
 export async function ensureInstallYaml(
   domains: Set<CommerceAppConfigDomain>,
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
-  const rootDirectory = await getProjectRootDirectory(cwd);
-
   if (domains.has("businessConfig.schema")) {
     await addExtensionPointToInstallYaml(
       CONFIGURATION_EXTENSION_POINT_ID,
-      rootDirectory,
+      projectRoot,
       " This extension is required for business configuration. Do not remove.",
     );
   }
@@ -311,7 +309,7 @@ export async function ensureInstallYaml(
   if (domains.has("adminUi")) {
     await addExtensionPointToInstallYaml(
       BACKEND_UI_V2_EXTENSION_POINT_ID,
-      rootDirectory,
+      projectRoot,
       " This extension is required for Admin UI. Do not remove.",
     );
   }
@@ -319,7 +317,7 @@ export async function ensureInstallYaml(
   // This is always needed (to get the app config at least)
   await addExtensionPointToInstallYaml(
     EXTENSIBILITY_EXTENSION_POINT_ID,
-    rootDirectory,
+    projectRoot,
     " This extension is required for app management. Do not remove.",
   );
 }

--- a/packages/aio-commerce-lib-app/source/commands/init/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/lib.ts
@@ -57,7 +57,12 @@ import type { CommerceAppConfigDomain } from "#config/index";
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 import type { InitFlags } from "./main";
 
-/** Ensure app.commerce.config file exists, allow creating if it doesn't. When options are provided, prompts are skipped. */
+/**
+ * Ensures a valid app configuration exists, creating one when requested.
+ * @param projectRoot - Resolved project root containing the app configuration.
+ * @param formatConfig - Whether to format a newly created configuration.
+ * @param flags - Non-interactive answers; prompts are used when omitted.
+ */
 export async function ensureCommerceAppConfig(
   projectRoot: string,
   formatConfig = true,
@@ -138,8 +143,8 @@ export async function ensureCommerceAppConfig(
 }
 
 /**
- * Ensure a package.json exists and detect the package manager.
- * @param cwd - Directory to check; defaults to `process.cwd()`
+ * Ensures package.json exists, then resolves the project root and package manager.
+ * @param cwd - Directory in which to create or discover package.json.
  */
 export async function ensurePackageJson(cwd = process.cwd()) {
   const existing = await readPackageJson(cwd);
@@ -177,9 +182,9 @@ export async function ensurePackageJson(cwd = process.cwd()) {
 }
 
 /**
- * Register the `hooks postinstall` script in package.json.
- * @param execCommand - Prefix for running local binaries (e.g. `pnpm exec`, `npx`)
- * @param projectRoot - Resolved project root containing the package.json to update
+ * Registers the postinstall hook in package.json.
+ * @param execCommand - Prefix for running local binaries, such as `pnpm exec`.
+ * @param projectRoot - Resolved project root containing package.json.
  */
 export async function writePostinstallHook(
   execCommand: string,
@@ -219,7 +224,11 @@ export async function writePostinstallHook(
   consola.success(`Added postinstall script to ${PACKAGE_JSON_FILE}`);
 }
 
-/** Ensure app.config.yaml has the extension reference */
+/**
+ * Ensures app.config.yaml references the enabled domain extensions.
+ * @param domains - Domains enabled in the app configuration.
+ * @param projectRoot - Resolved project root containing app.config.yaml.
+ */
 export async function ensureAppConfig(
   domains: Set<CommerceAppConfigDomain>,
   projectRoot: string,
@@ -273,7 +282,12 @@ export function installDependencies(
   runInstall(packageManager, packages, projectRoot);
 }
 
-/** Run the generation command */
+/**
+ * Generates all project artifacts during initialization.
+ * @param appConfig - Validated app configuration used for generation.
+ * @param execCommand - Command prefix included in manual recovery guidance.
+ * @param projectRoot - Resolved project root where artifacts are generated.
+ */
 export async function runGeneration(
   appConfig: CommerceAppConfigOutputModel,
   execCommand: string,
@@ -293,7 +307,11 @@ export async function runGeneration(
   }
 }
 
-/** Ensure install.yaml has the extension reference */
+/**
+ * Ensures install.yaml references the enabled domain extensions.
+ * @param domains - Domains enabled in the app configuration.
+ * @param projectRoot - Resolved project root containing install.yaml.
+ */
 export async function ensureInstallYaml(
   domains: Set<CommerceAppConfigDomain>,
   projectRoot: string,

--- a/packages/aio-commerce-lib-app/source/commands/init/lib.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/lib.ts
@@ -276,11 +276,13 @@ export function installDependencies(
 export async function runGeneration(
   appConfig: CommerceAppConfigOutputModel,
   execCommand: string,
+  cwd = process.cwd(),
 ) {
   try {
-    await generateActionsCommand(appConfig);
-    await generateManifestCommand(appConfig);
-    await generateSchemaCommand(appConfig);
+    const projectRoot = await getProjectRootDirectory(cwd);
+    await generateActionsCommand(appConfig, { cwd: projectRoot });
+    await generateManifestCommand(appConfig, projectRoot);
+    await generateSchemaCommand(appConfig, projectRoot);
   } catch (error) {
     throw new Error(
       `Failed to run generation command. Please run manually: ${execCommand} aio-commerce-lib-app generate all`,

--- a/packages/aio-commerce-lib-app/source/commands/init/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/main.ts
@@ -49,17 +49,20 @@ export type InitFlags = {
 /** Extra options that can be given to the `init` handler that would not necessarily become CLI flags. */
 type InitExtraOptions = {
   formatConfig?: boolean;
+  /** Working directory to initialize in. Defaults to the CWD. */
+  cwd?: string;
 };
 
 /** Initialize the project */
 export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   consola.start("Initializing app...");
 
-  const { execCommand, packageManager } = await ensurePackageJson();
-  runInstall(packageManager, REQUIRED_DEPENDENCIES);
+  const cwd = extraOptions?.cwd ?? process.cwd();
+  const { execCommand, packageManager } = await ensurePackageJson(cwd);
+  runInstall(packageManager, REQUIRED_DEPENDENCIES, cwd);
 
   const configResult = await ensureCommerceAppConfig(
-    process.cwd(),
+    cwd,
     extraOptions?.formatConfig ?? true,
     flags,
   );
@@ -67,13 +70,13 @@ export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   const { config, domains, configFormat } = configResult;
   const isTypeScriptProject = configFormat === "ts";
 
-  installDependencies(packageManager, domains);
+  installDependencies(packageManager, domains, cwd);
   if (isTypeScriptProject) {
-    await scaffoldTypeScriptProject(packageManager);
+    await scaffoldTypeScriptProject(packageManager, cwd);
   }
 
   // Sync the package.json with the app config
-  const pkg = await loadPackageJson(process.cwd());
+  const pkg = await loadPackageJson(cwd);
   if (pkg === null) {
     throw new Error("Could not find package.json.");
   }
@@ -87,16 +90,16 @@ export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   await pkg.save();
 
   if (isTypeScriptProject) {
-    await syncActionsTypecheckScript();
+    await syncActionsTypecheckScript(cwd);
   }
 
-  await runGeneration(config, execCommand);
-  await ensureAppConfig(domains);
-  await ensureInstallYaml(domains);
+  await runGeneration(config, execCommand, cwd);
+  await ensureAppConfig(domains, cwd);
+  await ensureInstallYaml(domains, cwd);
 
   // Register the postinstall hook last so future installs run after init has
   // created the files the hook depends on.
-  await writePostinstallHook(execCommand);
+  await writePostinstallHook(execCommand, cwd);
 
   consola.success("Initialization complete!");
   consola.box(

--- a/packages/aio-commerce-lib-app/source/commands/init/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/main.ts
@@ -46,14 +46,19 @@ export type InitFlags = {
   domains: CommerceAppConfigDomain[];
 };
 
-/** Extra options that can be given to the `init` handler that would not necessarily become CLI flags. */
+/** Internal execution options for the init handler. */
 type InitExtraOptions = {
+  /** Whether to format a newly created app configuration. */
   formatConfig?: boolean;
   /** Working directory to initialize in. Defaults to the CWD. */
   cwd?: string;
 };
 
-/** Initialize the project */
+/**
+ * Initializes a Commerce App project.
+ * @param flags - Non-interactive initialization answers.
+ * @param extraOptions - Internal formatting and working-directory overrides.
+ */
 export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   consola.start("Initializing app...");
 

--- a/packages/aio-commerce-lib-app/source/commands/init/main.ts
+++ b/packages/aio-commerce-lib-app/source/commands/init/main.ts
@@ -58,11 +58,13 @@ export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   consola.start("Initializing app...");
 
   const cwd = extraOptions?.cwd ?? process.cwd();
-  const { execCommand, packageManager } = await ensurePackageJson(cwd);
-  runInstall(packageManager, REQUIRED_DEPENDENCIES, cwd);
+  const { execCommand, packageManager, projectRoot } =
+    await ensurePackageJson(cwd);
+
+  runInstall(packageManager, REQUIRED_DEPENDENCIES, projectRoot);
 
   const configResult = await ensureCommerceAppConfig(
-    cwd,
+    projectRoot,
     extraOptions?.formatConfig ?? true,
     flags,
   );
@@ -70,13 +72,13 @@ export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   const { config, domains, configFormat } = configResult;
   const isTypeScriptProject = configFormat === "ts";
 
-  installDependencies(packageManager, domains, cwd);
+  installDependencies(packageManager, domains, projectRoot);
   if (isTypeScriptProject) {
-    await scaffoldTypeScriptProject(packageManager, cwd);
+    await scaffoldTypeScriptProject(packageManager, projectRoot);
   }
 
   // Sync the package.json with the app config
-  const pkg = await loadPackageJson(cwd);
+  const pkg = await loadPackageJson(projectRoot);
   if (pkg === null) {
     throw new Error("Could not find package.json.");
   }
@@ -90,16 +92,16 @@ export async function run(flags?: InitFlags, extraOptions?: InitExtraOptions) {
   await pkg.save();
 
   if (isTypeScriptProject) {
-    await syncActionsTypecheckScript(cwd);
+    await syncActionsTypecheckScript(projectRoot);
   }
 
-  await runGeneration(config, execCommand, cwd);
-  await ensureAppConfig(domains, cwd);
-  await ensureInstallYaml(domains, cwd);
+  await runGeneration(config, execCommand, projectRoot);
+  await ensureAppConfig(domains, projectRoot);
+  await ensureInstallYaml(domains, projectRoot);
 
   // Register the postinstall hook last so future installs run after init has
   // created the files the hook depends on.
-  await writePostinstallHook(execCommand, cwd);
+  await writePostinstallHook(execCommand, projectRoot);
 
   consola.success("Initialization complete!");
   consola.box(

--- a/packages/aio-commerce-lib-app/source/commands/typescript.ts
+++ b/packages/aio-commerce-lib-app/source/commands/typescript.ts
@@ -18,7 +18,6 @@ import {
   appendCommand,
   detectPackageManager,
   getPackageDependencyInstallPlan,
-  getProjectRootDirectory,
   getRunScriptCommand,
   loadPackageJson,
 } from "@aio-commerce-sdk/scripting-utils/project";
@@ -155,13 +154,12 @@ async function installTypeScriptDependencies(
 /**
  * Scaffold the files and dependencies for a new TypeScript Commerce project.
  * @param packageManager Package manager used by the initialized project.
- * @param cwd Directory within the App Builder project.
+ * @param projectRoot Resolved project root.
  */
 export async function scaffoldTypeScriptProject(
   packageManager: PackageManager,
-  cwd = process.cwd(),
+  projectRoot: string,
 ) {
-  const projectRoot = await getProjectRootDirectory(cwd);
   await scaffoldWebpackConfig(projectRoot);
   await scaffoldTypeScriptConfig(projectRoot);
   await installTypeScriptDependencies(packageManager, projectRoot);
@@ -171,16 +169,15 @@ export async function scaffoldTypeScriptProject(
  * Add a generated typecheck script and compose it into the root typecheck script.
  * @param scriptName Generated package script name.
  * @param command TypeScript command run by the generated script.
- * @param cwd Directory within the App Builder project.
+ * @param projectRoot Resolved project root.
  */
 async function syncTypecheckScript(
   scriptName:
     | typeof ACTIONS_TYPECHECK_SCRIPT
     | typeof WEB_SOURCE_TYPECHECK_SCRIPT,
   command: string,
-  cwd: string,
+  projectRoot: string,
 ) {
-  const projectRoot = await getProjectRootDirectory(cwd);
   const pkg = await loadPackageJson(projectRoot);
   if (pkg === null) {
     throw new Error("Could not find package.json.");
@@ -208,24 +205,24 @@ async function syncTypecheckScript(
 
 /**
  * Add the Runtime actions typecheck script to a project.
- * @param cwd Directory within the App Builder project.
+ * @param projectRoot Resolved project root.
  */
-export async function syncActionsTypecheckScript(cwd = process.cwd()) {
+export async function syncActionsTypecheckScript(projectRoot: string) {
   await syncTypecheckScript(
     ACTIONS_TYPECHECK_SCRIPT,
     ACTIONS_TYPECHECK_COMMAND,
-    cwd,
+    projectRoot,
   );
 }
 
 /**
  * Add the web-src typecheck script to a project.
- * @param cwd Directory within the App Builder project.
+ * @param projectRoot Resolved project root.
  */
-export async function syncWebSourceTypecheckScript(cwd = process.cwd()) {
+export async function syncWebSourceTypecheckScript(projectRoot: string) {
   await syncTypecheckScript(
     WEB_SOURCE_TYPECHECK_SCRIPT,
     WEB_SOURCE_TYPECHECK_COMMAND,
-    cwd,
+    projectRoot,
   );
 }

--- a/packages/aio-commerce-lib-app/source/commands/utils.ts
+++ b/packages/aio-commerce-lib-app/source/commands/utils.ts
@@ -59,7 +59,7 @@ export function prettierFormat(content: string, filepath: string) {
 
 /**
  * Load the app commerce config.
- * @param projectRoot - Resolved project root.
+ * @param projectRoot - Resolved project root containing the app configuration.
  */
 export async function loadAppManifest(projectRoot: string) {
   // If the config file is invalid or missing, we want to fail early before generating any files
@@ -173,7 +173,7 @@ export function hasDynamicAppConfig(appConfig: CommerceAppConfigOutputModel) {
 /**
  * Whether preserving the app config requires generating a JavaScript module.
  * @param appConfig - The parsed app config.
- * @param projectRoot - Resolved project root.
+ * @param projectRoot - Resolved project root containing the source config.
  */
 export async function requiresJavaScriptAppConfig(
   appConfig: CommerceAppConfigOutputModel,

--- a/packages/aio-commerce-lib-app/source/commands/utils.ts
+++ b/packages/aio-commerce-lib-app/source/commands/utils.ts
@@ -57,10 +57,13 @@ export function prettierFormat(content: string, filepath: string) {
   });
 }
 
-/** Load the app commerce config */
-export async function loadAppManifest() {
+/**
+ * Load the app commerce config.
+ * @param projectRoot - Project root to resolve the config file from. Defaults to the CWD.
+ */
+export async function loadAppManifest(projectRoot = process.cwd()) {
   // If the config file is invalid or missing, we want to fail early before generating any files
-  const appConfig = await parseCommerceAppConfig();
+  const appConfig = await parseCommerceAppConfig(projectRoot);
   consola.debug("Loaded app commerce config");
 
   return appConfig;
@@ -167,12 +170,18 @@ export function hasDynamicAppConfig(appConfig: CommerceAppConfigOutputModel) {
   return Array.isArray(schema) && hasDynamicSchema(schema);
 }
 
-/** Whether preserving the app config requires generating a JavaScript module. */
+/**
+ * Whether preserving the app config requires generating a JavaScript module.
+ * @param appConfig - The parsed app config.
+ * @param projectRoot - Project root to resolve the config file from. Defaults to the CWD.
+ */
 export async function requiresJavaScriptAppConfig(
   appConfig: CommerceAppConfigOutputModel,
+  projectRoot = process.cwd(),
 ) {
   return (
-    hasDynamicAppConfig(appConfig) || (await hasNamedCommerceAppConfigExports())
+    hasDynamicAppConfig(appConfig) ||
+    (await hasNamedCommerceAppConfigExports(projectRoot))
   );
 }
 

--- a/packages/aio-commerce-lib-app/source/commands/utils.ts
+++ b/packages/aio-commerce-lib-app/source/commands/utils.ts
@@ -59,9 +59,9 @@ export function prettierFormat(content: string, filepath: string) {
 
 /**
  * Load the app commerce config.
- * @param projectRoot - Project root to resolve the config file from. Defaults to the CWD.
+ * @param projectRoot - Resolved project root.
  */
-export async function loadAppManifest(projectRoot = process.cwd()) {
+export async function loadAppManifest(projectRoot: string) {
   // If the config file is invalid or missing, we want to fail early before generating any files
   const appConfig = await parseCommerceAppConfig(projectRoot);
   consola.debug("Loaded app commerce config");
@@ -173,11 +173,11 @@ export function hasDynamicAppConfig(appConfig: CommerceAppConfigOutputModel) {
 /**
  * Whether preserving the app config requires generating a JavaScript module.
  * @param appConfig - The parsed app config.
- * @param projectRoot - Project root to resolve the config file from. Defaults to the CWD.
+ * @param projectRoot - Resolved project root.
  */
 export async function requiresJavaScriptAppConfig(
   appConfig: CommerceAppConfigOutputModel,
-  projectRoot = process.cwd(),
+  projectRoot: string,
 ) {
   return (
     hasDynamicAppConfig(appConfig) ||

--- a/packages/aio-commerce-lib-app/test/fixtures/project.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/project.ts
@@ -163,11 +163,9 @@ export async function withTempProject(
   callback: (tempDir: string) => void | Promise<void>,
 ) {
   await withTempFiles(files, async (tempDir) => {
-    // Point process.cwd() at the temp project instead of doing a real chdir.
-    // Commands resolve the project root from the CWD, but a real process.chdir
-    // can strand the process on a deleted directory when a test is interrupted
-    // mid-run, cascading ENOENT into unrelated tests. Overriding the getter
-    // avoids that race and nests correctly (each scope restores its parent's).
+    // Point process.cwd() at the temp project instead of a real chdir: a real
+    // chdir can strand the process on a deleted directory if a test is
+    // interrupted mid-run, cascading ENOENT into unrelated tests.
     const originalCwd = process.cwd;
     process.cwd = () => tempDir;
     try {

--- a/packages/aio-commerce-lib-app/test/fixtures/project.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/project.ts
@@ -187,7 +187,7 @@ export async function withGeneratedProject(
   await withTempProject(
     { ...EMPTY_PROJECT, ...makeTemplateFiles() },
     async (tempDir) => {
-      await runGeneration(config, "npx");
+      await runGeneration(config, "npx", tempDir);
       await assertions(tempDir);
     },
   );

--- a/packages/aio-commerce-lib-app/test/fixtures/project.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/project.ts
@@ -13,10 +13,7 @@
 import { join } from "node:path";
 import { inspect } from "node:util";
 
-import {
-  withChdir,
-  withTempFiles,
-} from "@aio-commerce-sdk/scripting-utils/filesystem";
+import { withTempFiles } from "@aio-commerce-sdk/scripting-utils/filesystem";
 import { stringify } from "yaml";
 
 import {
@@ -166,7 +163,18 @@ export async function withTempProject(
   callback: (tempDir: string) => void | Promise<void>,
 ) {
   await withTempFiles(files, async (tempDir) => {
-    await withChdir(tempDir, () => callback(tempDir));
+    // Point process.cwd() at the temp project instead of doing a real chdir.
+    // Commands resolve the project root from the CWD, but a real process.chdir
+    // can strand the process on a deleted directory when a test is interrupted
+    // mid-run, cascading ENOENT into unrelated tests. Overriding the getter
+    // avoids that race and nests correctly (each scope restores its parent's).
+    const originalCwd = process.cwd;
+    process.cwd = () => tempDir;
+    try {
+      await callback(tempDir);
+    } finally {
+      process.cwd = originalCwd;
+    }
   });
 }
 

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -14,6 +14,9 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
+// Generate actions takes an explicit projectRoot, so these tests seed a temp
+// project and pass it in directly instead of mutating the process CWD.
+import { withTempFiles } from "@aio-commerce-sdk/scripting-utils/filesystem";
 import { consola } from "consola";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -88,10 +91,13 @@ describe("commands/generate/actions", () => {
 
   describe("run", () => {
     test("generates app-config action for minimal config", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(minimalValidConfig, tempDir);
+          await run(minimalValidConfig, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const actionsDir = getActionsDir(
             tempDir,
@@ -104,10 +110,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("generates ext.config.yaml for extensibility extension point", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(minimalValidConfig, tempDir);
+          await run(minimalValidConfig, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const extConfigPath = join(
             tempDir,
@@ -121,10 +130,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("generates business configuration actions when business config schema is present", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithBusinessConfig, tempDir);
+          await run(configWithBusinessConfig, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const businessActionsDir = getActionsDir(
             tempDir,
@@ -140,10 +152,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("generates installation action with custom scripts loader", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithOneScript, tempDir);
+          await run(configWithOneScript, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const actionsDir = getActionsDir(
             tempDir,
@@ -160,10 +175,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("uses the app config alias when business config schema is static", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithBusinessConfig, tempDir);
+          await run(configWithBusinessConfig, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const configPath = join(
             getActionsDir(tempDir, CONFIGURATION_EXTENSION_POINT_ID),
@@ -189,7 +207,7 @@ describe("commands/generate/actions", () => {
     });
 
     test("uses the app config alias when business config schema is dynamic", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           ...EMPTY_PROJECT,
           ...makeTemplateFiles(),
@@ -197,7 +215,10 @@ describe("commands/generate/actions", () => {
           "package.json": JSON.stringify({ type: "module" }),
         },
         async (tempDir) => {
-          await run(configWithDynamicListOptions, tempDir);
+          await run(configWithDynamicListOptions, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const configPath = join(
             getActionsDir(tempDir, CONFIGURATION_EXTENSION_POINT_ID),
@@ -227,14 +248,17 @@ describe("commands/generate/actions", () => {
     });
 
     test("generates a runtime app config module and #app.commerce.config alias for a JS config file", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           "app.commerce.config.js": dynamicOptionsConfigFile,
           "package.json": JSON.stringify({ type: "module" }),
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run(configWithDynamicListOptions, tempDir);
+          await run(configWithDynamicListOptions, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
           expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -262,13 +286,16 @@ describe("commands/generate/actions", () => {
     });
 
     test("generates a JavaScript config module when a static config has named exports", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           ...MINIMAL_PROJECT_WITH_NAMED_EXPORT,
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run(minimalValidConfig, tempDir);
+          await run(minimalValidConfig, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
           expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -282,14 +309,17 @@ describe("commands/generate/actions", () => {
     test(
       "bundles a TypeScript app config for JavaScript actions",
       async () => {
-        await withTempProject(
+        await withTempFiles(
           {
             "app.commerce.config.ts": dynamicOptionsConfigFileTs,
             "package.json": JSON.stringify({ type: "module" }),
             ...makeTemplateFiles(),
           },
           async (tempDir) => {
-            await run(configWithDynamicListOptions, tempDir);
+            await run(configWithDynamicListOptions, {
+              cwd: tempDir,
+              templatesDir: tempDir,
+            });
 
             const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
             expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -324,8 +354,10 @@ describe("commands/generate/actions", () => {
             "package.json": JSON.stringify({ type: "module" }),
             ...makeTemplateFiles(),
           },
-          async () => {
-            await expect(run(configWithDynamicListOptions)).rejects.toThrow(
+          async (tempDir) => {
+            await expect(
+              run(configWithDynamicListOptions, { cwd: tempDir }),
+            ).rejects.toThrow(
               "Could not bundle the TypeScript app config with esbuild@",
             );
           },
@@ -337,14 +369,17 @@ describe("commands/generate/actions", () => {
     test.each(["ts", "mts", "cts"] as const)(
       "keeps JavaScript actions for a .%s config outside init",
       async (extension) => {
-        await withTempProject(
+        await withTempFiles(
           {
             [`app.commerce.config.${extension}`]: `export default ${JSON.stringify(minimalValidConfig)};`,
             "package.json": JSON.stringify({ type: "module" }),
             ...makeTemplateFiles(),
           },
           async (tempDir) => {
-            await run(minimalValidConfig, tempDir);
+            await run(minimalValidConfig, {
+              cwd: tempDir,
+              templatesDir: tempDir,
+            });
 
             const actionsDir = getActionsDir(
               tempDir,
@@ -365,7 +400,7 @@ describe("commands/generate/actions", () => {
     );
 
     test("writes a JSON passthrough module and #app.commerce.config alias for static config", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           ...EMPTY_PROJECT,
           ...makeTemplateFiles(),
@@ -375,7 +410,10 @@ describe("commands/generate/actions", () => {
           [getManifestPath()]: JSON.stringify({ metadata: { id: "static" } }),
         },
         async (tempDir) => {
-          await run(configWithBusinessConfig, tempDir);
+          await run(configWithBusinessConfig, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
           expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -401,10 +439,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("includes workerProcess for worker mass actions in backend-ui/2 ext.config.yaml", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithFullAdminUiV2, tempDir);
+          await run(configWithFullAdminUiV2, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const extConfigPath = join(
             tempDir,
@@ -420,10 +461,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("generates ext.config.yaml for backend-ui/2 with view and web but no workerProcess when only adminUi.menu is configured", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, tempDir);
+          await run(configWithAdminUiMenu, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const extConfigPath = join(
             tempDir,
@@ -443,10 +487,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("scaffolds web-src for backend-ui/2 when a view operation is generated", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, tempDir);
+          await run(configWithAdminUiMenu, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const webSrcDir = join(
             tempDir,
@@ -545,14 +592,17 @@ describe("commands/generate/actions", () => {
     });
 
     test("scaffolds TSX web-src files when the app config is TypeScript", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           ...makeProjectFiles(configWithAdminUiMenu),
           ...makeTemplateFiles(),
           "package-lock.json": "{}",
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, tempDir);
+          await run(configWithAdminUiMenu, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const webSrcDir = join(
             tempDir,
@@ -621,14 +671,17 @@ describe("commands/generate/actions", () => {
         "index.html",
       );
 
-      await withTempProject(
+      await withTempFiles(
         {
           ...EMPTY_PROJECT,
           ...makeTemplateFiles(),
           [entrypoint]: "<html>custom</html>",
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, tempDir);
+          await run(configWithAdminUiMenu, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const entrypointPath = join(tempDir, entrypoint);
           expect(await readFile(entrypointPath, "utf-8")).toBe(
@@ -662,7 +715,7 @@ describe("commands/generate/actions", () => {
     });
 
     test("throws when an installed web-src dependency is incompatible", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           ...EMPTY_PROJECT,
           ...makeTemplateFiles(),
@@ -673,7 +726,9 @@ describe("commands/generate/actions", () => {
           }),
         },
         async (tempDir) => {
-          await expect(run(configWithAdminUiMenu, tempDir)).rejects.toThrow(
+          await expect(
+            run(configWithAdminUiMenu, { cwd: tempDir, templatesDir: tempDir }),
+          ).rejects.toThrow(
             "Cannot scaffold web-src because installed dependencies are incompatible",
           );
 
@@ -697,14 +752,17 @@ describe("commands/generate/actions", () => {
         ),
       );
 
-      await withTempProject(
+      await withTempFiles(
         {
           ...EMPTY_PROJECT,
           ...makeTemplateFiles(),
           ...installedDependencies,
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, tempDir);
+          await run(configWithAdminUiMenu, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const webSrcDir = join(
             tempDir,
@@ -725,10 +783,13 @@ describe("commands/generate/actions", () => {
     });
 
     test("does not scaffold web-src or write the #web/* alias when adminUi has no view operation", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithWorkerMassActions, tempDir);
+          await run(configWithWorkerMassActions, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const extensionDir = join(
             tempDir,
@@ -748,13 +809,16 @@ describe("commands/generate/actions", () => {
     });
 
     test("scaffolds JSX web-src files when a JavaScript app config file exists", async () => {
-      await withTempProject(
+      await withTempFiles(
         {
           ...makeProjectFiles(configWithAdminUiMenu, "cjs"),
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, tempDir);
+          await run(configWithAdminUiMenu, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const webSrcDir = join(
             tempDir,
@@ -778,21 +842,24 @@ describe("commands/generate/actions", () => {
     test("throws when installing web-src dependencies fails", async () => {
       mockSpawnSync.mockReturnValueOnce({ status: 1 });
 
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await expect(run(configWithAdminUiMenu, tempDir)).rejects.toThrow(
-            "Failed to install dependencies automatically",
-          );
+          await expect(
+            run(configWithAdminUiMenu, { cwd: tempDir, templatesDir: tempDir }),
+          ).rejects.toThrow("Failed to install dependencies automatically");
         },
       );
     });
 
     test("generates ext.config.yaml for backend-ui/2 when adminUi is configured", async () => {
-      await withTempProject(
+      await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithFullAdminUiV2, tempDir);
+          await run(configWithFullAdminUiV2, {
+            cwd: tempDir,
+            templatesDir: tempDir,
+          });
 
           const extConfigPath = join(
             tempDir,

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -15,7 +15,7 @@ import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
 // Generate actions takes an explicit projectRoot, so these tests seed a temp
-// project and pass it in directly instead of mutating the process CWD.
+// project and pass it in directly.
 import { withTempFiles } from "@aio-commerce-sdk/scripting-utils/filesystem";
 import { consola } from "consola";
 import { afterEach, describe, expect, test, vi } from "vitest";

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -361,6 +361,7 @@ describe("commands/generate/actions", () => {
           },
         );
       },
+      TS_BUNDLE_TIMEOUT_MS,
     );
 
     test("writes a JSON passthrough module and #app.commerce.config alias for static config", async () => {

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/actions.test.ts
@@ -94,10 +94,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(minimalValidConfig, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(minimalValidConfig, tempDir, tempDir);
 
           const actionsDir = getActionsDir(
             tempDir,
@@ -113,10 +110,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(minimalValidConfig, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(minimalValidConfig, tempDir, tempDir);
 
           const extConfigPath = join(
             tempDir,
@@ -133,10 +127,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithBusinessConfig, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithBusinessConfig, tempDir, tempDir);
 
           const businessActionsDir = getActionsDir(
             tempDir,
@@ -155,10 +146,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithOneScript, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithOneScript, tempDir, tempDir);
 
           const actionsDir = getActionsDir(
             tempDir,
@@ -178,10 +166,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithBusinessConfig, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithBusinessConfig, tempDir, tempDir);
 
           const configPath = join(
             getActionsDir(tempDir, CONFIGURATION_EXTENSION_POINT_ID),
@@ -215,10 +200,7 @@ describe("commands/generate/actions", () => {
           "package.json": JSON.stringify({ type: "module" }),
         },
         async (tempDir) => {
-          await run(configWithDynamicListOptions, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithDynamicListOptions, tempDir, tempDir);
 
           const configPath = join(
             getActionsDir(tempDir, CONFIGURATION_EXTENSION_POINT_ID),
@@ -255,10 +237,7 @@ describe("commands/generate/actions", () => {
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run(configWithDynamicListOptions, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithDynamicListOptions, tempDir, tempDir);
 
           const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
           expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -292,10 +271,7 @@ describe("commands/generate/actions", () => {
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run(minimalValidConfig, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(minimalValidConfig, tempDir, tempDir);
 
           const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
           expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -316,10 +292,7 @@ describe("commands/generate/actions", () => {
             ...makeTemplateFiles(),
           },
           async (tempDir) => {
-            await run(configWithDynamicListOptions, {
-              cwd: tempDir,
-              templatesDir: tempDir,
-            });
+            await run(configWithDynamicListOptions, tempDir, tempDir);
 
             const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
             expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -348,7 +321,7 @@ describe("commands/generate/actions", () => {
       async () => {
         mockSpawnSync.mockReturnValueOnce({ status: 1 });
 
-        await withTempProject(
+        await withTempFiles(
           {
             "app.commerce.config.ts": dynamicOptionsConfigFileTs,
             "package.json": JSON.stringify({ type: "module" }),
@@ -356,7 +329,7 @@ describe("commands/generate/actions", () => {
           },
           async (tempDir) => {
             await expect(
-              run(configWithDynamicListOptions, { cwd: tempDir }),
+              run(configWithDynamicListOptions, tempDir),
             ).rejects.toThrow(
               "Could not bundle the TypeScript app config with esbuild@",
             );
@@ -376,10 +349,7 @@ describe("commands/generate/actions", () => {
             ...makeTemplateFiles(),
           },
           async (tempDir) => {
-            await run(minimalValidConfig, {
-              cwd: tempDir,
-              templatesDir: tempDir,
-            });
+            await run(minimalValidConfig, tempDir, tempDir);
 
             const actionsDir = getActionsDir(
               tempDir,
@@ -410,10 +380,7 @@ describe("commands/generate/actions", () => {
           [getManifestPath()]: JSON.stringify({ metadata: { id: "static" } }),
         },
         async (tempDir) => {
-          await run(configWithBusinessConfig, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithBusinessConfig, tempDir, tempDir);
 
           const runtimeConfigPath = join(tempDir, getRuntimeAppConfigPath());
           expect(existsSync(runtimeConfigPath)).toBe(true);
@@ -442,10 +409,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithFullAdminUiV2, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithFullAdminUiV2, tempDir, tempDir);
 
           const extConfigPath = join(
             tempDir,
@@ -464,10 +428,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithAdminUiMenu, tempDir, tempDir);
 
           const extConfigPath = join(
             tempDir,
@@ -490,10 +451,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithAdminUiMenu, tempDir, tempDir);
 
           const webSrcDir = join(
             tempDir,
@@ -599,10 +557,7 @@ describe("commands/generate/actions", () => {
           "package-lock.json": "{}",
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithAdminUiMenu, tempDir, tempDir);
 
           const webSrcDir = join(
             tempDir,
@@ -678,10 +633,7 @@ describe("commands/generate/actions", () => {
           [entrypoint]: "<html>custom</html>",
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithAdminUiMenu, tempDir, tempDir);
 
           const entrypointPath = join(tempDir, entrypoint);
           expect(await readFile(entrypointPath, "utf-8")).toBe(
@@ -727,7 +679,7 @@ describe("commands/generate/actions", () => {
         },
         async (tempDir) => {
           await expect(
-            run(configWithAdminUiMenu, { cwd: tempDir, templatesDir: tempDir }),
+            run(configWithAdminUiMenu, tempDir, tempDir),
           ).rejects.toThrow(
             "Cannot scaffold web-src because installed dependencies are incompatible",
           );
@@ -759,10 +711,7 @@ describe("commands/generate/actions", () => {
           ...installedDependencies,
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithAdminUiMenu, tempDir, tempDir);
 
           const webSrcDir = join(
             tempDir,
@@ -786,10 +735,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithWorkerMassActions, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithWorkerMassActions, tempDir, tempDir);
 
           const extensionDir = join(
             tempDir,
@@ -815,10 +761,7 @@ describe("commands/generate/actions", () => {
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run(configWithAdminUiMenu, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithAdminUiMenu, tempDir, tempDir);
 
           const webSrcDir = join(
             tempDir,
@@ -846,7 +789,7 @@ describe("commands/generate/actions", () => {
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
           await expect(
-            run(configWithAdminUiMenu, { cwd: tempDir, templatesDir: tempDir }),
+            run(configWithAdminUiMenu, tempDir, tempDir),
           ).rejects.toThrow("Failed to install dependencies automatically");
         },
       );
@@ -856,10 +799,7 @@ describe("commands/generate/actions", () => {
       await withTempFiles(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithFullAdminUiV2, {
-            cwd: tempDir,
-            templatesDir: tempDir,
-          });
+          await run(configWithFullAdminUiV2, tempDir, tempDir);
 
           const extConfigPath = join(
             tempDir,

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/manifest.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/manifest.test.ts
@@ -60,7 +60,7 @@ describe("commands/generate/manifest", () => {
   describe("run", () => {
     test("writes manifest JSON to the extensibility extension point directory", async () => {
       await withTempProject(EMPTY_PROJECT, async (tempDir) => {
-        await run(minimalValidConfig);
+        await run(minimalValidConfig, tempDir);
 
         const contents = await readFile(getManifestPath(tempDir), "utf-8");
         expect(JSON.parse(contents)).toEqual(minimalValidConfig);
@@ -82,13 +82,13 @@ describe("commands/generate/manifest", () => {
       };
 
       await withTempProject(EMPTY_PROJECT, async (tempDirA) => {
-        await run(configA);
+        await run(configA, tempDirA);
         const hashA = sha256(
           await readFile(getManifestPath(tempDirA), "utf-8"),
         );
 
         await withTempProject(EMPTY_PROJECT, async (tempDirB) => {
-          await run(configB);
+          await run(configB, tempDirB);
           const hashB = sha256(
             await readFile(getManifestPath(tempDirB), "utf-8"),
           );
@@ -100,30 +100,33 @@ describe("commands/generate/manifest", () => {
 
     test("does not emit a JSON manifest when schema is dynamic", async () => {
       await withTempProject(EMPTY_PROJECT, async (tempDir) => {
-        await run(configWithDynamicListOptions);
+        await run(configWithDynamicListOptions, tempDir);
         await expectFileToNotExist(getManifestPath(tempDir));
       });
     });
 
     test("does not emit a JSON manifest when the config has named exports", async () => {
-      await withTempProject(MINIMAL_PROJECT_WITH_NAMED_EXPORT, async () => {
-        await run(minimalValidConfig);
-        await expectFileToNotExist(getManifestPath(process.cwd()));
-      });
+      await withTempProject(
+        MINIMAL_PROJECT_WITH_NAMED_EXPORT,
+        async (tempDir) => {
+          await run(minimalValidConfig, tempDir);
+          await expectFileToNotExist(getManifestPath(tempDir));
+        },
+      );
     });
 
     test("removes a stale JSON manifest when regenerating as dynamic", async () => {
       await withTempProject(EMPTY_PROJECT, async (tempDir) => {
-        await run(configWithBusinessConfig);
+        await run(configWithBusinessConfig, tempDir);
         await expectFileToExist(getManifestPath(tempDir));
-        await run(configWithDynamicListOptions);
+        await run(configWithDynamicListOptions, tempDir);
         await expectFileToNotExist(getManifestPath(tempDir));
       });
     });
 
     test("serializes all config fields", async () => {
       await withTempProject(EMPTY_PROJECT, async (tempDir) => {
-        await run(fullConfig);
+        await run(fullConfig, tempDir);
 
         const outputPath = join(
           tempDir,

--- a/packages/aio-commerce-lib-app/test/integration/commands/generate/schema.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/generate/schema.test.ts
@@ -70,7 +70,7 @@ describe("commands/generate/schema", () => {
   describe("run", () => {
     test("skips generation when config has no business config schema", async () => {
       await withTempProject(EMPTY_PROJECT, async (tempDir) => {
-        await run(minimalValidConfig);
+        await run(minimalValidConfig, tempDir);
         const outputDir = join(
           tempDir,
           getExtensionPointFolderPath(CONFIGURATION_EXTENSION_POINT_ID),
@@ -85,7 +85,7 @@ describe("commands/generate/schema", () => {
 
     test("writes schema JSON when business config schema is present", async () => {
       await withTempProject(EMPTY_PROJECT, async (tempDir) => {
-        await run(configWithBusinessConfig);
+        await run(configWithBusinessConfig, tempDir);
         const parsed = JSON.parse(
           await readFile(getSchemaPath(tempDir), "utf-8"),
         );
@@ -115,11 +115,11 @@ describe("commands/generate/schema", () => {
       };
 
       await withTempProject(EMPTY_PROJECT, async (tempDirA) => {
-        await run(schemaA);
+        await run(schemaA, tempDirA);
         const hashA = sha256(await readFile(getSchemaPath(tempDirA), "utf-8"));
 
         await withTempProject(EMPTY_PROJECT, async (tempDirB) => {
-          await run(schemaB);
+          await run(schemaB, tempDirB);
           const hashB = sha256(
             await readFile(getSchemaPath(tempDirB), "utf-8"),
           );
@@ -150,8 +150,8 @@ describe("commands/generate/schema", () => {
             AIO_COMMERCE_CONFIG_ENCRYPTION_KEY: "some-valid-key",
           }),
         }),
-        async () => {
-          await run(configWithPassword);
+        async (tempDir) => {
+          await run(configWithPassword, tempDir);
           expect(mockExecSync).toHaveBeenCalledWith(
             expect.stringContaining("encryption validate"),
           );
@@ -166,7 +166,7 @@ describe("commands/generate/schema", () => {
       };
 
       await withTempProject(projectFiles, async (tempDir) => {
-        await run(configWithDynamicListOptions);
+        await run(configWithDynamicListOptions, tempDir);
 
         const jsonPath = getSchemaPath(tempDir);
         await expectFileToNotExist(jsonPath);
@@ -188,8 +188,8 @@ describe("commands/generate/schema", () => {
         },
       };
 
-      await withTempProject(EMPTY_PROJECT, async () => {
-        await run(configWithPassword);
+      await withTempProject(EMPTY_PROJECT, async (tempDir) => {
+        await run(configWithPassword, tempDir);
         expect(mockExecSync).toHaveBeenCalledWith(
           expect.stringContaining("encryption setup"),
         );

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/postinstall.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/postinstall.test.ts
@@ -39,7 +39,7 @@ describe("commands/hooks/postinstall", () => {
       await withTempProject(
         { ...BUSINESS_CONFIG_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithBusinessConfig, tempDir);
+          await run(configWithBusinessConfig, { templatesDir: tempDir });
 
           const extensibilityDir = join(
             tempDir,

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/postinstall.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/postinstall.test.ts
@@ -39,7 +39,7 @@ describe("commands/hooks/postinstall", () => {
       await withTempProject(
         { ...BUSINESS_CONFIG_PROJECT, ...makeTemplateFiles() },
         async (tempDir) => {
-          await run(configWithBusinessConfig, { templatesDir: tempDir });
+          await run(configWithBusinessConfig, tempDir, tempDir);
 
           const extensibilityDir = join(
             tempDir,

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
@@ -79,7 +79,7 @@ describe("commands/hooks/pre-app-build", () => {
       };
 
       await withTempProject(extensibilityProject, async (tempDir) => {
-        await run("extensibility/1", { templatesDir: tempDir });
+        await run("extensibility/1", tempDir, tempDir);
 
         const manifestPath = join(tempDir, getManifestPath());
         const appConfigPath = extensibilityActionFile(tempDir, "app-config");
@@ -106,7 +106,7 @@ describe("commands/hooks/pre-app-build", () => {
       };
 
       await withTempProject(businessConfigProject, async (tempDir) => {
-        await run("configuration/1", { templatesDir: tempDir });
+        await run("configuration/1", tempDir, tempDir);
 
         const schemaPath = join(tempDir, getSchemaPath());
         const configActionPath = businessConfigActionFile(tempDir, "config");
@@ -128,7 +128,7 @@ describe("commands/hooks/pre-app-build", () => {
       await withTempProject(
         makeProjectFiles(configWithAdminUiSingleGrid),
         async (tempDir) => {
-          await run("backend-ui/2");
+          await run("backend-ui/2", tempDir);
 
           const extConfigPath = join(
             tempDir,
@@ -151,7 +151,7 @@ describe("commands/hooks/pre-app-build", () => {
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run("backend-ui/2");
+          await run("backend-ui/2", tempDir);
 
           const extConfigPath = join(
             tempDir,
@@ -209,7 +209,7 @@ describe("commands/hooks/pre-app-build", () => {
           ...makeTemplateFiles(),
         },
         async (tempDir) => {
-          await run("backend-ui/2");
+          await run("backend-ui/2", tempDir);
 
           const extConfigPath = join(
             tempDir,
@@ -242,7 +242,7 @@ describe("commands/hooks/pre-app-build", () => {
 
     test("does not write ext.config.yaml for backend-ui/2 when adminUi is absent", async () => {
       await withTempProject(MINIMAL_PROJECT, async (tempDir) => {
-        await run("backend-ui/2");
+        await run("backend-ui/2", tempDir);
 
         const extConfigPath = join(
           tempDir,
@@ -254,10 +254,10 @@ describe("commands/hooks/pre-app-build", () => {
     });
 
     test("throws for unsupported extension", async () => {
-      await withTempProject(MINIMAL_PROJECT, async () => {
+      await withTempProject(MINIMAL_PROJECT, async (tempDir) => {
         await expect(
           // @ts-expect-error Testing with invalid extension value
-          run("unknown/1"),
+          run("unknown/1", tempDir),
         ).rejects.toThrow("Unsupported extension");
       });
     });

--- a/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/hooks/pre-app-build.test.ts
@@ -79,7 +79,7 @@ describe("commands/hooks/pre-app-build", () => {
       };
 
       await withTempProject(extensibilityProject, async (tempDir) => {
-        await run("extensibility/1", tempDir);
+        await run("extensibility/1", { templatesDir: tempDir });
 
         const manifestPath = join(tempDir, getManifestPath());
         const appConfigPath = extensibilityActionFile(tempDir, "app-config");
@@ -106,7 +106,7 @@ describe("commands/hooks/pre-app-build", () => {
       };
 
       await withTempProject(businessConfigProject, async (tempDir) => {
-        await run("configuration/1", tempDir);
+        await run("configuration/1", { templatesDir: tempDir });
 
         const schemaPath = join(tempDir, getSchemaPath());
         const configActionPath = businessConfigActionFile(tempDir, "config");

--- a/packages/aio-commerce-lib-app/test/integration/commands/init/lib.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/init/lib.test.ts
@@ -555,9 +555,9 @@ describe("commands/init/lib", () => {
 
       await withTempProject(
         { ...EMPTY_PROJECT, ...makeTemplateFiles() },
-        async () => {
+        async (tempDir) => {
           await expect(
-            runGeneration(configWithBusinessConfig, "npx"),
+            runGeneration(configWithBusinessConfig, "npx", tempDir),
           ).rejects.toThrow();
         },
       );

--- a/packages/aio-commerce-lib-app/test/integration/commands/typescript.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/commands/typescript.test.ts
@@ -44,7 +44,7 @@ describe("commands/typescript", () => {
         "package.json": JSON.stringify({ type: "module" }),
       },
       async (tempDir) => {
-        await scaffoldTypeScriptProject("npm");
+        await scaffoldTypeScriptProject("npm", tempDir);
 
         const webpackPath = join(tempDir, "webpack-config.cjs");
         const require = createRequire(import.meta.url);
@@ -105,7 +105,7 @@ describe("commands/typescript", () => {
         "webpack-config.js": webpackConfig,
       },
       async (tempDir) => {
-        await scaffoldTypeScriptProject("npm");
+        await scaffoldTypeScriptProject("npm", tempDir);
         await expect(
           readFile(join(tempDir, "webpack-config.js"), "utf-8"),
         ).resolves.toBe(webpackConfig);
@@ -128,7 +128,7 @@ describe("commands/typescript", () => {
         "package.json": JSON.stringify({ type: "module" }),
       },
       async (tempDir) => {
-        await scaffoldTypeScriptProject("npm");
+        await scaffoldTypeScriptProject("npm", tempDir);
         await expect(
           readFile(join(tempDir, "custom-webpack-config.cjs"), "utf-8"),
         ).resolves.toBe(webpackConfig);
@@ -149,8 +149,8 @@ describe("commands/typescript", () => {
           type: "module",
         }),
       },
-      async () => {
-        await expect(scaffoldTypeScriptProject("npm")).rejects.toThrow(
+      async (tempDir) => {
+        await expect(scaffoldTypeScriptProject("npm", tempDir)).rejects.toThrow(
           `typescript@4.9.5 does not satisfy ${__TYPESCRIPT_VERSION__}`,
         );
       },
@@ -175,9 +175,9 @@ describe("commands/typescript", () => {
           "src/commerce-backend-ui-2/web-src/tsconfig.json": "{}",
         },
         async (tempDir) => {
-          await syncActionsTypecheckScript();
-          await syncActionsTypecheckScript();
-          await syncWebSourceTypecheckScript();
+          await syncActionsTypecheckScript(tempDir);
+          await syncActionsTypecheckScript(tempDir);
+          await syncWebSourceTypecheckScript(tempDir);
 
           const pkg = JSON.parse(
             await readFile(join(tempDir, "package.json"), "utf-8"),

--- a/packages/aio-commerce-lib-app/test/unit/commands/generate/actions/lib.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/commands/generate/actions/lib.test.ts
@@ -31,10 +31,6 @@ import {
 
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 
-const getProjectRootDirectory = vi.hoisted(() =>
-  vi.fn(() => "/fake/project/root"),
-);
-
 vi.mock("@aio-commerce-sdk/scripting-utils/project", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -42,7 +38,6 @@ vi.mock("@aio-commerce-sdk/scripting-utils/project", async (importOriginal) => {
     >();
   return {
     ...actual,
-    getProjectRootDirectory,
     makeOutputDirFor: vi.fn(() => Promise.resolve("/fake/output/dir")),
   };
 });
@@ -64,7 +59,7 @@ describe("readExtConfig", () => {
     vi.mocked(readYamlFile).mockRejectedValue(new Error("ENOENT"));
 
     await expect(
-      readExtConfig(EXTENSIBILITY_EXTENSION_POINT_ID),
+      readExtConfig(EXTENSIBILITY_EXTENSION_POINT_ID, "/fake/project/root"),
     ).rejects.toThrow(
       "Could not read ext.config.yaml for commerce/extensibility/1",
     );
@@ -77,6 +72,7 @@ describe("applyCustomScripts", () => {
       const scriptsTemplate = await generateCustomScriptsTemplate(
         templates.customScripts,
         minimalValidConfig,
+        "/fake/project/root",
       );
 
       const result = applyCustomScripts(
@@ -96,6 +92,7 @@ describe("applyCustomScripts", () => {
       const scriptsTemplate = await generateCustomScriptsTemplate(
         templates.customScripts,
         configWithCustomInstallationSteps,
+        "/fake/project/root",
       );
 
       const result = applyCustomScripts(
@@ -121,6 +118,7 @@ describe("applyCustomScripts", () => {
       const scriptsTemplate = await generateCustomScriptsTemplate(
         templates.customScripts,
         appManifest as CommerceAppConfigOutputModel,
+        "/fake/project/root",
       );
 
       const result = applyCustomScripts(
@@ -141,6 +139,7 @@ describe("generateCustomScriptsTemplate", () => {
       const result = await generateCustomScriptsTemplate(
         templates.customScripts,
         minimalValidConfig,
+        "/fake/project/root",
       );
 
       expect(result).toBeNull();
@@ -152,6 +151,7 @@ describe("generateCustomScriptsTemplate", () => {
       const result = await generateCustomScriptsTemplate(
         templates.customScripts,
         configWithCustomInstallationSteps,
+        "/fake/project/root",
       );
 
       const expectedImports = [
@@ -186,6 +186,7 @@ describe("generateCustomScriptsTemplate", () => {
       const result = await generateCustomScriptsTemplate(
         templates.customScripts,
         appManifest as CommerceAppConfigOutputModel,
+        "/fake/project/root",
       );
 
       expect(result).toBeNull();
@@ -208,6 +209,7 @@ describe("generateCustomScriptsTemplate", () => {
       const result = await generateCustomScriptsTemplate(
         templates.customScripts,
         appManifest as CommerceAppConfigOutputModel,
+        "/fake/project/root",
       );
 
       expect(result).toContain('import * as customScript0 from "./nested.js"');

--- a/packages/aio-commerce-lib-app/test/unit/commands/generate/web-src.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/commands/generate/web-src.test.ts
@@ -13,44 +13,28 @@
 import { readFile } from "node:fs/promises";
 
 import { withTempFiles } from "@aio-commerce-sdk/scripting-utils/filesystem";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { prepareWebSourceImportAlias } from "#commands/generate/web-src";
-
-const getProjectRootDirectory = vi.hoisted(() => vi.fn());
-
-vi.mock("@aio-commerce-sdk/scripting-utils/project", async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import("@aio-commerce-sdk/scripting-utils/project")
-    >();
-  return {
-    ...actual,
-    getProjectRootDirectory,
-  };
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
-});
 
 describe("prepareWebSourceImportAlias", () => {
   test("throws when package.json is missing", async () => {
     await withTempFiles({}, async (tempDir) => {
-      getProjectRootDirectory.mockReturnValue(tempDir);
-
       await expect(
-        prepareWebSourceImportAlias({
-          operations: {
-            view: [
-              {
-                impl: "index.html",
-                type: "web",
-              },
-            ],
+        prepareWebSourceImportAlias(
+          {
+            operations: {
+              view: [
+                {
+                  impl: "index.html",
+                  type: "web",
+                },
+              ],
+            },
+            web: "web-src",
           },
-          web: "web-src",
-        }),
+          tempDir,
+        ),
       ).rejects.toThrow("Could not find package.json.");
     });
   });
@@ -65,19 +49,20 @@ describe("prepareWebSourceImportAlias", () => {
         }),
       },
       async (tempDir) => {
-        getProjectRootDirectory.mockReturnValue(tempDir);
-
-        await prepareWebSourceImportAlias({
-          operations: {
-            view: [
-              {
-                impl: "index.html",
-                type: "web",
-              },
-            ],
+        await prepareWebSourceImportAlias(
+          {
+            operations: {
+              view: [
+                {
+                  impl: "index.html",
+                  type: "web",
+                },
+              ],
+            },
+            web: "web-src",
           },
-          web: "web-src",
-        });
+          tempDir,
+        );
 
         await expect(
           readFile(`${tempDir}/package.json`, "utf-8").then(JSON.parse),

--- a/packages/aio-commerce-lib-auth/source/commands/sync-ims-credentials.ts
+++ b/packages/aio-commerce-lib-auth/source/commands/sync-ims-credentials.ts
@@ -15,7 +15,9 @@ import { stringifyError } from "@aio-commerce-sdk/scripting-utils/error";
 import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
-/** Synchronizes the current context IMS credentials to their AIO_COMMERCE_IMS_AUTH counterparts. */
+/**
+ * Synchronizes current-context IMS credentials to the nearest project's `.env`.
+ */
 export async function run() {
   consola.start("Syncing IMS credentials...");
 

--- a/packages/aio-commerce-lib-auth/source/commands/sync-ims-credentials.ts
+++ b/packages/aio-commerce-lib-auth/source/commands/sync-ims-credentials.ts
@@ -1,5 +1,18 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 import { syncImsCredentials } from "@aio-commerce-sdk/scripting-utils/env";
 import { stringifyError } from "@aio-commerce-sdk/scripting-utils/error";
+import { getProjectRootDirectory } from "@aio-commerce-sdk/scripting-utils/project";
 import consola from "consola";
 
 /** Synchronizes the current context IMS credentials to their AIO_COMMERCE_IMS_AUTH counterparts. */
@@ -7,7 +20,8 @@ export async function run() {
   consola.start("Syncing IMS credentials...");
 
   try {
-    const result = await syncImsCredentials();
+    const projectRoot = await getProjectRootDirectory();
+    const result = await syncImsCredentials(projectRoot);
 
     if (!result.ok) {
       switch (result.reason) {


### PR DESCRIPTION
## Description

Fixes the intermittent `generate/actions` test failure caused by a timed-out TypeScript bundle leaving the process working directory inside a deleted temporary project.

The change also establishes a consistent project-root boundary across the affected commands:

- Parameterless `exec()` entrypoints resolve the project root from the current working directory.
- Internal `run()` functions and leaf helpers require an explicit resolved `projectRoot` and do not resolve it again.
- `init` creates or discovers `package.json` before resolving the root, which supports greenfield projects.
- `generate all` intentionally composes the individual parameterless command entrypoints.
- `post-app-deploy` remains root-free because it does not access project files.
- The new `pre-app-dev` and `pre-app-run` hooks resolve the root before updating the project `.env`.
- Environment helpers and the auth IMS synchronization command follow the same boundary/core split.

The tests now use `withTempFiles` when exercising root-injected internal functions and reserve `withTempProject` for parameterless command boundaries that intentionally discover the root from CWD. `withTempProject` overrides `process.cwd()` instead of changing the OS working directory, while `withChdir` is hardened so an interrupted test cannot cascade `ENOENT` failures through the suite.

JSDoc has been updated to describe the explicit root contracts and current command behavior.

## Related Issue

No tracked issue. This fixes a CI flake observed on `main`.

## Motivation and Context

The affected tests ran `esbuild` for real while the process was chdir'd into a temporary project. Under CI load, bundling could exceed Vitest's five-second timeout. The temporary directory was then removed before the process working directory was safely restored, causing later tests to fail with `ENOENT`.

Increasing the bundle-test timeout removes the immediate trigger, and hardening `withChdir` contains interrupted callers. Passing a resolved project root through internal command code removes the underlying dependency on mutable global process state and prevents repeated root discovery.

## How Has This Been Tested?

- `@adobe/aio-commerce-lib-app`: 1,027 tests passing
- `@adobe/aio-commerce-lib-auth`: 126 tests passing
- `@aio-commerce-sdk/scripting-utils`: 156 tests passing
- `@adobe/aio-commerce-lib-config`: 212 tests passing
- Typechecks pass for app, auth, scripting-utils, and config
- Biome passes on all changed TypeScript files

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
