### PR TITLE
CEXT-6675: Update skills with the correct path to payload

### DIFF
--- a/.changeset/funky-rivers-retire.md
+++ b/.changeset/funky-rivers-retire.md
@@ -1,0 +1,8 @@
+---
+"@adobe/aio-commerce-plugin-app-management": patch
+---
+
+Corrected how the eventing and storage skills document reading an action's incoming payload, so generated handlers read the right fields:
+
+- Event handlers now read the event data from `params.data.value` (previously the skills pointed at `params.data`, which also holds delivery metadata and would leave every field undefined).
+- Webhook handlers are now documented separately from events, since their payloads differ: the Commerce operation data arrives directly on `params` (for example `params.order`), and responses use the helpers from `@adobe/aio-commerce-lib-webhooks/responses`.

--- a/plugins/commerce/app-management/skills/commerce-app-eventing/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-eventing/SKILL.md
@@ -130,16 +130,17 @@ The `<package>/<action>` format in `runtimeActions` maps directly: `my-app/handl
 
 ### Handler skeleton
 
-Event handlers receive a CloudEvents-shaped payload. The event data lives in `params.data`.
+Event handlers receive a CloudEvents-shaped payload. `params.data` bundles the event payload together with metadata, so don't read fields directly off `params.data`: `params.data.value` is the event payload — the fields declared in the event's `fields` array (or the full payload if `fields` is empty); `params.data._metadata` is Commerce instance metadata; `params.data.source` is the merchant/environment ID pair configured in the Commerce eventing configuration.
 
 ```typescript
 // src/commerce-extensibility-1/actions/handle-order-placed/index.ts
 export async function main(params: Record<string, unknown>) {
   const data = params.data as Record<string, unknown>;
-  // data contains the fields declared in the event's `fields` array
+  const value = data.value as Record<string, unknown>;
+  // value contains the fields declared in the event's `fields` array
   // (or the full payload if fields is empty)
 
-  const orderId = data["order_id"];
+  const orderId = value["order_id"];
 
   // process the event ...
 

--- a/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/SKILL.md
@@ -153,12 +153,16 @@ export async function main(params: Record<string, unknown>) {
 }
 ```
 
-For an **event/webhook action** the only differences are `web: "no"` in registration and that the payload arrives in `params.data`:
+Event and webhook actions both register with `web: "no"`, but their payloads have different shapes — do not treat them as the same:
+
+- **Event handler** (wired via `commerce-app-eventing`): the extracted fields arrive in `params.data.value`. `params.data` also carries `_metadata` (Commerce instance metadata) and `source` (the merchant/environment ID pair from the Commerce eventing configuration) — neither is handler input.
+- **Webhook handler** (wired via `commerce-app-webhooks`): there is no `data` wrapper — the Commerce operation payload arrives directly on `params` (e.g. `params.order`), and the response must use the operation helpers from `@adobe/aio-commerce-lib-webhooks/responses` (see `commerce-app-webhooks`), not the plain `ok`/`buildErrorResponse` shape used above.
 
 ```ts
-// Event/webhook handler — same init/connect/close lifecycle
+// Event handler — src/commerce-extensibility-1/actions/store-order/index.ts
 export async function main(params: Record<string, unknown>) {
   const data = params.data as Record<string, unknown>;
+  const value = data.value as Record<string, unknown>;
   let client;
   try {
     const authProvider = getImsAuthProvider(resolveImsAuthParams(params));
@@ -167,8 +171,33 @@ export async function main(params: Record<string, unknown>) {
     client = await db.connect();
     await client
       .collection("orders")
-      .insertOne({ orderId: data.order_id, receivedAt: new Date() });
+      .insertOne({ orderId: value.order_id, receivedAt: new Date() });
     return ok({ body: { processed: true } });
+  } finally {
+    if (client) await client.close();
+  }
+}
+```
+
+```ts
+// Webhook handler — src/commerce-extensibility-1/actions/log-order/index.ts
+import {
+  ok,
+  successOperation,
+} from "@adobe/aio-commerce-lib-webhooks/responses";
+
+export async function main(params: Record<string, unknown>) {
+  const order = params.order as Record<string, unknown>; // Commerce operation payload, directly on params
+  let client;
+  try {
+    const authProvider = getImsAuthProvider(resolveImsAuthParams(params));
+    const token = await authProvider.getAccessToken();
+    const db = await initDb({ token, region: "emea" });
+    client = await db.connect();
+    await client
+      .collection("orders")
+      .insertOne({ orderId: order.entity_id, receivedAt: new Date() });
+    return ok(successOperation());
   } finally {
     if (client) await client.close();
   }

--- a/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/assets/db-action.ts
@@ -1,12 +1,15 @@
 // Full annotated reference for a Commerce app runtime action backed by
 // App Builder Database Storage (@adobe/aio-lib-db).
 //
-// Lifecycle (identical for web actions and event/webhook handlers):
+// This example is a web action. The DB lifecycle below is identical whichever
+// action type calls it — what differs is the input payload shape and the
+// response format (see the commerce-app-storage skill for event and webhook
+// handler variants):
 //   resolveImsAuthParams -> getAccessToken -> init -> connect -> use collection -> ALWAYS close.
 //
 // Registration requirements (in src/commerce-extensibility-1/ext.config.yaml):
 //   - include-ims-credentials: true   (REQUIRED — provides the IMS token below)
-//   - web: "yes" for an HTTP-invokable web action; "no" for an event/webhook handler
+//   - web: "yes" for an HTTP-invokable web action; "no" for an event or webhook handler
 //   - the "App Builder Data Services" API must be added to the project in the
 //     Adobe Developer Console (every workspace that uses the database)
 //   - the workspace database must be provisioned: declaratively via the
@@ -31,9 +34,6 @@ export async function main(params: Record<string, unknown>) {
     level: (params.LOG_LEVEL as string) || "info",
   });
 
-  // Web actions receive input directly on params; event/webhook handlers
-  // receive the payload on params.data instead:
-  //   const data = params.data as Record<string, unknown>;
   let client: DbClient | undefined;
 
   try {

--- a/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
+++ b/plugins/commerce/app-management/skills/commerce-app-storage/evals/evals.json
@@ -18,10 +18,10 @@
     {
       "id": 2,
       "prompt": "When an order is placed in Commerce, I want to record it in our database. The order event handler already needs to be created. Scaffold the event action and have it write the order to a collection.",
-      "expected_output": "The agent scaffolds an event/webhook action (web: \"no\") registered with include-ims-credentials: true, reading the payload from params.data, and writing to a collection using the init/connect/close lifecycle. After build passes it suggests commerce-app-eventing to wire the action to the order event via runtimeActions.",
+      "expected_output": "The agent scaffolds an App Builder runtime action to consume the Commerce event (web: \"no\") registered with include-ims-credentials: true, reading the payload from params.data.value, and writing to a collection using the init/connect/close lifecycle. After build passes it suggests commerce-app-eventing to wire the action to the order event via runtimeActions.",
       "assertions": [
         "The action is registered with include-ims-credentials: true",
-        "The handler reads the event payload from params.data",
+        "The handler reads the event payload from params.data.value",
         "The handler uses init() -> connect() -> collection write -> close() in finally",
         "The action is registered with web: \"no\"",
         "Agent mentions commerce-app-eventing (or runtimeActions) to wire the action to the event"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

https://jira.corp.adobe.com/browse/CEXT-6675

Corrects the runtime action payload guidance in the Commerce app skills. Event handlers must read extracted fields from `params.data.value` (not `params.data`), and webhook handlers receive the Commerce operation payload directly on `params` — the two were previously conflated as one shape. Updates the `commerce-app-eventing` and `commerce-app-storage` skills, their inline examples, the DB action reference, and the storage eval, verified against a real deployed app.

## Motivation and Context

  The `commerce-app-eventing` and `commerce-app-storage` skills told agents to read event fields directly off `params.data`. That's wrong: for Commerce events, the extracted fields live under `params.data.value`,
  while `params.data` also carries `_metadata` (Commerce instance metadata) and `source` (the merchant/environment ID pair from the eventing configuration). Handlers generated from the old guidance would read
  `undefined` for every field.

  This PR corrects the payload path and, in `commerce-app-storage`, splits the previously-conflated "event/webhook action" into two distinct handler shapes, since their payloads are unrelated:

  - **Event handlers** — fields under `params.data.value`.
  - **Webhook handlers** — the Commerce operation payload arrives directly on `params` (e.g. `params.order`), with no `data` wrapper, and the response uses the operation helpers from
  `@adobe/aio-commerce-lib-webhooks/responses`.

  Both variants were verified against a real deployed app's event and webhook handlers. Includes a patch changeset for `@adobe/aio-commerce-plugin-app-management`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
