### PR TITLE
CEXT-6707: Admin UI ACL resource ids can silently collide after Comme…

### DIFF
--- a/.changeset/admin-ui-id-collision-validation.md
+++ b/.changeset/admin-ui-id-collision-validation.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Reject Admin UI ids that would map to the same Commerce permission. Conflicting grid column, mass action, order view button, or custom ACL resource ids now fail config validation instead of silently overwriting one another.

--- a/.changeset/admin-ui-sanitize-segment-export.md
+++ b/.changeset/admin-ui-sanitize-segment-export.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-admin-ui": minor
+---
+
+Export `sanitizeSegment`, which normalizes an id the same way Commerce does when generating ACL resource ids.

--- a/packages/aio-commerce-lib-admin-ui/docs/usage.md
+++ b/packages/aio-commerce-lib-admin-ui/docs/usage.md
@@ -372,7 +372,7 @@ getMenuAclResourceId("approval-dashboard-app", "approval_dashboard");
 // → "Magento_CommerceBackendUix::adminuisdk_app_approval_dashboard_app_menu_approval_dashboard"
 ```
 
-Each segment is sanitized independently (trimmed, lowercased, non-`[a-z0-9_]` characters replaced with `_`), mirroring the Commerce module's id generator exactly. `getMenuAclResourceId` returns an empty string when `metadataId` is blank. Pass either id to `check()` or `require()`:
+Each segment is sanitized independently (trimmed, lowercased, non-`[a-z0-9_]` characters replaced with `_`), mirroring the Commerce module's id generator exactly. The `sanitizeSegment` helper that performs this per-segment normalization is also exported from `@adobe/aio-commerce-lib-admin-ui/api`, so you can reproduce how Commerce normalizes a single id segment. `getMenuAclResourceId` returns an empty string when `metadataId` is blank. Pass either id to `check()` or `require()`:
 
 ```typescript
 const allowed = await permissionClient.check(

--- a/packages/aio-commerce-lib-admin-ui/source/api/index.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/api/index.ts
@@ -16,6 +16,7 @@ export * from "../errors";
 export {
   getAclResourceId,
   getCustomAclResourceId,
+  sanitizeSegment,
 } from "./lib/acl-resource-id";
 export * from "./lib/api-client";
 export * from "./lib/permission-client";

--- a/packages/aio-commerce-lib-admin-ui/source/api/lib/acl-resource-id.ts
+++ b/packages/aio-commerce-lib-admin-ui/source/api/lib/acl-resource-id.ts
@@ -23,9 +23,9 @@ export const PREFIX = "Magento_CommerceBackendUix::adminuisdk_app_";
 
 /**
  * Sanitizes a single ACL id segment: trims whitespace, lowercases, and replaces every
- * character outside [a-z0-9_] with an underscore.
- *
- * @internal Exported for use by domain ACL helpers only — not part of the public API.
+ * character outside [a-z0-9_] with an underscore. This mirrors the Commerce module's own
+ * per-segment normalization — the same step applied when building any ACL resource id from a
+ * config id.
  */
 export function sanitizeSegment(segment: string): string {
   return segment

--- a/packages/aio-commerce-lib-app/source/config/schema/admin-ui.ts
+++ b/packages/aio-commerce-lib-app/source/config/schema/admin-ui.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { sanitizeSegment } from "@adobe/aio-commerce-lib-admin-ui/api";
 import { COMMERCE_MENUS } from "@adobe/aio-commerce-lib-admin-ui/menu";
 import {
   nonEmptyStringValueSchema,
@@ -20,6 +21,16 @@ import * as v from "valibot";
 import type { AnyCommerceAppConfig, CommerceAppConfigOutputModel } from "./app";
 
 // ─── Shared ───────────────────────────────────────────────────────────────────
+
+/**
+ * Whether the given items have distinct ids once Commerce sanitizes them into resource ids.
+ * Catches ids that differ only by case or by a character that sanitizes to `_`. Used by the
+ * component fields whose ids are otherwise unconstrained (grid columns, mass actions, view buttons).
+ */
+function hasUniqueSanitizedIds(items: readonly { id: string }[]): boolean {
+  const ids = items.map((item) => sanitizeSegment(item.id));
+  return new Set(ids).size === ids.length;
+}
 
 const SANDBOX_PERMISSION_VALUES = [
   "allow-downloads",
@@ -79,6 +90,10 @@ const GridColumnsSchema = v.object({
   columns: v.pipe(
     v.array(GridColumnSchema),
     v.minLength(1, "At least one grid column is required"),
+    v.check(
+      (items) => hasUniqueSanitizedIds(items),
+      "Grid column ids must be unique after Commerce id sanitization.",
+    ),
   ),
   description: nonEmptyStringValueSchema("grid columns description"),
   label: nonEmptyStringValueSchema("grid columns label"),
@@ -167,8 +182,8 @@ const OrderViewButtonSchema = v.variant("type", [
 const MassActionsSchema = v.pipe(
   v.array(MassActionSchema),
   v.check(
-    (items) => new Set(items.map((item) => item.id)).size === items.length,
-    "Mass action ids must be unique.",
+    (items) => hasUniqueSanitizedIds(items),
+    "Mass action ids must be unique after Commerce id sanitization.",
   ),
 );
 
@@ -179,8 +194,8 @@ const AdminUiOrderSchema = v.object({
     v.pipe(
       v.array(OrderViewButtonSchema),
       v.check(
-        (items) => new Set(items.map((item) => item.id)).size === items.length,
-        "Order view button ids must be unique.",
+        (items) => hasUniqueSanitizedIds(items),
+        "Order view button ids must be unique after Commerce id sanitization.",
       ),
     ),
   ),
@@ -277,6 +292,26 @@ const AclResourceEntrySchema = v.strictObject({
   label: AclResourceLabelSchema,
 });
 
+/**
+ * The Commerce ACL resource ids an `acl` config resolves to, relative to the app root: every
+ * top-level entry and group node contributes its own id, and every group child contributes the
+ * `<group>_<child>` id Commerce builds by joining segments with "_". Comparing these catches ids
+ * that look distinct but collapse to the same Commerce resource (e.g. a leaf `reports_export` vs a
+ * group `reports` with a child `export`). Ids are already canonical (see {@link AclResourceIdSchema}).
+ */
+function aclResourceIdentities(
+  entries: readonly { id: string; children?: readonly { id: string }[] }[],
+): string[] {
+  const ids: string[] = [];
+  for (const entry of entries) {
+    ids.push(entry.id);
+    for (const child of entry.children ?? []) {
+      ids.push(`${entry.id}_${child.id}`);
+    }
+  }
+  return ids;
+}
+
 const AdminUiAclSchema = v.pipe(
   v.array(AclResourceEntrySchema),
   v.minLength(1, "At least one ACL resource is required when acl is defined"),
@@ -284,6 +319,10 @@ const AdminUiAclSchema = v.pipe(
     (items) => new Set(items.map((i) => i.id)).size === items.length,
     "Top-level ACL resource ids must be unique.",
   ),
+  v.check((items) => {
+    const ids = aclResourceIdentities(items);
+    return new Set(ids).size === ids.length;
+  }, 'Custom ACL resource ids must stay unique after Commerce derivation: a top-level resource id must not equal a group\'s "<group>_<child>" combination.'),
 );
 
 // ─── Top-level schema ─────────────────────────────────────────────────────────

--- a/packages/aio-commerce-lib-app/test/unit/config/schema/admin-ui.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/config/schema/admin-ui.test.ts
@@ -121,6 +121,50 @@ describe("AdminUiSchema unique ids", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  test("rejects mass action ids that collide after Commerce id sanitization", () => {
+    // "Export" and "export" both sanitize to the same Commerce ACL resource id.
+    const result = v.safeParse(AdminUiSchema, {
+      order: { massActions: [massAction, { ...massAction, id: "Export" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects order view button ids that collide after Commerce id sanitization", () => {
+    const result = v.safeParse(AdminUiSchema, {
+      order: { viewButtons: [viewButton, { ...viewButton, id: "Reorder" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  const gridColumnsWith = (ids: string[]) => ({
+    order: {
+      gridColumns: {
+        columns: ids.map((id) => ({
+          align: "left" as const,
+          id,
+          label: `Column ${id}`,
+          type: "string" as const,
+        })),
+        description: "Order grid columns",
+        label: "Order grid",
+        runtimeAction: "orders/fetch",
+      },
+    },
+  });
+
+  test.each([
+    { ids: ["status", "status"], label: "exact duplicates", success: false },
+    {
+      ids: ["Status", "status"],
+      label: "colliding after sanitization",
+      success: false,
+    },
+    { ids: ["status", "priority"], label: "distinct values", success: true },
+  ])("grid column ids ($label)", ({ ids, success }) => {
+    const result = v.safeParse(AdminUiSchema, gridColumnsWith(ids));
+    expect(result.success).toBe(success);
+  });
 });
 
 describe("AdminUiSchema", () => {
@@ -788,6 +832,58 @@ describe("adminUi.acl", () => {
       ],
     };
     expect(() => v.parse(AdminUiSchema, config)).toThrow();
+  });
+
+  test("rejects a top-level leaf id that collides with a group child path", () => {
+    // A leaf "reports_export" and group "reports" + child "export" both derive
+    // ..._acl_reports_export in Commerce.
+    expect(() =>
+      v.parse(AdminUiSchema, {
+        acl: [
+          { id: "reports_export", label: "Reports Export" },
+          {
+            children: [{ id: "export", label: "Export" }],
+            id: "reports",
+            label: "Reports",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a group node id that collides with another group's child path", () => {
+    // Group node "a_b" and group "a" + child "b" both derive ..._acl_a_b.
+    expect(() =>
+      v.parse(AdminUiSchema, {
+        acl: [
+          {
+            children: [{ id: "c", label: "Cee" }],
+            id: "a_b",
+            label: "Group A B",
+          },
+          {
+            children: [{ id: "b", label: "Bee" }],
+            id: "a",
+            label: "Group A",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test("accepts a leaf whose id resembles but does not equal a group child path", () => {
+    expect(() =>
+      v.parse(AdminUiSchema, {
+        acl: [
+          { id: "reports_summary", label: "Reports Summary" },
+          {
+            children: [{ id: "export", label: "Export" }],
+            id: "reports",
+            label: "Reports",
+          },
+        ],
+      }),
+    ).not.toThrow();
   });
 
   test("rejects an id with uppercase letters", () => {


### PR DESCRIPTION
## Description
https://jira.corp.adobe.com/browse/CEXT-6707

Admin UI component ids are turned into Commerce ACL resource ids by sanitizing each segment (lowercase, non-`[a-z0-9_]` → `_`) and joining with `_`. Distinct config ids could silently collapse to the same Commerce permission, with one overwriting the other. This adds config-time validation so those collisions fail with a clear error:

- **Grid columns / mass actions / view buttons** — ids are now compared after sanitization (`"Export"` and `"export"` no longer both pass); grid columns also gain a uniqueness check they previously lacked.
- **Custom `adminUi.acl`** — a top-level leaf id can no longer equal a group's `<group>_<child>` combination.
- Exposes `sanitizeSegment` from `@adobe/aio-commerce-lib-admin-ui/api` so the schema can reuse Commerce's own normalization.

Non-breaking: existing valid ids (including dashed ones) still pass — only genuinely colliding configs, which were already broken, are now rejected.

## Related Issue

[CEXT-6696](https://jira.corp.adobe.com/browse/CEXT-6696)

https://github.com/adobe/aio-commerce-sdk/pull/653

## Motivation and Context

The ACL case/dash fix in CEXT-6696 only covered standalone `adminUi.acl` ids. This closes the remaining collision gaps across the other id-bearing Admin UI fields, so conflicts surface at build time instead of silently dropping a permission.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
