### PR TITLE
CEXT-6661: fix uninstallation failing on dynamicList business config fields

### DIFF
--- a/.changeset/quiet-beers-invent.md
+++ b/.changeset/quiet-beers-invent.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Fix uninstallation failing for apps with a `dynamicList` Business Configuration field, caused by revalidating the recorded installation snapshot against a schema that required functions a JSON-serialized snapshot can never have. Uninstallation now validates the recorded config with `validateRecordedCommerceAppConfig`, which accepts a `dynamicList` field without `options`/`default`.

--- a/.changeset/tricky-lions-make.md
+++ b/.changeset/tricky-lions-make.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-config": minor
+---
+
+Add a `RecordedSchemaBusinessConfig` schema (and matching `RecordedBusinessConfig` type) that accepts `dynamicList` fields recovered from storage without their `options`/`default` functions, since those cannot survive a JSON round trip.

--- a/packages/aio-commerce-lib-app/source/actions/installation/uninstall.ts
+++ b/packages/aio-commerce-lib-app/source/actions/installation/uninstall.ts
@@ -19,7 +19,7 @@ import {
 } from "@adobe/aio-commerce-lib-core/responses";
 import openwhisk from "openwhisk";
 
-import { validateCommerceAppConfig } from "#config/lib/validate";
+import { validateRecordedCommerceAppConfig } from "#config/lib/validate";
 import {
   createInitialUninstallationState,
   isFailedState,
@@ -90,7 +90,7 @@ export async function startUninstallation({
   );
 
   const initialState = createInitialUninstallationState({
-    config: validateCommerceAppConfig(uninstallConfig),
+    config: validateRecordedCommerceAppConfig(uninstallConfig),
   });
   logger.debug(`Created initial uninstall state: ${initialState.id}`);
   await store.put(getStorageKey(), initialState);
@@ -141,7 +141,7 @@ export async function executeUninstallation({
     return badRequest("appConfig is required for execution");
   }
 
-  const appConfig = validateCommerceAppConfig(rawAppConfig);
+  const appConfig = validateRecordedCommerceAppConfig(rawAppConfig);
   const store = await createUninstallationStore();
   const hooks = createInstallationHooks(store, (msg) => logger.debug(msg));
   const installationContext = buildLifecycleContext(params, appConfig, logger);

--- a/packages/aio-commerce-lib-app/source/config/lib/validate.ts
+++ b/packages/aio-commerce-lib-app/source/config/lib/validate.ts
@@ -13,7 +13,10 @@
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import * as v from "valibot";
 
-import { CommerceAppConfigSchema } from "#config/schema/app";
+import {
+  CommerceAppConfigSchema,
+  RecordedCommerceAppConfigSchema,
+} from "#config/schema/app";
 import { CommerceAppConfigSchemas } from "#config/schema/domains";
 
 import type { Get } from "type-fest";
@@ -63,6 +66,33 @@ export function validateCommerceAppConfig(
   }
 
   return validatedConfig.output;
+}
+
+/**
+ * Validates a commerce app config recovered from a persisted lifecycle
+ * snapshot (installation/upgrade baseline) against the schema.
+ *
+ * @param config - The configuration object to validate.
+ * @returns The validated and typed configuration output model.
+ *
+ * @throws {CommerceSdkValidationError} If the configuration is invalid, with
+ * detailed validation issues included.
+ */
+export function validateRecordedCommerceAppConfig(
+  config: unknown,
+): CommerceAppConfigOutputModel {
+  const validatedConfig = v.safeParse(RecordedCommerceAppConfigSchema, config);
+
+  if (!validatedConfig.success) {
+    throw new CommerceSdkValidationError("Invalid commerce app config", {
+      issues: validatedConfig.issues,
+    });
+  }
+
+  // Nothing in the installation/uninstallation workflow reads
+  // `businessConfig.schema` `options`/`default`, so a recorded config missing
+  // those functions is safe to thread through as the regular output model.
+  return validatedConfig.output as CommerceAppConfigOutputModel;
 }
 
 /**

--- a/packages/aio-commerce-lib-app/source/config/schema/app.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/app.ts
@@ -57,11 +57,6 @@ export const RecordedCommerceAppConfigSchema = v.looseObject({
   businessConfig: v.optional(RecordedSchemaBusinessConfig),
 });
 
-/** The output shape of the recorded commerce app config schema. */
-export type RecordedCommerceAppConfigOutputModel = v.InferOutput<
-  typeof RecordedCommerceAppConfigSchema
->;
-
 /** @internal Any commerce app config, input contract or validated output. */
 export type AnyCommerceAppConfig =
   | CommerceAppConfig

--- a/packages/aio-commerce-lib-app/source/config/schema/app.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/app.ts
@@ -15,7 +15,10 @@
 import * as v from "valibot";
 
 import { AdminUiSchema } from "./admin-ui";
-import { SchemaBusinessConfig } from "./business-configuration";
+import {
+  RecordedSchemaBusinessConfig,
+  SchemaBusinessConfig,
+} from "./business-configuration";
 import { getConfigDomains } from "./domains";
 import { EventingSchema } from "./eventing";
 import { InstallationSchema } from "./installation";
@@ -41,6 +44,22 @@ export type CommerceAppConfig = v.InferInput<typeof CommerceAppConfigSchema>;
 /** The output shape of the commerce app config schema. */
 export type CommerceAppConfigOutputModel = v.InferOutput<
   typeof CommerceAppConfigSchema
+>;
+
+/**
+ * The schema used to validate a commerce app config recovered from a
+ * persisted lifecycle snapshot (installation/upgrade baseline), where
+ * `businessConfig.schema` `dynamicList` fields may have lost their
+ * `options`/`default` functions to a JSON round trip through storage.
+ */
+export const RecordedCommerceAppConfigSchema = v.looseObject({
+  ...CommerceAppConfigSchema.entries,
+  businessConfig: v.optional(RecordedSchemaBusinessConfig),
+});
+
+/** The output shape of the recorded commerce app config schema. */
+export type RecordedCommerceAppConfigOutputModel = v.InferOutput<
+  typeof RecordedCommerceAppConfigSchema
 >;
 
 /** @internal Any commerce app config, input contract or validated output. */

--- a/packages/aio-commerce-lib-app/source/config/schema/business-configuration.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/business-configuration.ts
@@ -13,7 +13,10 @@
 import type { AnyCommerceAppConfig } from "./app";
 
 // biome-ignore lint/performance/noBarrelFile: The business config schema lives in a separate package.
-export { SchemaBusinessConfig } from "@adobe/aio-commerce-lib-config";
+export {
+  RecordedSchemaBusinessConfig,
+  SchemaBusinessConfig,
+} from "@adobe/aio-commerce-lib-config";
 
 /** Config type when business config is present. */
 export type AppConfigWithBusinessConfig<T extends AnyCommerceAppConfig> = T & {

--- a/packages/aio-commerce-lib-app/test/fixtures/installation.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/installation.ts
@@ -284,9 +284,21 @@ export function createMockValidationResult(
   };
 }
 
+/** Options for {@link createMockInstallationStore}. */
+export type MockInstallationStoreOptions = {
+  /**
+   * When true, `put` round-trips the value through `JSON.stringify`/`parse`,
+   * matching the real state/files stores. Function-valued properties (e.g. a
+   * `dynamicList` field's `options`/`default`) do not survive this and are
+   * dropped, same as in production.
+   */
+  serialize?: boolean;
+};
+
 /** Creates an in-memory mock of a key/value store for installation state. */
 export function createMockInstallationStore(
   initialValue: WorkflowRunState | null = null,
+  { serialize = false }: MockInstallationStoreOptions = {},
 ) {
   let value = initialValue;
 
@@ -298,7 +310,7 @@ export function createMockInstallationStore(
     }),
     get: vi.fn(async (_key: string) => value),
     put: vi.fn(async (_key: string, nextValue: WorkflowRunState) => {
-      value = nextValue;
+      value = serialize ? JSON.parse(JSON.stringify(nextValue)) : nextValue;
     }),
   };
 }

