### PR TITLE
CEXT-6527: reconcile live webhook subscriptions

### DIFF
--- a/.changeset/small-aliens-double.md
+++ b/.changeset/small-aliens-double.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Prune app-owned Commerce webhooks that are absent from the target configuration during upgrades.

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/apply.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/apply.ts
@@ -10,16 +10,23 @@
  * governing permissions and limitations under the License.
  */
 
+import { getInstallCommerceEnv } from "#config/lib/environment";
+
 import {
   createWebhookSubscription,
   deleteWebhookSubscription,
   getWebhookName,
+  isDesiredWebhook,
+  isWebhookInList,
+  isWebhookOwnedByApp,
+  resolveDesiredWebhooks,
   resolveDeveloperConsoleOAuthCredentials,
   toIdentity,
   webhookIdentitiesMatch,
 } from "./utils";
 
 import type { WebhookSubscribeParams } from "@adobe/aio-commerce-lib-webhooks/api";
+import type { WebhooksConfig } from "#config/schema/webhooks";
 import type {
   ApplyContext,
   ApplyResult,
@@ -32,22 +39,55 @@ import type {
 } from "./types";
 
 /**
- * Applies a webhooks domain plan: re-checks live Commerce state before each add/remove
- * (idempotent under retry). Aborts on the first failure rather than report partial success.
+ * Applies a webhooks domain plan and prunes live app-owned webhooks absent from
+ * the target. Aborts on the first failure rather than report partial success.
  */
 export async function applyWebhookSubscriptions(
   plan: WebhookDomainPlan,
-  context: ApplyContext<WebhooksStepContext>,
+  context: ApplyContext<
+    WebhooksStepContext,
+    WebhooksConfig,
+    WebhookSnapshotData
+  >,
 ): Promise<ApplyResult<WebhookSnapshotData>> {
   const { logger, commerceWebhooksClient, params } = context;
 
-  let liveIdentities = (await commerceWebhooksClient.getWebhookList()).map(
-    toIdentity,
+  const liveWebhooks = await commerceWebhooksClient.getWebhookList();
+  let liveIdentities = liveWebhooks.map(toIdentity);
+
+  let subscribedWebhooks: WebhookSubscribeParams[] = [
+    ...(context.baseline?.data.subscribedWebhooks ?? []),
+  ];
+
+  const appConfig = context.targetConfig ?? context.baseline?.config;
+  if (!appConfig) {
+    throw new Error(
+      "Cannot apply webhook subscriptions without a baseline or target config",
+    );
+  }
+
+  const env = getInstallCommerceEnv(params);
+  const desired = context.targetConfig
+    ? resolveDesiredWebhooks(context.targetConfig, env)
+    : [];
+
+  const staleWebhooks = liveWebhooks.filter(
+    (webhook) =>
+      isWebhookOwnedByApp(webhook, appConfig.metadata.id) &&
+      !isDesiredWebhook(webhook, desired),
   );
 
-  const subscribedWebhooks: WebhookSubscribeParams[] = [
-    ...plan.retainedWebhooks,
-  ];
+  for (const stale of staleWebhooks) {
+    const identity = toIdentity(stale);
+
+    // biome-ignore lint/performance/noAwaitInLoops: removals must run sequentially so a failure aborts the remaining work
+    await deleteWebhookSubscription(commerceWebhooksClient, identity, identity);
+
+    logger.info(`Unsubscribed webhook: ${getWebhookName(identity)}`);
+    liveIdentities = liveIdentities.filter(
+      (live) => !webhookIdentitiesMatch(live, identity),
+    );
+  }
 
   for (const operation of plan.operations) {
     if (operation.kind === "add") {
@@ -56,9 +96,7 @@ export async function applyWebhookSubscriptions(
         operation.after as ResolvedWebhookPayload;
       const identity = toIdentity(resolvedWebhook);
 
-      if (
-        liveIdentities.some((live) => webhookIdentitiesMatch(live, identity))
-      ) {
+      if (isWebhookInList(liveIdentities, identity)) {
         logger.info(
           `Webhook already subscribed, skipping: ${getWebhookName(identity)}`,
         );
@@ -77,13 +115,13 @@ export async function applyWebhookSubscriptions(
         liveIdentities = [...liveIdentities, identity];
       }
 
-      subscribedWebhooks.push(resolvedWebhook);
+      if (!isWebhookInList(subscribedWebhooks, identity)) {
+        subscribedWebhooks.push(resolvedWebhook);
+      }
     } else if (operation.kind === "remove") {
       const identity = toIdentity(operation.before);
 
-      if (
-        liveIdentities.some((live) => webhookIdentitiesMatch(live, identity))
-      ) {
+      if (isWebhookInList(liveIdentities, identity)) {
         await deleteWebhookSubscription(
           commerceWebhooksClient,
           identity,
@@ -98,6 +136,10 @@ export async function applyWebhookSubscriptions(
           `Webhook not found, skipping unsubscribe: ${getWebhookName(identity)}`,
         );
       }
+
+      subscribedWebhooks = subscribedWebhooks.filter(
+        (subscribed) => !webhookIdentitiesMatch(subscribed, identity),
+      );
     }
   }
 

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/branch.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/branch.ts
@@ -41,6 +41,10 @@ const subscriptionsStep = defineLeafStep({
       description: "Deletes webhook subscriptions from Adobe Commerce",
       label: "Delete Subscriptions",
     },
+    upgrade: {
+      description: "Reconciles webhook subscriptions in Adobe Commerce",
+      label: "Upgrade Subscriptions",
+    },
   },
   name: "subscriptions",
   plan: planWebhookSubscriptions,
@@ -69,6 +73,10 @@ export const webhooksStep = defineBranchStep({
     },
     uninstall: {
       description: "Removes Commerce webhooks",
+      label: "Webhooks",
+    },
+    upgrade: {
+      description: "Reconciles Commerce webhooks",
       label: "Webhooks",
     },
   },

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/plan.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/plan.ts
@@ -10,18 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import { appliesToEnv, getInstallCommerceEnv } from "#config/lib/environment";
+import { getInstallCommerceEnv } from "#config/lib/environment";
 
 import {
-  buildWebhookIdPrefix,
   getWebhookName,
-  resolveWebhookPayload,
+  isDesiredWebhook,
+  resolveDesiredWebhooks,
   toIdentity,
   webhookIdentitiesMatch,
   webhookOperationId,
 } from "./utils";
 
-import type { WebhookSubscribeParams } from "@adobe/aio-commerce-lib-webhooks/api";
 import type { WebhooksConfig } from "#config/schema/webhooks";
 import type {
   PlanningInput,
@@ -35,17 +34,6 @@ import type {
   WebhookOperationValue,
   WebhookSnapshotData,
 } from "./types";
-
-/** Resolves every config webhook entry that applies to `env` — no credentials, for planning only. */
-function resolveDesiredWebhooks(
-  config: WebhooksConfig,
-  env: ReturnType<typeof getInstallCommerceEnv>,
-): WebhookOperationValue[] {
-  const idPrefix = buildWebhookIdPrefix(config.metadata.id);
-  return config.webhooks
-    .filter((entry) => appliesToEnv(entry, env))
-    .map((entry) => resolveWebhookPayload(entry, idPrefix));
-}
 
 /**
  * Diffs the target config against the baseline into add/remove operations. Pure —
@@ -85,7 +73,6 @@ export function planWebhookSubscriptions(
   // Removes precede adds (see the concat below) so a rename never briefly double-registers a hook point.
   const addOperations: ResourceOperation<WebhookOperationValue>[] = [];
   const removeOperations: ResourceOperation<WebhookOperationValue>[] = [];
-  const retainedWebhooks: WebhookSubscribeParams[] = [];
 
   for (const webhook of desired) {
     const owned = ownedFromBaseline.find((candidate) =>
@@ -93,7 +80,6 @@ export function planWebhookSubscriptions(
     );
 
     if (owned) {
-      retainedWebhooks.push(owned);
       continue;
     }
 
@@ -107,14 +93,13 @@ export function planWebhookSubscriptions(
   }
 
   const staleFromBaseline = ownedFromBaseline.filter(
-    (owned) =>
-      !desired.some((webhook) => webhookIdentitiesMatch(webhook, owned)),
+    (owned) => !isDesiredWebhook(owned, desired),
   );
 
   for (const stale of staleFromBaseline) {
     const identity = toIdentity(stale);
     removeOperations.push({
-      before: stale,
+      before: identity,
       id: webhookOperationId("remove", identity),
       kind: "remove",
       label: `Unsubscribe webhook: ${getWebhookName(identity)}`,
@@ -126,7 +111,6 @@ export function planWebhookSubscriptions(
     plan: {
       operations: [...removeOperations, ...addOperations],
       path,
-      retainedWebhooks,
     },
   });
 }

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/types.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/types.ts
@@ -52,10 +52,8 @@ export type ResolvedWebhookPayload = WebhookIdentity &
 export type WebhookOperationValue = WebhookIdentity &
   Partial<Omit<ResolvedWebhookPayload, keyof WebhookIdentity>>;
 
-/** The webhooks domain plan. `retainedWebhooks` lets `apply` rebuild the full resulting state without needing the baseline. */
-export type WebhookDomainPlan = DomainPlan<WebhookOperationValue> & {
-  retainedWebhooks: WebhookSubscribeParams[];
-};
+/** The webhooks domain plan. */
+export type WebhookDomainPlan = DomainPlan<WebhookOperationValue>;
 
 /** The snapshot data the webhooks domain persists after applying its plan. */
 export type WebhookSnapshotData = WebhookSubscriptionResult;

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/utils.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/utils.ts
@@ -13,11 +13,13 @@
 import { unwrapHttpError } from "@adobe/aio-commerce-lib-api/utils";
 import { resolveImsAuthParams } from "@adobe/aio-commerce-lib-auth";
 
+import { appliesToEnv } from "#config/lib/environment";
+
 import type {
-  CommerceWebhook,
   WebhookSubscribeParams,
   WebhookUnsubscribeParams,
 } from "@adobe/aio-commerce-lib-webhooks/api";
+import type { getInstallCommerceEnv } from "#config/lib/environment";
 import type { WebhookEntry } from "#config/schema/webhooks";
 import type { WebhooksExecutionContext } from "./context";
 import type { ResolvedWebhookPayload, WebhookIdentity } from "./types";
@@ -80,10 +82,18 @@ export function webhookIdentitiesMatch(
 
 /** True when a webhook with the given four-part identity exists in the list. */
 export function isWebhookInList(
-  existing: CommerceWebhook[],
+  existing: readonly WebhookIdentity[],
   candidate: WebhookIdentity,
 ): boolean {
   return existing.some((w) => webhookIdentitiesMatch(w, candidate));
+}
+
+/** Returns whether a webhook identity is present in the desired target set. */
+export function isDesiredWebhook(
+  webhook: WebhookIdentity,
+  desiredWebhooks: readonly WebhookIdentity[],
+): boolean {
+  return isWebhookInList(desiredWebhooks, webhook);
 }
 
 /** Strips the `.magento` segment Commerce drops when persisting plugin webhook methods. */
@@ -114,6 +124,29 @@ export function buildWebhookIdPrefix(appId: string): string {
     .replace(NON_IDENTIFIER_CHAR_REGEX, "_")
     .replace(MULTIPLE_UNDERSCORES_REGEX, "_");
   return prefix.endsWith("_") ? prefix : `${prefix}_`;
+}
+
+/** Returns whether a Commerce webhook belongs to the app with the given metadata ID. */
+export function isWebhookOwnedByApp(
+  webhook: Pick<WebhookIdentity, "batch_name" | "hook_name">,
+  appId: string,
+): boolean {
+  const idPrefix = buildWebhookIdPrefix(appId);
+  return (
+    webhook.batch_name.startsWith(idPrefix) &&
+    webhook.hook_name.startsWith(idPrefix)
+  );
+}
+
+/** Resolves every configured webhook that applies to the Commerce environment. */
+export function resolveDesiredWebhooks(
+  config: { metadata: { id: string }; webhooks: WebhookEntry[] },
+  env: ReturnType<typeof getInstallCommerceEnv>,
+): ResolvedWebhookPayload[] {
+  const idPrefix = buildWebhookIdPrefix(config.metadata.id);
+  return config.webhooks
+    .filter((entry) => appliesToEnv(entry, env))
+    .map((entry) => resolveWebhookPayload(entry, idPrefix));
 }
 
 /** Resolves a config webhook entry's identity/payload (idPrefix, URL) — no credentials. Pure. */

--- a/packages/aio-commerce-lib-app/test/integration/management/webhooks.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/management/webhooks.test.ts
@@ -241,7 +241,7 @@ describe("webhooks upgrade planning integration", () => {
     );
   });
 
-  test("plans and applies a removal for a webhook dropped from the target config", async () => {
+  test("prunes a live app webhook absent from the baseline and target", async () => {
     const [subscribedWebhook] = configWithWebhooks.webhooks;
     const baselineWebhook = {
       batch_name: "test_app_webhooks_default",
@@ -251,6 +251,11 @@ describe("webhooks upgrade planning integration", () => {
       webhook_method: subscribedWebhook.webhook.webhook_method,
       webhook_type: subscribedWebhook.webhook.webhook_type,
     };
+    const foreignWebhook = {
+      ...baselineWebhook,
+      batch_name: "other_app_default",
+      hook_name: "other_app_order_created",
+    };
 
     const capture = {
       unsubscribeBody: null as Record<string, unknown> | null,
@@ -258,7 +263,7 @@ describe("webhooks upgrade planning integration", () => {
 
     apiServer.use(
       http.get(`${COMMERCE_BASE_URL}/webhooks/list`, () =>
-        HttpResponse.json([baselineWebhook]),
+        HttpResponse.json([baselineWebhook, foreignWebhook]),
       ),
       http.post(
         `${COMMERCE_BASE_URL}/webhooks/unsubscribe`,
@@ -280,7 +285,7 @@ describe("webhooks upgrade planning integration", () => {
     };
     const baseline = {
       config: configWithWebhooks,
-      data: { subscribedWebhooks: [baselineWebhook] },
+      data: { subscribedWebhooks: [] },
     };
 
     const planResult = await planWebhookSubscriptions(
@@ -293,9 +298,7 @@ describe("webhooks upgrade planning integration", () => {
     );
 
     expect.assert(planResult.kind === "planned");
-    expect(planResult.plan.operations).toEqual([
-      expect.objectContaining({ kind: "remove" }),
-    ]);
+    expect(planResult.plan.operations).toEqual([]);
 
     const applyResult = await applyWebhookSubscriptions(planResult.plan, {
       ...context,

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
@@ -10,12 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { applyWebhookSubscriptions } from "#management/domains/webhooks/apply";
 import { DEFAULT_INSTALLATION_PARAMS } from "#test/fixtures/installation";
 import {
   createMockResolvedWebhook,
+  createMockRuntimeWebhookEntry,
+  createMockWebhooksConfig,
   createMockWebhooksContext,
 } from "#test/fixtures/webhooks";
 
@@ -47,6 +49,14 @@ const DEFAULT_RESOLVED_IDENTITY = {
   webhook_type: "after",
 };
 describe("applyWebhookSubscriptions", () => {
+  beforeEach(() => {
+    vi.stubEnv("__OW_NAMESPACE", "test-namespace");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   function makeApplyContext(
     subscribeWebhookFn = vi.fn().mockResolvedValue(null),
     getWebhookListFn = vi.fn().mockResolvedValue([]),
@@ -61,7 +71,20 @@ describe("applyWebhookSubscriptions", () => {
       ),
       attemptId: "attempt-1",
       baseline: null,
-      targetConfig: null,
+      targetConfig: createMockWebhooksConfig(),
+    };
+  }
+
+  function withBaseline(
+    context: ReturnType<typeof makeApplyContext>,
+    subscribedWebhooks: ReturnType<typeof createMockResolvedWebhook>[],
+  ) {
+    return {
+      ...context,
+      baseline: {
+        config: createMockWebhooksConfig(),
+        data: { subscribedWebhooks },
+      },
     };
   }
 
@@ -88,16 +111,72 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [retainedWebhook],
     };
 
     const result = await applyWebhookSubscriptions(plan, context);
 
     expect(subscribeWebhook).toHaveBeenCalledWith(addWebhook);
-    expect(result.snapshotData?.subscribedWebhooks).toEqual([
-      retainedWebhook,
-      addWebhook,
-    ]);
+    expect(result.snapshotData?.subscribedWebhooks).toEqual([addWebhook]);
+  });
+
+  test("preserves baseline webhooks in the resulting snapshot", async () => {
+    const context = withBaseline(makeApplyContext(), [retainedWebhook]);
+    const result = await applyWebhookSubscriptions(
+      { operations: [], path: UPGRADE_PATH },
+      context,
+    );
+
+    expect(result.snapshotData?.subscribedWebhooks).toEqual([retainedWebhook]);
+  });
+
+  test("prunes live app-owned webhooks absent from the target", async () => {
+    const targetConfig = createMockWebhooksConfig();
+    const baseline = {
+      config: targetConfig,
+      data: { subscribedWebhooks: [retainedWebhook] },
+    };
+
+    const staleAppWebhook = createMockResolvedWebhook({
+      batch_name: "test_app_webhooks_stale",
+      hook_name: "test_app_webhooks_stale",
+    });
+
+    const foreignWebhook = createMockResolvedWebhook({
+      batch_name: "other_app_default",
+      hook_name: "other_app_stale",
+    });
+
+    const getWebhookList = vi
+      .fn()
+      .mockResolvedValue([retainedWebhook, staleAppWebhook, foreignWebhook]);
+
+    const unsubscribeWebhook = vi.fn().mockResolvedValue(null);
+    const context = {
+      ...makeContext(
+        vi.fn(),
+        getWebhookList,
+        DEFAULT_PARAMS,
+        unsubscribeWebhook,
+      ),
+      attemptId: "attempt-1",
+      baseline,
+      targetConfig,
+    };
+
+    const result = await applyWebhookSubscriptions(
+      { operations: [], path: UPGRADE_PATH },
+      context,
+    );
+
+    expect(unsubscribeWebhook).toHaveBeenCalledOnce();
+    expect(unsubscribeWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batch_name: staleAppWebhook.batch_name,
+        hook_name: staleAppWebhook.hook_name,
+      }),
+    );
+
+    expect(result.snapshotData?.subscribedWebhooks).toEqual([retainedWebhook]);
   });
 
   test("attaches credentials to the subscribe call but keeps the snapshot secret-free", async () => {
@@ -114,7 +193,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     const result = await applyWebhookSubscriptions(plan, context);
@@ -131,7 +209,21 @@ describe("applyWebhookSubscriptions", () => {
   test("skips subscribing an add that is already live", async () => {
     const subscribeWebhook = vi.fn();
     const getWebhookList = vi.fn().mockResolvedValue([addWebhook]);
-    const context = makeApplyContext(subscribeWebhook, getWebhookList);
+    const context = {
+      ...makeApplyContext(subscribeWebhook, getWebhookList),
+      targetConfig: createMockWebhooksConfig({
+        webhooks: [
+          createMockRuntimeWebhookEntry({
+            webhook: {
+              batch_name: "products",
+              hook_name: "validate",
+              webhook_method: addWebhook.webhook_method,
+              webhook_type: addWebhook.webhook_type,
+            },
+          }),
+        ],
+      }),
+    };
 
     const plan = {
       operations: [
@@ -143,7 +235,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     const result = await applyWebhookSubscriptions(plan, context);
@@ -155,10 +246,9 @@ describe("applyWebhookSubscriptions", () => {
   test("unsubscribes a planned remove that is live", async () => {
     const unsubscribeWebhook = vi.fn().mockResolvedValue(null);
     const getWebhookList = vi.fn().mockResolvedValue([retainedWebhook]);
-    const context = makeApplyContext(
-      vi.fn(),
-      getWebhookList,
-      unsubscribeWebhook,
+    const context = withBaseline(
+      makeApplyContext(vi.fn(), getWebhookList, unsubscribeWebhook),
+      [retainedWebhook],
     );
 
     const plan = {
@@ -171,7 +261,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     const result = await applyWebhookSubscriptions(plan, context);
@@ -200,7 +289,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     await applyWebhookSubscriptions(plan, context);
@@ -237,7 +325,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     await expect(applyWebhookSubscriptions(plan, context)).rejects.toThrow();
@@ -273,7 +360,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     await expect(applyWebhookSubscriptions(plan, context)).rejects.toThrow();
@@ -316,7 +402,6 @@ describe("applyWebhookSubscriptions", () => {
         },
       ],
       path: UPGRADE_PATH,
-      retainedWebhooks: [],
     };
 
     await applyWebhookSubscriptions(plan, context);

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/branch.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/branch.test.ts
@@ -39,6 +39,10 @@ describe("webhooks installation module", () => {
           description: "Removes Commerce webhooks",
           label: "Webhooks",
         },
+        upgrade: {
+          description: "Reconciles Commerce webhooks",
+          label: "Webhooks",
+        },
       });
     });
 
@@ -73,6 +77,10 @@ describe("webhooks installation module", () => {
         uninstall: {
           description: "Deletes webhook subscriptions from Adobe Commerce",
           label: "Delete Subscriptions",
+        },
+        upgrade: {
+          description: "Reconciles webhook subscriptions in Adobe Commerce",
+          label: "Upgrade Subscriptions",
         },
       });
     });

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/plan.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/plan.test.ts
@@ -77,7 +77,6 @@ describe("planWebhookSubscriptions", () => {
       after: expect.objectContaining(DEFAULT_RESOLVED_IDENTITY),
       kind: "add",
     });
-    expect(result.plan.retainedWebhooks).toHaveLength(0);
   });
 
   test("blocks planning instead of guessing when a baseline's data didn't resolve", async () => {
@@ -159,7 +158,7 @@ describe("planWebhookSubscriptions", () => {
     expect.assert(result.kind === "planned");
     expect(result.plan.operations).toEqual([
       expect.objectContaining({
-        before: baselineWebhook,
+        before: expect.objectContaining(DEFAULT_RESOLVED_IDENTITY),
         kind: "remove",
       }),
     ]);
@@ -182,7 +181,6 @@ describe("planWebhookSubscriptions", () => {
 
     expect.assert(result.kind === "planned");
     expect(result.plan.operations).toHaveLength(0);
-    expect(result.plan.retainedWebhooks).toEqual([baselineWebhook]);
   });
 
   test("plans an add and a remove when the target and baseline differ", async () => {
@@ -219,7 +217,7 @@ describe("planWebhookSubscriptions", () => {
       expect.arrayContaining([
         expect.objectContaining({ kind: "add" }),
         expect.objectContaining({
-          before: baselineWebhook,
+          before: expect.objectContaining(DEFAULT_RESOLVED_IDENTITY),
           kind: "remove",
         }),
       ]),
@@ -291,7 +289,6 @@ describe("planWebhookSubscriptions", () => {
 
     expect.assert(result.kind === "planned");
     expect(result.plan.operations).toHaveLength(0);
-    expect(result.plan.retainedWebhooks).toHaveLength(1);
   });
 
   test("excludes webhooks scoped to a different environment from the desired set", async () => {

--- a/packages/aio-commerce-lib-app/test/unit/management/installation/root.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/installation/root.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, test } from "vitest";
 
+import { createInitialPlanExecutionState } from "#management/common/workflow/execute";
 import { isBranchStep } from "#management/common/workflow/step";
 import { adminUiStep } from "#management/domains/admin-ui/branch";
 import { eventingStep } from "#management/domains/events/branch";
@@ -22,8 +23,10 @@ import {
 } from "#management/installation/root";
 import {
   configWithCustomInstallationSteps,
+  configWithWebhooks,
   minimalValidConfig,
 } from "#test/fixtures/config";
+import { createMockLifecyclePlan } from "#test/fixtures/lifecycle";
 
 describe("createRootInstallationStep", () => {
   test("should create installation step with default children", () => {
@@ -57,6 +60,42 @@ describe("createRootInstallationStep", () => {
       "Demo Success",
     );
     expect(customInstallationStep.children[0].type).toBe("leaf");
+  });
+
+  test("creates upgrade progress for a planned webhook operation", () => {
+    const rootStep = createRootInstallationStep(configWithWebhooks);
+    const plan = createMockLifecyclePlan({
+      domains: [
+        {
+          operations: [
+            {
+              after: {},
+              id: "webhook-add",
+              kind: "add",
+              label: "Add webhook",
+            },
+          ],
+          path: ["installation", "webhooks", "subscriptions"],
+        },
+      ],
+      target: {
+        appVersion: configWithWebhooks.metadata.version,
+        config: configWithWebhooks,
+      },
+    });
+
+    const state = createInitialPlanExecutionState({
+      plan,
+      rootStep,
+      targetConfig: configWithWebhooks,
+    });
+
+    const [webhooksStatus] = state.step.children;
+    expect.assert(webhooksStatus, "Expected webhook upgrade progress");
+    expect(webhooksStatus.meta).toEqual(webhooksStep.meta.upgrade);
+    expect(webhooksStatus.children.at(0)?.meta).toEqual(
+      webhooksStep.children.at(0)?.meta.upgrade,
+    );
   });
 });
 


### PR DESCRIPTION
## Description

Reworks webhook upgrade reconciliation so planning uses only the saved baseline and target configuration. During apply, the domain lists the current Commerce webhooks, removes app-owned webhooks that are absent from the target, preserves foreign webhooks, and rebuilds the saved snapshot from the apply baseline.

This also removes obsolete retained-webhook and cleanup-resource data from webhook plans.

## Related Issue

CEXT-6527

## Motivation and Context

Commerce can change between planning and execution, so stale webhook detection must use live state during apply. The apply context now provides the baseline directly, making the old plan-carried state unnecessary.

## How Has This Been Tested?

Added unit and integration coverage for app-owned stale pruning, foreign webhook preservation, baseline-derived snapshots, and retry behavior. Ran the full repository test suite, typecheck, lint, build, OpenAPI lint, and package validation.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
