### PR TITLE
CEXT-6715: Document commerce-app-admin-ui: how a menu/view page calls its own action

### DIFF
--- a/.changeset/open-lights-relate.md
+++ b/.changeset/open-lights-relate.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-management": minor
+---
+
+Document how a menu or view page in the `commerce-app-admin-ui` skill can call its own action directly via the auto-generated `web-src/src/config.json` and `getActionUrl` pattern.

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -282,6 +282,46 @@ createExtensionApp({
 
 For an order view button, swap the hook for `useOrderViewButtonContext()` and read `data.orderId` after handling `error` — see [order-view-buttons](references/order-view-buttons.md).
 
+### Calling your own action from a menu/view page
+
+A menu or view page often needs data that isn't handed to it via context — for example, a custom menu page rendering a table it must fetch itself. For that, the page calls one of the app's own worker actions directly from `web-src`, instead of Commerce invoking it on the page's behalf.
+
+Whenever an extension declares both `actions` and `web-src` (true for any extension with a worker `runtimeAction` plus a menu or view entry), `aio app build`/`aio app dev` write every action's live URL to `web-src/src/config.json` (`config.web.injectedConfig`) automatically. That file is gitignored and regenerated on every build — there is nothing to scaffold or configure by hand.
+
+Wrap it in a small hook so pages don't import `config.json` directly:
+
+```jsx
+// src/commerce-backend-ui-2/web-src/src/hooks/use-config.js
+import { useCallback } from "react";
+import actionUrls from "../config.json";
+
+export function useConfig() {
+  const getActionUrl = useCallback((action) => actionUrls[action], []);
+  return { getActionUrl };
+}
+```
+
+Call the action with `useIms()` for the token and org id, and `useConfig()` for the URL:
+
+```jsx
+import { useIms } from "@adobe/aio-commerce-lib-admin-ui/web";
+import { useConfig } from "#web/hooks/use-config.js";
+
+const { data, error } = useIms();
+if (error) throw error;
+const { imsToken, imsOrgId } = data;
+const { getActionUrl } = useConfig();
+
+const response = await fetch(getActionUrl("my-app/order-grid"), {
+  headers: {
+    authorization: `Bearer ${imsToken}`,
+    "x-gw-ims-org-id": imsOrgId,
+  },
+});
+```
+
+An action with `require-adobe-auth: true` rejects the request unless both headers are present — `authorization: Bearer <imsToken>` alone is not enough. Without `x-gw-ims-org-id`, the action fails with "cannot authorize request, reason: missing x-gw-ims-org-id header".
+
 ## Step 5 — Validate
 
 Build the project to confirm the updated config is valid:

--- a/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-admin-ui/SKILL.md
@@ -284,11 +284,9 @@ For an order view button, swap the hook for `useOrderViewButtonContext()` and re
 
 ### Calling your own action from a menu/view page
 
-A menu or view page often needs data that isn't handed to it via context — for example, a custom menu page rendering a table it must fetch itself. For that, the page calls one of the app's own worker actions directly from `web-src`, instead of Commerce invoking it on the page's behalf.
+A menu or view page sometimes needs to fetch its own data — a custom menu page rendering a table, for example — instead of receiving it from Commerce. For that, it calls one of the app's own actions directly from `web-src`.
 
-Whenever an extension declares both `actions` and `web-src` (true for any extension with a worker `runtimeAction` plus a menu or view entry), `aio app build`/`aio app dev` write every action's live URL to `web-src/src/config.json` (`config.web.injectedConfig`) automatically. That file is gitignored and regenerated on every build — there is nothing to scaffold or configure by hand.
-
-Wrap it in a small hook so pages don't import `config.json` directly:
+Whenever an extension declares both `actions` and `web-src`, `aio app build`/`aio app dev` auto-generate `web-src/src/config.json` (`config.web.injectedConfig`) with every action's live URL — gitignored, regenerated on every build, nothing to scaffold by hand:
 
 ```jsx
 // src/commerce-backend-ui-2/web-src/src/hooks/use-config.js
@@ -296,31 +294,22 @@ import { useCallback } from "react";
 import actionUrls from "../config.json";
 
 export function useConfig() {
-  const getActionUrl = useCallback((action) => actionUrls[action], []);
-  return { getActionUrl };
+  return { getActionUrl: useCallback((action) => actionUrls[action], []) };
 }
-```
 
-Call the action with `useIms()` for the token and org id, and `useConfig()` for the URL:
-
-```jsx
+// Usage — combine with useIms() for the auth headers:
 import { useIms } from "@adobe/aio-commerce-lib-admin-ui/web";
-import { useConfig } from "#web/hooks/use-config.js";
 
 const { data, error } = useIms();
 if (error) throw error;
-const { imsToken, imsOrgId } = data;
-const { getActionUrl } = useConfig();
 
 const response = await fetch(getActionUrl("my-app/order-grid"), {
   headers: {
-    authorization: `Bearer ${imsToken}`,
-    "x-gw-ims-org-id": imsOrgId,
+    authorization: `Bearer ${data.imsToken}`,
+    "x-gw-ims-org-id": data.imsOrgId, // required for require-adobe-auth: true actions, or the request fails
   },
 });
 ```
-
-An action with `require-adobe-auth: true` rejects the request unless both headers are present — `authorization: Bearer <imsToken>` alone is not enough. Without `x-gw-ims-org-id`, the action fails with "cannot authorize request, reason: missing x-gw-ims-org-id header".
 
 ## Step 5 — Validate
 


### PR DESCRIPTION
## Description

Adds a new section to the `commerce-app-admin-ui` skill documenting how a menu/view page can call one of the app's own runtime actions (e.g. a custom menu page fetching data for a table), covering:

- The auto-generated `web-src/src/config.json` (`config.web.injectedConfig`), written by `aio app build`/`aio app dev` whenever an extension declares both `actions` and `web-src` — no manual scaffolding needed.
- A `useConfig()`/`getActionUrl()` hook example, combined with `useIms()` for auth headers.
- The required `x-gw-ims-org-id` header alongside `Authorization: Bearer` for `require-adobe-auth: true` actions.

## Related Issue

CEXT-6715

## Motivation and Context

The skill previously only covered cases where Commerce invokes the extension's action or opens its iframe (grid columns, mass actions, view buttons, menu). It never documented the reverse case — a page calling its own action — even though the tooling already supports it out of the box via `config.json`. Without this documented, the alternative is fragile, undocumented env-var/URL guessing.

## How Has This Been Tested?

Documentation-only change (skill `SKILL.md`). No code paths affected; not applicable for automated tests.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.