--- a/packages/aio-commerce-lib-app/test/unit/actions/installation.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/actions/installation.test.ts
@@ -80,6 +80,7 @@ import { installationRuntimeAction } from "#actions/installation/index";
 import { createRuntimeActionParams } from "#test/fixtures/actions";
 import {
   configWithCommerceEventing,
+  configWithDynamicListOptions,
   createMockConfig,
   minimalValidConfig,
 } from "#test/fixtures/config";
@@ -1389,6 +1390,50 @@ describe("installationRuntimeAction", () => {
 
       expect(createInitialUninstallationStateMock).toHaveBeenCalledWith({
         config: minimalValidConfig,
+      });
+    });
+
+    test("CEXT-6661: uninstalls when the recorded snapshot lost its dynamicList functions to storage", async () => {
+      // The mock's `put` round-trips through JSON, exactly like the real
+      // state/files stores, so the persisted snapshot loses the `options`/
+      // `default` functions from `configWithDynamicListOptions` — the same
+      // way a real installation record does once it is written to storage.
+      installationStore = createMockInstallationStore(null, {
+        serialize: true,
+      });
+      await installationStore.put(
+        "installation",
+        createMockSucceededState({
+          config: configWithDynamicListOptions,
+          id: "installation-1",
+        }),
+      );
+
+      const handler = installationRuntimeAction({
+        appConfig: minimalValidConfig,
+      });
+
+      const result = await handler(
+        createRuntimeActionParams({
+          body: requestBody,
+          method: "post",
+          path: "/uninstallation",
+          ...DEFAULT_INSTALLATION_PARAMS,
+        }),
+      );
+
+      expect(result).not.toMatchObject({ statusCode: 500 });
+      expect(createInitialUninstallationStateMock).toHaveBeenCalledWith({
+        config: expect.objectContaining({
+          businessConfig: expect.objectContaining({
+            schema: [
+              expect.objectContaining({
+                name: "paymentMethod",
+                type: "dynamicList",
+              }),
+            ],
+          }),
+        }),
       });
     });
   });

