### PR TITLE
CEXT-6661: hotfix uninstallation failing on dynamicList business config fields

### DIFF
--- a/.changeset/quiet-beers-invent.md
+++ b/.changeset/quiet-beers-invent.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": minor
+---
+
+Fix uninstallation failing for apps with a `dynamicList` Business Configuration field, caused by revalidating the recorded installation snapshot against a schema that required functions a JSON-serialized snapshot can never have. Uninstallation now validates the recorded config with `validateRecordedCommerceAppConfig`, which accepts a `dynamicList` field without `options`/`default`.

--- a/.changeset/tricky-lions-make.md
+++ b/.changeset/tricky-lions-make.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-config": minor
+---
+
+Add a `RecordedSchemaBusinessConfig` schema (and matching `RecordedBusinessConfig` type) that accepts `dynamicList` fields recovered from storage without their `options`/`default` functions, since those cannot survive a JSON round trip.

--- a/packages/aio-commerce-lib-app/source/actions/installation/router.ts
+++ b/packages/aio-commerce-lib-app/source/actions/installation/router.ts
@@ -25,7 +25,10 @@ import {
 import { createCombinedStore } from "@aio-commerce-sdk/common-utils/storage";
 import openwhisk from "openwhisk";
 
-import { validateCommerceAppConfig } from "#config/lib/validate";
+import {
+  validateCommerceAppConfig,
+  validateRecordedCommerceAppConfig,
+} from "#config/lib/validate";
 import {
   createInitialInstallationState,
   createInitialUninstallationState,
@@ -496,7 +499,7 @@ router.post("/uninstallation", {
     );
 
     const initialState = createInitialUninstallationState({
-      config: validateCommerceAppConfig(uninstallConfig),
+      config: validateRecordedCommerceAppConfig(uninstallConfig),
     });
     logger.debug(`Created initial uninstall state: ${initialState.id}`);
     await store.put(getStorageKey(), initialState);
@@ -557,7 +560,7 @@ router.post("/uninstallation/execution", {
       return badRequest("appConfig is required for execution");
     }
 
-    const appConfig = validateCommerceAppConfig(rawAppConfig);
+    const appConfig = validateRecordedCommerceAppConfig(rawAppConfig);
     const store = await createUninstallationStore();
     const hooks = createInstallationHooks(store, (msg) => logger.debug(msg));
     const installationContext = buildInstallationContext(

--- a/packages/aio-commerce-lib-app/source/config/lib/validate.ts
+++ b/packages/aio-commerce-lib-app/source/config/lib/validate.ts
@@ -13,7 +13,10 @@
 import { CommerceSdkValidationError } from "@adobe/aio-commerce-lib-core/error";
 import * as v from "valibot";
 
-import { CommerceAppConfigSchema } from "#config/schema/app";
+import {
+  CommerceAppConfigSchema,
+  RecordedCommerceAppConfigSchema,
+} from "#config/schema/app";
 import { CommerceAppConfigSchemas } from "#config/schema/domains";
 
 import type { Get } from "type-fest";
@@ -63,6 +66,33 @@ export function validateCommerceAppConfig(
   }
 
   return validatedConfig.output;
+}
+
+/**
+ * Validates a commerce app config recovered from a persisted lifecycle
+ * snapshot (installation/upgrade baseline) against the schema.
+ *
+ * @param config - The configuration object to validate.
+ * @returns The validated and typed configuration output model.
+ *
+ * @throws {CommerceSdkValidationError} If the configuration is invalid, with
+ * detailed validation issues included.
+ */
+export function validateRecordedCommerceAppConfig(
+  config: unknown,
+): CommerceAppConfigOutputModel {
+  const validatedConfig = v.safeParse(RecordedCommerceAppConfigSchema, config);
+
+  if (!validatedConfig.success) {
+    throw new CommerceSdkValidationError("Invalid commerce app config", {
+      issues: validatedConfig.issues,
+    });
+  }
+
+  // Nothing in the installation/uninstallation workflow reads
+  // `businessConfig.schema` `options`/`default`, so a recorded config missing
+  // those functions is safe to thread through as the regular output model.
+  return validatedConfig.output as CommerceAppConfigOutputModel;
 }
 
 /**

--- a/packages/aio-commerce-lib-app/source/config/schema/app.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/app.ts
@@ -15,7 +15,10 @@
 import * as v from "valibot";
 
 import { AdminUiSchema } from "./admin-ui";
-import { SchemaBusinessConfig } from "./business-configuration";
+import {
+  RecordedSchemaBusinessConfig,
+  SchemaBusinessConfig,
+} from "./business-configuration";
 import { getConfigDomains } from "./domains";
 import { EventingSchema } from "./eventing";
 import { InstallationSchema } from "./installation";
@@ -42,6 +45,17 @@ export type CommerceAppConfig = v.InferInput<typeof CommerceAppConfigSchema>;
 export type CommerceAppConfigOutputModel = v.InferOutput<
   typeof CommerceAppConfigSchema
 >;
+
+/**
+ * The schema used to validate a commerce app config recovered from a
+ * persisted lifecycle snapshot (installation/upgrade baseline), where
+ * `businessConfig.schema` `dynamicList` fields may have lost their
+ * `options`/`default` functions to a JSON round trip through storage.
+ */
+export const RecordedCommerceAppConfigSchema = v.looseObject({
+  ...CommerceAppConfigSchema.entries,
+  businessConfig: v.optional(RecordedSchemaBusinessConfig),
+});
 
 /** @internal Any commerce app config, input contract or validated output. */
 export type AnyCommerceAppConfig =

--- a/packages/aio-commerce-lib-app/source/config/schema/business-configuration.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/business-configuration.ts
@@ -13,7 +13,10 @@
 import type { AnyCommerceAppConfig } from "./app";
 
 // biome-ignore lint/performance/noBarrelFile: The business config schema lives in a separate package.
-export { SchemaBusinessConfig } from "@adobe/aio-commerce-lib-config";
+export {
+  RecordedSchemaBusinessConfig,
+  SchemaBusinessConfig,
+} from "@adobe/aio-commerce-lib-config";
 
 /** Config type when business config is present. */
 export type AppConfigWithBusinessConfig<T extends AnyCommerceAppConfig> = T & {

--- a/packages/aio-commerce-lib-app/test/fixtures/installation.ts
+++ b/packages/aio-commerce-lib-app/test/fixtures/installation.ts
@@ -303,9 +303,21 @@ export function createMockValidationResult(
   };
 }
 
+/** Options for {@link createMockInstallationStore}. */
+export type MockInstallationStoreOptions = {
+  /**
+   * When true, `put` round-trips the value through `JSON.stringify`/`parse`,
+   * matching the real state/files stores. Function-valued properties (e.g. a
+   * `dynamicList` field's `options`/`default`) do not survive this and are
+   * dropped, same as in production.
+   */
+  serialize?: boolean;
+};
+
 /** Creates an in-memory mock of a key/value store for installation state. */
 export function createMockInstallationStore(
   initialValue: InstallationState | null = null,
+  { serialize = false }: MockInstallationStoreOptions = {},
 ) {
   let value = initialValue;
 
@@ -317,7 +329,7 @@ export function createMockInstallationStore(
     }),
     get: vi.fn(async (_key: string) => value),
     put: vi.fn(async (_key: string, nextValue: InstallationState) => {
-      value = nextValue;
+      value = serialize ? JSON.parse(JSON.stringify(nextValue)) : nextValue;
     }),
   };
 }

--- a/packages/aio-commerce-lib-app/test/unit/actions/installation.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/actions/installation.test.ts
@@ -68,6 +68,7 @@ import { installationRuntimeAction } from "#actions/installation/index";
 import { createRuntimeActionParams } from "#test/fixtures/actions";
 import {
   configWithCommerceEventing,
+  configWithDynamicListOptions,
   minimalValidConfig,
 } from "#test/fixtures/config";
 import {
@@ -755,6 +756,50 @@ describe("installationRuntimeAction", () => {
 
       expect(createInitialUninstallationStateMock).toHaveBeenCalledWith({
         config: minimalValidConfig,
+      });
+    });
+
+    test("CEXT-6661: uninstalls when the recorded snapshot lost its dynamicList functions to storage", async () => {
+      // The mock's `put` round-trips through JSON, exactly like the real
+      // state/files stores, so the persisted snapshot loses the `options`/
+      // `default` functions from `configWithDynamicListOptions` — the same
+      // way a real installation record does once it is written to storage.
+      installationStore = createMockInstallationStore(null, {
+        serialize: true,
+      });
+      await installationStore.put(
+        "current",
+        createMockSucceededState({
+          config: configWithDynamicListOptions,
+          id: "installation-1",
+        }),
+      );
+
+      const handler = installationRuntimeAction({
+        appConfig: minimalValidConfig,
+      });
+
+      const result = await handler(
+        createRuntimeActionParams({
+          body: requestBody,
+          method: "post",
+          path: "/uninstallation",
+          ...DEFAULT_INSTALLATION_PARAMS,
+        }),
+      );
+
+      expect(result).not.toMatchObject({ statusCode: 500 });
+      expect(createInitialUninstallationStateMock).toHaveBeenCalledWith({
+        config: expect.objectContaining({
+          businessConfig: expect.objectContaining({
+            schema: [
+              expect.objectContaining({
+                name: "paymentMethod",
+                type: "dynamicList",
+              }),
+            ],
+          }),
+        }),
       });
     });
   });

--- a/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/validate.test.ts
@@ -15,9 +15,11 @@ import { describe, expect, test } from "vitest";
 import {
   validateCommerceAppConfig,
   validateCommerceAppConfigDomain,
+  validateRecordedCommerceAppConfig,
 } from "#config/lib/validate";
 import {
   configWithCustomInstallationSteps,
+  configWithDynamicListOptions,
   createCommerceEventConfig,
 } from "#test/fixtures/config";
 
@@ -1592,5 +1594,51 @@ describe("validateConfigDomain", () => {
     });
 
     expect(() => validateCommerceAppConfig(config)).toThrow();
+  });
+});
+
+describe("validateRecordedCommerceAppConfig", () => {
+  test("accepts a config whose dynamicList business config field still has functions", () => {
+    expect(() =>
+      validateRecordedCommerceAppConfig(configWithDynamicListOptions),
+    ).not.toThrow();
+  });
+
+  test("CEXT-6661: accepts a dynamicList field that lost its options/default to a JSON round trip", () => {
+    const recorded = JSON.parse(JSON.stringify(configWithDynamicListOptions));
+
+    const validated = validateRecordedCommerceAppConfig(recorded);
+    expect(validated.businessConfig?.schema).toEqual([
+      expect.objectContaining({
+        name: "paymentMethod",
+        type: "dynamicList",
+      }),
+    ]);
+  });
+
+  test("still rejects a config missing required metadata", () => {
+    const recorded = JSON.parse(
+      JSON.stringify({ ...configWithDynamicListOptions, metadata: undefined }),
+    );
+
+    expect(() => validateRecordedCommerceAppConfig(recorded)).toThrow();
+  });
+
+  test("still rejects a dynamicList field with a non-function options property", () => {
+    const config = {
+      ...configWithDynamicListOptions,
+      businessConfig: {
+        schema: [
+          {
+            name: "paymentMethod",
+            options: "not-a-function",
+            selectionMode: "single",
+            type: "dynamicList",
+          },
+        ],
+      },
+    };
+
+    expect(() => validateRecordedCommerceAppConfig(config)).toThrow();
   });
 });