--- a/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
@@ -15,9 +15,11 @@ import { describe, expect, test } from "vitest";
 import {
   validateCommerceAppConfig,
   validateCommerceAppConfigDomain,
+  validateRecordedCommerceAppConfig,
 } from "#config/lib/validate";
 import {
   configWithCustomInstallationSteps,
+  configWithDynamicListOptions,
   createCommerceEventConfig,
 } from "#test/fixtures/config";
 
@@ -1640,5 +1642,51 @@ describe("validateConfigDomain", () => {
     });
 
     expect(() => validateCommerceAppConfig(config)).toThrow();
+  });
+});
+
+describe("validateRecordedCommerceAppConfig", () => {
+  test("accepts a config whose dynamicList business config field still has functions", () => {
+    expect(() =>
+      validateRecordedCommerceAppConfig(configWithDynamicListOptions),
+    ).not.toThrow();
+  });
+
+  test("CEXT-6661: accepts a dynamicList field that lost its options/default to a JSON round trip", () => {
+    const recorded = JSON.parse(JSON.stringify(configWithDynamicListOptions));
+
+    const validated = validateRecordedCommerceAppConfig(recorded);
+    expect(validated.businessConfig?.schema).toEqual([
+      expect.objectContaining({
+        name: "paymentMethod",
+        type: "dynamicList",
+      }),
+    ]);
+  });
+
+  test("still rejects a config missing required metadata", () => {
+    const recorded = JSON.parse(
+      JSON.stringify({ ...configWithDynamicListOptions, metadata: undefined }),
+    );
+
+    expect(() => validateRecordedCommerceAppConfig(recorded)).toThrow();
+  });
+
+  test("still rejects a dynamicList field with a non-function options property", () => {
+    const config = {
+      ...configWithDynamicListOptions,
+      businessConfig: {
+        schema: [
+          {
+            name: "paymentMethod",
+            options: "not-a-function",
+            selectionMode: "single",
+            type: "dynamicList",
+          },
+        ],
+      },
+    };
+
+    expect(() => validateRecordedCommerceAppConfig(config)).toThrow();
   });
 });

--- a/packages/aio-commerce-lib-config/source/index.ts
+++ b/packages/aio-commerce-lib-config/source/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./modules/configuration/system-config";
 export {
   hasDynamicSchema,
+  RecordedSchemaBusinessConfig,
   resolveBusinessConfigSchema,
   SchemaBusinessConfig,
 } from "./modules/schema";
@@ -51,6 +52,7 @@ export type {
   BusinessConfigSchemaField,
   BusinessConfigSchemaListOption,
   BusinessConfigSchemaValue,
+  RecordedBusinessConfig,
   ResolvedBusinessConfigSchema,
 } from "./modules/schema";
 export type { ScopeNode, ScopeTree } from "./modules/scope-tree";

--- a/packages/aio-commerce-lib-config/source/modules/schema/fields.ts
+++ b/packages/aio-commerce-lib-config/source/modules/schema/fields.ts
@@ -265,3 +265,74 @@ export const SchemaBusinessConfigSchema = v.pipe(
   v.array(FieldSchema, "Expected an array of configuration fields"),
   v.minLength(1, "At least one configuration parameter is required"),
 );
+
+// A JSON round trip through storage (e.g. a persisted lifecycle snapshot)
+// cannot preserve function values, so `options`/`default` are structurally
+// guaranteed to be missing on a recorded `dynamicList` field, not just on a
+// malformed one. The schemas below accept that absence instead of rejecting it.
+
+/** Entries shared between the recorded single- and multiple-selection dynamic list field schemas. */
+const RecordedDynamicListEntriesCommon = {
+  ...BaseOptionSchema.entries,
+  options: v.optional(
+    v.custom<OptionsFactory>(
+      (input) => typeof input === "function",
+      'Expected a function for "options"',
+    ),
+  ),
+  type: v.literal("dynamicList", "Expected the type to be 'dynamicList'"),
+};
+
+/** Schema for a recorded dynamic list field that allows single selection. */
+const RecordedSingleDynamicListSchema = v.object({
+  ...RecordedDynamicListEntriesCommon,
+  default: v.optional(
+    v.custom<SingleDefaultFactory>(
+      (input) => typeof input === "function",
+      'Expected a function for "default"',
+    ),
+  ),
+  selectionMode: v.literal(
+    "single",
+    "Expected the selectionMode to be 'single'",
+  ),
+});
+
+/** Schema for a recorded dynamic list field that allows multiple selections. */
+const RecordedMultipleDynamicListSchema = v.object({
+  ...RecordedDynamicListEntriesCommon,
+  default: v.optional(
+    v.custom<MultipleDefaultFactory>(
+      (input) => typeof input === "function",
+      'Expected a function for "default"',
+    ),
+  ),
+  selectionMode: v.literal(
+    "multiple",
+    "Expected the selectionMode to be 'multiple'",
+  ),
+});
+
+/** Schema for recorded dynamic list fields supporting either single or multiple selection modes. */
+export const RecordedDynamicListSchema = v.variant("selectionMode", [
+  RecordedSingleDynamicListSchema,
+  RecordedMultipleDynamicListSchema,
+]);
+
+/** Schema for a single configuration field as recovered from a persisted lifecycle snapshot. */
+export const RecordedFieldSchema = v.variant("type", [
+  ListSchema,
+  RecordedDynamicListSchema,
+  TextSchema,
+  PasswordSchema,
+  EmailSchema,
+  UrlSchema,
+  PhoneSchema,
+  BooleanSchema,
+]);
+
+/** Schema for the business configuration schema as recovered from a persisted lifecycle snapshot. */
+export const RecordedSchemaBusinessConfigSchema = v.pipe(
+  v.array(RecordedFieldSchema, "Expected an array of configuration fields"),
+  v.minLength(1, "At least one configuration parameter is required"),
+);