--- a/packages/aio-commerce-lib-config/source/index.ts
+++ b/packages/aio-commerce-lib-config/source/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./modules/configuration/system-config";
 export {
   hasDynamicSchema,
+  RecordedSchemaBusinessConfig,
   resolveBusinessConfigSchema,
   SchemaBusinessConfig,
 } from "./modules/schema";
@@ -51,6 +52,7 @@ export type {
   BusinessConfigSchemaField,
   BusinessConfigSchemaListOption,
   BusinessConfigSchemaValue,
+  RecordedBusinessConfig,
   ResolvedBusinessConfigSchema,
 } from "./modules/schema";
 export type { ScopeNode, ScopeTree } from "./modules/scope-tree";

--- a/packages/aio-commerce-lib-config/source/modules/schema/fields.ts
+++ b/packages/aio-commerce-lib-config/source/modules/schema/fields.ts
@@ -265,3 +265,43 @@ export const SchemaBusinessConfigSchema = v.pipe(
   v.array(FieldSchema, "Expected an array of configuration fields"),
   v.minLength(1, "At least one configuration parameter is required"),
 );
+
+// A JSON round trip through storage (e.g. a persisted lifecycle snapshot)
+// cannot preserve function values, so `options`/`default` are structurally
+// guaranteed to be missing on a recorded `dynamicList` field, not just on a
+// malformed one. The schemas below accept that absence instead of rejecting it.
+
+/** Schema for a recorded dynamic list field that allows single selection. */
+const RecordedSingleDynamicListSchema = v.partial(SingleDynamicListSchema, [
+  "options",
+  "default",
+]);
+
+/** Schema for a recorded dynamic list field that allows multiple selections. */
+const RecordedMultipleDynamicListSchema = v.partial(MultipleDynamicListSchema, [
+  "options",
+]);
+
+/** Schema for recorded dynamic list fields supporting either single or multiple selection modes. */
+export const RecordedDynamicListSchema = v.variant("selectionMode", [
+  RecordedSingleDynamicListSchema,
+  RecordedMultipleDynamicListSchema,
+]);
+
+/** Schema for a single configuration field as recovered from a persisted lifecycle snapshot. */
+export const RecordedFieldSchema = v.variant("type", [
+  ListSchema,
+  RecordedDynamicListSchema,
+  TextSchema,
+  PasswordSchema,
+  EmailSchema,
+  UrlSchema,
+  PhoneSchema,
+  BooleanSchema,
+]);
+
+/** Schema for the business configuration schema as recovered from a persisted lifecycle snapshot. */
+export const RecordedSchemaBusinessConfigSchema = v.pipe(
+  v.array(RecordedFieldSchema, "Expected an array of configuration fields"),
+  v.minLength(1, "At least one configuration parameter is required"),
+);