--- a/packages/aio-commerce-lib-config/source/modules/schema/fields.ts
+++ b/packages/aio-commerce-lib-config/source/modules/schema/fields.ts
@@ -271,47 +271,16 @@ export const SchemaBusinessConfigSchema = v.pipe(
 // guaranteed to be missing on a recorded `dynamicList` field, not just on a
 // malformed one. The schemas below accept that absence instead of rejecting it.
 
-/** Entries shared between the recorded single- and multiple-selection dynamic list field schemas. */
-const RecordedDynamicListEntriesCommon = {
-  ...BaseOptionSchema.entries,
-  options: v.optional(
-    v.custom<OptionsFactory>(
-      (input) => typeof input === "function",
-      'Expected a function for "options"',
-    ),
-  ),
-  type: v.literal("dynamicList", "Expected the type to be 'dynamicList'"),
-};
-
 /** Schema for a recorded dynamic list field that allows single selection. */
-const RecordedSingleDynamicListSchema = v.object({
-  ...RecordedDynamicListEntriesCommon,
-  default: v.optional(
-    v.custom<SingleDefaultFactory>(
-      (input) => typeof input === "function",
-      'Expected a function for "default"',
-    ),
-  ),
-  selectionMode: v.literal(
-    "single",
-    "Expected the selectionMode to be 'single'",
-  ),
-});
+const RecordedSingleDynamicListSchema = v.partial(SingleDynamicListSchema, [
+  "options",
+  "default",
+]);
 
 /** Schema for a recorded dynamic list field that allows multiple selections. */
-const RecordedMultipleDynamicListSchema = v.object({
-  ...RecordedDynamicListEntriesCommon,
-  default: v.optional(
-    v.custom<MultipleDefaultFactory>(
-      (input) => typeof input === "function",
-      'Expected a function for "default"',
-    ),
-  ),
-  selectionMode: v.literal(
-    "multiple",
-    "Expected the selectionMode to be 'multiple'",
-  ),
-});
+const RecordedMultipleDynamicListSchema = v.partial(MultipleDynamicListSchema, [
+  "options",
+]);
 
 /** Schema for recorded dynamic list fields supporting either single or multiple selection modes. */
 export const RecordedDynamicListSchema = v.variant("selectionMode", [

--- a/packages/aio-commerce-lib-config/source/modules/schema/index.ts
+++ b/packages/aio-commerce-lib-config/source/modules/schema/index.ts
@@ -12,7 +12,10 @@
 
 import * as v from "valibot";
 
-import { SchemaBusinessConfigSchema } from "./fields";
+import {
+  RecordedSchemaBusinessConfigSchema,
+  SchemaBusinessConfigSchema,
+} from "./fields";
 
 /** The schema used to validate the business configuration settings. */
 export const SchemaBusinessConfig = v.object({
@@ -21,6 +24,20 @@ export const SchemaBusinessConfig = v.object({
 
 /** Defines the shape of the business configuration settings. */
 export type BusinessConfig = v.InferInput<typeof SchemaBusinessConfig>;
+
+/**
+ * The schema used to validate business configuration settings recovered from
+ * a persisted lifecycle snapshot, where `dynamicList` fields may be missing
+ * their `options`/`default` functions.
+ */
+export const RecordedSchemaBusinessConfig = v.object({
+  schema: v.optional(RecordedSchemaBusinessConfigSchema, []),
+});
+
+/** Defines the shape of a recorded business configuration settings object. */
+export type RecordedBusinessConfig = v.InferInput<
+  typeof RecordedSchemaBusinessConfig
+>;
 
 export {
   hasDynamicSchema,

--- a/packages/aio-commerce-lib-config/test/unit/modules/schema/fields.test.ts
+++ b/packages/aio-commerce-lib-config/test/unit/modules/schema/fields.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import * as v from "valibot";
+import { describe, expect, test } from "vitest";
+
+import {
+  RecordedSchemaBusinessConfigSchema,
+  SchemaBusinessConfigSchema,
+} from "#modules/schema/fields";
+
+const dynamicListField = {
+  default: (opts: { value: string }[]) => opts[0].value,
+  name: "paymentMethod",
+  options: () => [{ label: "Braintree", value: "braintree" }],
+  selectionMode: "single",
+  type: "dynamicList",
+};
+
+// What `dynamicListField` looks like after a JSON round trip through storage:
+// `JSON.stringify` drops function-valued properties entirely.
+const recordedDynamicListField = {
+  name: "paymentMethod",
+  selectionMode: "single",
+  type: "dynamicList",
+};
+
+const multipleDynamicListField = {
+  default: (opts: { value: string }[]) => opts.map((o) => o.value),
+  name: "paymentMethods",
+  options: () => [{ label: "Braintree", value: "braintree" }],
+  selectionMode: "multiple",
+  type: "dynamicList",
+};
+
+const recordedMultipleDynamicListField = {
+  name: "paymentMethods",
+  selectionMode: "multiple",
+  type: "dynamicList",
+};
+
+describe("SchemaBusinessConfigSchema", () => {
+  test("accepts a dynamicList field with function options and default", () => {
+    const result = v.safeParse(SchemaBusinessConfigSchema, [dynamicListField]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a multiple-selection dynamicList field with function options and default", () => {
+    const result = v.safeParse(SchemaBusinessConfigSchema, [
+      multipleDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a dynamicList field that lost its options/default functions", () => {
+    const result = v.safeParse(SchemaBusinessConfigSchema, [
+      recordedDynamicListField,
+    ]);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("RecordedSchemaBusinessConfigSchema", () => {
+  test("accepts a dynamicList field with function options and default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      dynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a dynamicList field recovered from storage without options/default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      recordedDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a multiple-selection dynamicList field with function options and default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      multipleDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a multiple-selection dynamicList field recovered from storage without options/default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      recordedMultipleDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a dynamicList field with a non-function options property", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { ...recordedDynamicListField, options: "not-a-function" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a field missing the required name", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { selectionMode: "single", type: "dynamicList" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an invalid selectionMode", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { ...recordedDynamicListField, selectionMode: "bogus" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("still validates non-dynamicList field types strictly", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { name: "apiKey", options: [{ label: "A" }], type: "list" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Uninstallation revalidates the recorded installation snapshot against the strict `businessConfig` schema, which requires `dynamicList` `options`/`default` to be functions. Those functions never survive the `JSON.stringify` used to persist the snapshot (State/Files stores), so uninstallation always failed for apps with a `dynamicList` field.

Adds a `Recorded*` schema variant (in `aio-commerce-lib-config` and `aio-commerce-lib-app`) that accepts a `dynamicList` field without `options`/`default`, since nothing in the uninstall workflow reads them, and uses it only for the recorded-config validation in `uninstall.ts`. Install, upgrade, and the domains that do need strict validation during uninstall (webhooks, events, adminUi, custom installation) are unaffected.

## Related Issue

Closes [CEXT-6661](https://jira.corp.adobe.com/browse/CEXT-6661)

## Motivation and Context

A partner developing an Algolia integration hit this on every uninstall of an app using a `dynamicList` Business Configuration field.

## How Has This Been Tested?

- New unit tests for the `Recorded*` schemas in `aio-commerce-lib-config` (accepts `dynamicList` without functions, still rejects real corruption).
- New unit tests for `validateRecordedCommerceAppConfig` in `aio-commerce-lib-app`.
- Fixed a test-double gap: the installation store mock passed values by reference instead of round-tripping through JSON like the real stores, which is why this bug was invisible to the existing suite. Added a serializing variant and an end-to-end regression test (install a `dynamicList` field, then uninstall) that fails without the fix.
- Reproduced manually end-to-end against a real deployed app before and after the fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.