--- a/packages/aio-commerce-lib-config/source/modules/schema/index.ts
+++ b/packages/aio-commerce-lib-config/source/modules/schema/index.ts
@@ -12,7 +12,10 @@
 
 import * as v from "valibot";
 
-import { SchemaBusinessConfigSchema } from "./fields";
+import {
+  RecordedSchemaBusinessConfigSchema,
+  SchemaBusinessConfigSchema,
+} from "./fields";
 
 /** The schema used to validate the business configuration settings. */
 export const SchemaBusinessConfig = v.object({
@@ -21,6 +24,20 @@ export const SchemaBusinessConfig = v.object({
 
 /** Defines the shape of the business configuration settings. */
 export type BusinessConfig = v.InferInput<typeof SchemaBusinessConfig>;
+
+/**
+ * The schema used to validate business configuration settings recovered from
+ * a persisted lifecycle snapshot, where `dynamicList` fields may be missing
+ * their `options`/`default` functions.
+ */
+export const RecordedSchemaBusinessConfig = v.object({
+  schema: v.optional(RecordedSchemaBusinessConfigSchema, []),
+});
+
+/** Defines the shape of a recorded business configuration settings object. */
+export type RecordedBusinessConfig = v.InferInput<
+  typeof RecordedSchemaBusinessConfig
+>;
 
 export {
   hasDynamicSchema,

--- a/packages/aio-commerce-lib-config/test/unit/modules/schema/fields.test.ts
+++ b/packages/aio-commerce-lib-config/test/unit/modules/schema/fields.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import * as v from "valibot";
+import { describe, expect, test } from "vitest";
+
+import {
+  RecordedSchemaBusinessConfigSchema,
+  SchemaBusinessConfigSchema,
+} from "#modules/schema/fields";
+
+const dynamicListField = {
+  default: (opts: { value: string }[]) => opts[0].value,
+  name: "paymentMethod",
+  options: () => [{ label: "Braintree", value: "braintree" }],
+  selectionMode: "single",
+  type: "dynamicList",
+};
+
+// What `dynamicListField` looks like after a JSON round trip through storage:
+// `JSON.stringify` drops function-valued properties entirely.
+const recordedDynamicListField = {
+  name: "paymentMethod",
+  selectionMode: "single",
+  type: "dynamicList",
+};
+
+const multipleDynamicListField = {
+  default: (opts: { value: string }[]) => opts.map((o) => o.value),
+  name: "paymentMethods",
+  options: () => [{ label: "Braintree", value: "braintree" }],
+  selectionMode: "multiple",
+  type: "dynamicList",
+};
+
+const recordedMultipleDynamicListField = {
+  name: "paymentMethods",
+  selectionMode: "multiple",
+  type: "dynamicList",
+};
+
+describe("SchemaBusinessConfigSchema", () => {
+  test("accepts a dynamicList field with function options and default", () => {
+    const result = v.safeParse(SchemaBusinessConfigSchema, [dynamicListField]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a multiple-selection dynamicList field with function options and default", () => {
+    const result = v.safeParse(SchemaBusinessConfigSchema, [
+      multipleDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a dynamicList field that lost its options/default functions", () => {
+    const result = v.safeParse(SchemaBusinessConfigSchema, [
+      recordedDynamicListField,
+    ]);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("RecordedSchemaBusinessConfigSchema", () => {
+  test("accepts a dynamicList field with function options and default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      dynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a dynamicList field recovered from storage without options/default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      recordedDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a multiple-selection dynamicList field with function options and default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      multipleDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a multiple-selection dynamicList field recovered from storage without options/default", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      recordedMultipleDynamicListField,
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a dynamicList field with a non-function options property", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { ...recordedDynamicListField, options: "not-a-function" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a field missing the required name", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { selectionMode: "single", type: "dynamicList" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an invalid selectionMode", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { ...recordedDynamicListField, selectionMode: "bogus" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+
+  test("still validates non-dynamicList field types strictly", () => {
+    const result = v.safeParse(RecordedSchemaBusinessConfigSchema, [
+      { name: "apiKey", options: [{ label: "A" }], type: "list" },
+    ]);
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Hotfix backport of #648 directly onto `release`. `main` currently has 26 commits ahead of `release` (in-progress upgrade orchestration work, several still in QA) that this fix does not depend on, so this targets `release` directly instead of going through the normal `main` → promote flow, to avoid shipping unrelated unfinished work.

Uninstallation revalidated the recorded installation snapshot against the strict `businessConfig` schema, which requires `dynamicList` `options`/`default` to be functions. Those functions never survive the `JSON.stringify` used to persist the snapshot (State/Files stores), so uninstallation always failed for apps with a `dynamicList` field.

Adds a `Recorded*` schema variant (in `aio-commerce-lib-config` and `aio-commerce-lib-app`) that accepts a `dynamicList` field without `options`/`default`, since nothing in the uninstall workflow reads them, and uses it only for the recorded-config validation in the two uninstallation handlers in `router.ts` (`release` predates the `install.ts`/`uninstall.ts`/`upgrade.ts` split, so this is the same fix ported to `release`'s current file layout). Install and validation are unaffected.

## Related Issue

Closes [CEXT-6661](https://jira.corp.adobe.com/browse/CEXT-6661). Already fixed on `main` via #648.

## Motivation and Context

A partner developing an Algolia integration hit this on every uninstall of an app using a `dynamicList` Business Configuration field. Approved as a hotfix directly to `release` to avoid waiting on unrelated in-progress work on `main`.

## How Has This Been Tested?

- Same unit test coverage as #648, ported to `release`'s test file layout: `Recorded*` schema tests in `aio-commerce-lib-config`, `validateRecordedCommerceAppConfig` tests, and an end-to-end regression test (install a `dynamicList` field through a serializing store mock, then uninstall) that fails without the fix.
- `pnpm test`/`typecheck`/lint all green on both affected packages.
- The underlying fix was already reproduced and verified manually end-to-end on a real deployed app (see #648).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.