### PR TITLE
CEXT-6659 Handle target-system rejections safely during upgrade replacements

### DIFF
--- a/.changeset/yummy-places-teach.md
+++ b/.changeset/yummy-places-teach.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Recover safely when Commerce rejects a webhook or event-subscription replacement or addition during an upgrade. An identity change is applied as a remove-then-add; if the target accepts the removal but rejects the replacement, the previous entity is now restored and the upgrade fails reporting the original rejection, instead of leaving the target out of sync with the stored baseline. Adding several new event subscriptions in one upgrade is no longer partial either: if the target rejects one, the ones already created in that attempt are rolled back too. When recovery itself cannot restore the baseline, the failure records both errors and flags that the target may no longer match the baseline. Fresh installs keep their existing best-effort behavior.

--- a/packages/aio-commerce-lib-app/source/management/common/workflow/recovery.ts
+++ b/packages/aio-commerce-lib-app/source/management/common/workflow/recovery.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { unwrapHttpError } from "@adobe/aio-commerce-lib-api/utils";
+
+/** Failure key set when an upgrade replacement fails and recovery cannot fully restore the baseline. */
+export const UPGRADE_RECOVERY_FAILED = "UPGRADE_RECOVERY_FAILED";
+
+/** Payload recorded on a {@link UPGRADE_RECOVERY_FAILED} failure. */
+export type UpgradeRecoveryFailedPayload = {
+  recovery: "failed";
+
+  /** The target rejection that triggered recovery, message-unwrapped. */
+  originalError: string;
+
+  /** The error(s) raised while trying to restore the baseline, message-unwrapped. */
+  recoveryError: string;
+
+  /** Always `true`: the target may no longer match the stored baseline. */
+  targetMayDivergeFromBaseline: true;
+};
+
+/** An `Error` that carries a machine-readable `key` and optional structured `payload` alongside its message. */
+export class WorkflowStepError<TPayload = unknown> extends Error {
+  public readonly key: string;
+  public readonly payload?: TPayload;
+
+  public constructor(
+    message: string,
+    options: { key: string; payload?: TPayload; cause?: unknown },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "WorkflowStepError";
+    this.key = options.key;
+    this.payload = options.payload;
+  }
+}
+
+/** A compensating action that reverses one already-applied change back toward the baseline. */
+export type Compensation = () => Promise<void>;
+
+type RecoveryLogger = {
+  error: (message: string) => void;
+};
+
+/**
+ * Tracks compensating actions for changes already applied to a target system, and replays them in
+ * reverse (last-applied first), best-effort, to roll the target back to baseline when a later
+ * change fails:
+ *
+ * - if every compensation succeeds, the original error is rethrown as-is;
+ * - if any compensation fails, throws a {@link WorkflowStepError} keyed {@link UPGRADE_RECOVERY_FAILED},
+ *   carrying both the original and recovery errors and a flag that the target may no longer match
+ *   the baseline.
+ */
+export class RecoveryScope {
+  private readonly compensations: Compensation[] = [];
+  private readonly logger: RecoveryLogger;
+
+  public constructor(logger: RecoveryLogger) {
+    this.logger = logger;
+  }
+
+  /** Registers a compensation to run if the apply later fails. Recorded in apply order, run reversed. */
+  public onFailure(compensation: Compensation): void {
+    this.compensations.push(compensation);
+  }
+
+  /** Rolls the target back to baseline, then throws. Never returns normally. */
+  public async recover(originalError: unknown): Promise<never> {
+    const recoveryErrors: unknown[] = [];
+
+    for (const compensation of [...this.compensations].reverse()) {
+      try {
+        // biome-ignore lint/performance/noAwaitInLoops: compensations must run sequentially in reverse order to converge on the baseline
+        await compensation();
+      } catch (error) {
+        recoveryErrors.push(error);
+        this.logger.error(
+          `Recovery step failed: ${await unwrapHttpError(error)}`,
+        );
+      }
+    }
+
+    if (recoveryErrors.length === 0) {
+      throw originalError;
+    }
+
+    // A nested scope already reported an unrecoverable failure (its own compensations failed and it
+    // threw a keyed WorkflowStepError). Its payload already flags the baseline divergence, so pass
+    // it through unchanged rather than flatten it into this scope's message — this scope's own
+    // recovery errors are surfaced through the logger above.
+    if (originalError instanceof WorkflowStepError) {
+      throw originalError;
+    }
+
+    const originalMessage = await unwrapHttpError(originalError);
+    const recoveryMessage = (
+      await Promise.all(recoveryErrors.map((error) => unwrapHttpError(error)))
+    ).join("; ");
+
+    throw new WorkflowStepError<UpgradeRecoveryFailedPayload>(
+      `Upgrade replacement failed and recovery could not restore the baseline: ${originalMessage}`,
+      {
+        cause: originalError,
+        key: UPGRADE_RECOVERY_FAILED,
+        payload: {
+          originalError: originalMessage,
+          recovery: "failed",
+          recoveryError: recoveryMessage,
+          targetMayDivergeFromBaseline: true,
+        },
+      },
+    );
+  }
+}

--- a/packages/aio-commerce-lib-app/source/management/common/workflow/utils.ts
+++ b/packages/aio-commerce-lib-app/source/management/common/workflow/utils.ts
@@ -12,6 +12,8 @@
 
 import { unwrapHttpError } from "@adobe/aio-commerce-lib-api/utils";
 
+import { WorkflowStepError } from "./recovery";
+
 import type { CommerceAppConfigOutputModel } from "#config/schema/app";
 import type { AnyStep } from "./step";
 import type {
@@ -88,6 +90,17 @@ export async function createWorkflowError(
   path: string[],
   key = "STEP_EXECUTION_FAILED",
 ): Promise<WorkflowError> {
+  // A domain can throw a WorkflowStepError to carry a machine-readable key and structured payload
+  // (e.g. recovery detail) through to the persisted failure, instead of just a message.
+  if (err instanceof WorkflowStepError) {
+    return {
+      key: err.key,
+      message: err.message,
+      path,
+      payload: err.payload,
+    };
+  }
+
   return {
     key,
     message: await unwrapHttpError(err),

--- a/packages/aio-commerce-lib-app/source/management/domains/events/apply.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/events/apply.ts
@@ -11,11 +11,13 @@
  */
 
 import { unwrapHttpError } from "@adobe/aio-commerce-lib-api/utils";
+import { HTTPError } from "ky";
 
 import {
   isHttpNotFoundError,
   throwHttpError,
 } from "#management/common/utils/http-error";
+import { RecoveryScope } from "#management/common/workflow/recovery";
 
 import {
   diffByKey,
@@ -53,6 +55,7 @@ import type {
 import type {
   ExistingIoEventsData,
   IoEventProviderWithMetadata,
+  SubscriptionChangeKind,
 } from "./utils";
 
 /** The synthetic config shape apply rebuilds from provider snapshots to reuse install/uninstall. */
@@ -101,35 +104,120 @@ export async function applyEventingLeaf(
     );
   }
 
-  // 2. Converge every target provider. `install` is create-or-get, so it handles added providers,
-  //    added metadata, and registrations for newly declared runtime actions.
-  if (plan.targetProviders.length > 0) {
-    await options.install(
-      // `targetMetadata` is non-null whenever there are target providers to onboard.
-      buildLeafConfig(
-        plan.targetProviders,
-        plan.targetMetadata as ApplicationMetadata,
-        options,
-      ),
-      eventsContext,
-    );
+  // Onboarding subscribes added events non-atomically, so roll back this upgrade's added
+  // subscriptions on failure — otherwise a rejected add leaves its accepted siblings behind.
+  const recovery = new RecoveryScope(eventsContext.logger);
+  if (options.isCommerce && plan.baselineMetadata) {
+    registerAddedSubscriptionCompensations(plan, eventsContext, recovery);
   }
 
-  // 3. Reconcile sub-resources of providers present on both sides: registration event-set changes
-  //    (PUT) and per-event metadata/subscription/registration removals — none of which `install` does.
-  if (plan.baselineMetadata) {
-    const existingData = await getIoEventsExistingData(eventsContext);
-    await reconcilePersistingProviders(
-      plan,
-      existingData,
-      eventsContext,
-      options,
-    );
+  try {
+    // 2. Converge every target provider. `install` is create-or-get, so it handles added providers,
+    //    added metadata, and registrations for newly declared runtime actions.
+    if (plan.targetProviders.length > 0) {
+      await options.install(
+        // `targetMetadata` is non-null whenever there are target providers to onboard.
+        buildLeafConfig(
+          plan.targetProviders,
+          plan.targetMetadata as ApplicationMetadata,
+          options,
+        ),
+        eventsContext,
+      );
+    }
+
+    // 3. Reconcile sub-resources of providers present on both sides: registration event-set changes
+    //    (PUT) and per-event metadata/subscription/registration removals — none of which `install` does.
+    if (plan.baselineMetadata) {
+      const existingData = await getIoEventsExistingData(eventsContext);
+      await reconcilePersistingProviders(
+        plan,
+        existingData,
+        eventsContext,
+        options,
+      );
+    }
+  } catch (error) {
+    // Deletes this upgrade's added subscriptions before surfacing the error. Persisting-provider
+    // reconciliation (registrations, dropped/changed subscriptions) has its own, narrower recovery.
+    return recovery.recover(error);
   }
 
   return {
     snapshotData: { providers: plan.targetProviders },
   };
+}
+
+/**
+ * Registers rollback for the Commerce subscriptions this upgrade adds: one compensation per event
+ * absent from the provider's baseline, so pre-existing subscriptions are never touched.
+ *
+ * Scoped to subscriptions only — a wholly new provider's empty shell is left in place on rollback
+ * rather than torn down, which is harmless drift a later converge reuses.
+ */
+function registerAddedSubscriptionCompensations(
+  plan: EventingDomainPlan,
+  context: EventsExecutionContext,
+  recovery: RecoveryScope,
+): void {
+  const baselineByKey = new Map(
+    plan.baselineProviders.map((provider) => [provider.key, provider]),
+  );
+  const targetMetadata = plan.targetMetadata as ApplicationMetadata;
+  const baselineMetadata = plan.baselineMetadata as ApplicationMetadata;
+
+  for (const target of plan.targetProviders) {
+    const baseline = baselineByKey.get(target.key);
+    const { added } = diffByKey(
+      target.events,
+      baseline?.events ?? [],
+      (event) => getNamespacedEvent(targetMetadata, event.name),
+      (event) => getNamespacedEvent(baselineMetadata, event.name),
+    );
+
+    for (const event of added) {
+      const name = getNamespacedEvent(targetMetadata, event.name);
+      recovery.onFailure(() => deleteAddedSubscription(name, context));
+    }
+  }
+}
+
+/** Matches Commerce's 400 response to unsubscribing an event it never registered. */
+const NOT_REGISTERED_PATTERN = /is not registered/i;
+
+/**
+ * Whether the error means there was nothing to roll back — the target was already gone (404), or,
+ * for the rejected event itself, never existed in the first place (Commerce's 400 for unsubscribing
+ * an unregistered event).
+ */
+async function isNothingToRollBack(error: unknown): Promise<boolean> {
+  if (isHttpNotFoundError(error)) {
+    return true;
+  }
+  if (!(error instanceof HTTPError) || error.response.status !== 400) {
+    return false;
+  }
+
+  const message = await unwrapHttpError(error);
+  return NOT_REGISTERED_PATTERN.test(message);
+}
+
+/** Deletes a Commerce subscription added during a failed upgrade; treats one that's already gone as done. */
+async function deleteAddedSubscription(
+  name: string,
+  context: EventsExecutionContext,
+): Promise<void> {
+  const { commerceEventsClient, logger } = context;
+
+  try {
+    await commerceEventsClient.deleteEventSubscription({ name });
+    logger.info(`Rolled back added Commerce event subscription "${name}".`);
+  } catch (error) {
+    if (await isNothingToRollBack(error)) {
+      return;
+    }
+    throw error;
+  }
 }
 
 /** Builds a synthetic leaf config from provider snapshots for reuse of install/uninstall. */
@@ -565,7 +653,7 @@ async function reconcileChangedSubscriptions(
   baselineMetadata: ApplicationMetadata,
   context: EventsExecutionContext,
 ): Promise<void> {
-  const { commerceEventsClient, logger } = context;
+  const { logger } = context;
   const baselineByName = new Map(
     baselineEvents.map((event) => [
       getNamespacedEvent(baselineMetadata, event.name),
@@ -573,56 +661,132 @@ async function reconcileChangedSubscriptions(
     ]),
   );
 
-  for (const event of targetEvents as CommerceEvent[]) {
-    const name = getNamespacedEvent(targetMetadata, event.name);
-    const baselineEvent = baselineByName.get(name);
-    if (!baselineEvent) {
-      // Added event — created by the idempotent install pass.
-      continue;
-    }
+  // Restore this provider's changed subscriptions to their baseline if any change fails: a
+  // `recreate` deletes before it creates, so a rejected create would otherwise lose the old
+  // subscription. Recovery is scoped to the subscription entity — the surrounding metadata and
+  // registration reconciliation keep their existing best-effort semantics.
+  const recovery = new RecoveryScope(logger);
 
-    const changeMode = getSubscriptionChangeKind(baselineEvent, event);
-    if (changeMode === "none") {
-      continue;
-    }
-
-    const subscription = {
-      fields: event.fields,
-      hipaa_audit_required: event.hipaa_audit_required,
-      name,
-      parent: event.name,
-      priority: event.priority,
-      provider_id: providerId,
-      rules: event.rules,
-    };
-
-    try {
-      if (changeMode === "in-place") {
-        // biome-ignore lint/performance/noAwaitInLoops: subscriptions are updated sequentially to avoid a Commerce rate-limit burst
-        await commerceEventsClient.updateEventSubscription(subscription);
-        logger.info(`Updated Commerce event subscription "${name}" in place.`);
-      } else {
-        // The merge-update endpoint cannot remove or re-key fields/rules, so re-subscribe. The
-        // Commerce unsubscribe/subscribe cascade churns the event's I/O metadata; the registration
-        // re-links by event code and is left untouched.
-        await commerceEventsClient.deleteEventSubscription({ name });
-        await commerceEventsClient.createEventSubscription({
-          ...subscription,
-          destination: event.destination,
-          force: event.force,
-        });
-        logger.info(`Recreated Commerce event subscription "${name}".`);
+  try {
+    for (const event of targetEvents as CommerceEvent[]) {
+      const name = getNamespacedEvent(targetMetadata, event.name);
+      const baselineEvent = baselineByName.get(name);
+      if (!baselineEvent) {
+        // Added event — created by the idempotent install pass.
+        continue;
       }
-    } catch (error) {
-      const message = await unwrapHttpError(error);
-      // Unlike the best-effort removals, a failure here fails the upgrade step: a silently stale
-      // subscription would diverge from the applied config.
-      throw new Error(
-        `Failed to update Commerce event subscription "${name}": ${message}`,
-        { cause: error },
+
+      const changeMode = getSubscriptionChangeKind(baselineEvent, event);
+      if (changeMode === "none") {
+        continue;
+      }
+
+      const registerRestore = () =>
+        recovery.onFailure(() =>
+          restoreBaselineSubscription(baselineEvent, name, providerId, context),
+        );
+
+      // A recreate deletes before it creates, so register its restore up front — even a failed
+      // create must roll back. An in-place update is non-destructive, so register its restore only
+      // after it applies; a failed update leaves the baseline subscription intact and recovery must
+      // not delete it.
+      if (changeMode === "recreate") {
+        registerRestore();
+      }
+
+      // biome-ignore lint/performance/noAwaitInLoops: subscriptions are reconciled sequentially to avoid a Commerce rate-limit burst
+      await applySubscriptionChange(
+        changeMode,
+        event,
+        name,
+        providerId,
+        context,
       );
+
+      if (changeMode === "in-place") {
+        registerRestore();
+      }
     }
+  } catch (error) {
+    // Roll this provider's subscriptions back to baseline before surfacing the error.
+    return recovery.recover(error);
   }
+}
+
+/** Applies one subscription's change to Commerce; a `recreate` re-subscribes (delete then create). */
+async function applySubscriptionChange(
+  changeMode: Exclude<SubscriptionChangeKind, "none">,
+  event: CommerceEvent,
+  name: string,
+  providerId: string,
+  context: EventsExecutionContext,
+): Promise<void> {
+  const { commerceEventsClient, logger } = context;
+  const subscription = {
+    fields: event.fields,
+    hipaa_audit_required: event.hipaa_audit_required,
+    name,
+    parent: event.name,
+    priority: event.priority,
+    provider_id: providerId,
+    rules: event.rules,
+  };
+
+  try {
+    if (changeMode === "in-place") {
+      await commerceEventsClient.updateEventSubscription(subscription);
+      logger.info(`Updated Commerce event subscription "${name}" in place.`);
+    } else {
+      // The merge-update endpoint cannot remove or re-key fields/rules, so re-subscribe. The
+      // Commerce unsubscribe/subscribe cascade churns the event's I/O metadata; the registration
+      // re-links by event code and is left untouched.
+      await commerceEventsClient.deleteEventSubscription({ name });
+      await commerceEventsClient.createEventSubscription({
+        ...subscription,
+        destination: event.destination,
+        force: event.force,
+      });
+      logger.info(`Recreated Commerce event subscription "${name}".`);
+    }
+  } catch (error) {
+    const message = await unwrapHttpError(error);
+    // Unlike the best-effort removals, a failure here fails the upgrade step: a silently stale
+    // subscription would diverge from the applied config.
+    throw new Error(
+      `Failed to update Commerce event subscription "${name}": ${message}`,
+      { cause: error },
+    );
+  }
+}
+
+/** Re-subscribes a subscription's baseline version, deleting any current one first. */
+async function restoreBaselineSubscription(
+  baselineEvent: CommerceEvent,
+  name: string,
+  providerId: string,
+  context: EventsExecutionContext,
+): Promise<void> {
+  const { commerceEventsClient, logger } = context;
+
+  try {
+    await commerceEventsClient.deleteEventSubscription({ name });
+  } catch (error) {
+    logger.debug(
+      `Subscription "${name}" already absent during recovery: ${await unwrapHttpError(error)}`,
+    );
+  }
+
+  await commerceEventsClient.createEventSubscription({
+    destination: baselineEvent.destination,
+    fields: baselineEvent.fields,
+    force: baselineEvent.force,
+    hipaa_audit_required: baselineEvent.hipaa_audit_required,
+    name,
+    parent: baselineEvent.name,
+    priority: baselineEvent.priority,
+    provider_id: providerId,
+    rules: baselineEvent.rules,
+  });
 }
 
 /** Finds a deployed registration by its current or legacy name. */

--- a/packages/aio-commerce-lib-app/source/management/domains/webhooks/apply.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/webhooks/apply.ts
@@ -11,6 +11,7 @@
  */
 
 import { getInstallCommerceEnv } from "#config/lib/environment";
+import { RecoveryScope } from "#management/common/workflow/recovery";
 
 import {
   createWebhookSubscription,
@@ -25,10 +26,7 @@ import {
   webhookIdentitiesMatch,
 } from "./utils";
 
-import type {
-  CommerceWebhook,
-  WebhookSubscribeParams,
-} from "@adobe/aio-commerce-lib-webhooks/api";
+import type { WebhookSubscribeParams } from "@adobe/aio-commerce-lib-webhooks/api";
 import type { WebhooksConfig } from "#config/schema/webhooks";
 import type {
   ApplyContext,
@@ -42,9 +40,26 @@ import type {
   WebhookSnapshotData,
 } from "./types";
 
+/** Mutable state threaded through the per-operation handlers as the apply progresses. */
+type WebhookApplyState = {
+  liveIdentities: WebhookIdentity[];
+  subscribedWebhooks: WebhookSubscribeParams[];
+};
+
+/** Everything a per-operation handler needs beyond the operation itself. */
+type WebhookApplyDeps = {
+  commerceWebhooksClient: WebhooksExecutionContext["commerceWebhooksClient"];
+  logger: WebhooksExecutionContext["logger"];
+  params: Record<string, unknown>;
+  recordRemovalOfAdded: (identity: WebhookIdentity) => void;
+  recordRestoreOfRemoved: (identity: WebhookIdentity) => void;
+};
+
 /**
- * Applies add, update, and remove operations while pruning live app-owned
- * webhooks absent from the target. Aborts on the first failure.
+ * Applies add, update, and remove operations while pruning live app-owned webhooks absent from the
+ * target. On the first failure it rolls every change already committed to Commerce back to the
+ * stored baseline (re-subscribing removed webhooks, unsubscribing added ones) before surfacing the
+ * error, so a rejected replacement never leaves Commerce out of sync with the baseline.
  */
 export async function applyWebhookSubscriptions(
   plan: WebhookDomainPlan,
@@ -58,10 +73,6 @@ export async function applyWebhookSubscriptions(
 
   const liveWebhooks = await commerceWebhooksClient.getWebhookList();
 
-  let subscribedWebhooks: WebhookSubscribeParams[] = [
-    ...(context.baseline?.data.subscribedWebhooks ?? []),
-  ];
-
   const appConfig = context.targetConfig ?? context.baseline?.config;
   if (!appConfig) {
     throw new Error(
@@ -74,133 +85,223 @@ export async function applyWebhookSubscriptions(
     ? resolveDesiredWebhooks(context.targetConfig, env)
     : [];
 
-  let liveIdentities = await pruneStaleWebhooks(
-    liveWebhooks,
-    desired,
-    appConfig.metadata.id,
-    context,
-  );
+  // Restoring a removed webhook needs `requiresAdobeAuth`, which only the baseline's own desired
+  // webhooks carry. Resolved lazily so the happy path never pays for it.
+  let baselineDesiredCache: ResolvedWebhookPayload[] | null = null;
+  const getBaselineDesired = (): ResolvedWebhookPayload[] => {
+    baselineDesiredCache ??= context.baseline
+      ? resolveDesiredWebhooks(context.baseline.config, env)
+      : [];
+    return baselineDesiredCache;
+  };
 
-  for (const operation of plan.operations) {
-    if (operation.kind === "add") {
-      // `after` is always fully resolved for `add` (see planWebhookSubscriptions).
-      const { requiresAdobeAuth, ...resolvedWebhook } =
-        operation.after as ResolvedWebhookPayload;
-      const identity = toIdentity(resolvedWebhook);
+  const recovery = new RecoveryScope(logger);
 
-      if (isWebhookInList(liveIdentities, identity)) {
-        logger.info(
-          `Webhook already subscribed, skipping: ${getWebhookName(identity)}`,
-        );
-      } else {
-        const toSubscribe = createSubscribeParams(
-          resolvedWebhook,
-          requiresAdobeAuth,
-          params,
-        );
-
-        // biome-ignore lint/performance/noAwaitInLoops: operations must run sequentially so a failure aborts the remaining ones
-        await createWebhookSubscription(commerceWebhooksClient, toSubscribe);
-        logger.info(`Subscribed webhook: ${getWebhookName(identity)}`);
-        liveIdentities = [...liveIdentities, identity];
-      }
-
-      if (!isWebhookInList(subscribedWebhooks, identity)) {
-        subscribedWebhooks.push(resolvedWebhook);
-      }
-    } else if (operation.kind === "update") {
-      const identity = toIdentity(operation.before);
-
-      // `after` is always fully resolved for `update` (see planWebhookSubscriptions).
-      const { requiresAdobeAuth, ...resolvedWebhook } =
-        operation.after as ResolvedWebhookPayload;
-
-      // Commerce's subscribe endpoint is a guarded insert, not an upsert — it rejects a
-      // still-live identity, so an update must unsubscribe before it can resubscribe.
-      if (isWebhookInList(liveIdentities, identity)) {
+  const deps: WebhookApplyDeps = {
+    commerceWebhooksClient,
+    logger,
+    params,
+    /** Records how to remove a just-added webhook, if the apply later fails. */
+    recordRemovalOfAdded: (identity) => {
+      recovery.onFailure(async () => {
         await deleteWebhookSubscription(
           commerceWebhooksClient,
           identity,
           identity,
         );
-        liveIdentities = liveIdentities.filter(
-          (live) => !webhookIdentitiesMatch(live, identity),
+      });
+    },
+    /** Records how to put a just-removed baseline webhook back, if the apply later fails. */
+    recordRestoreOfRemoved: (identity) => {
+      recovery.onFailure(async () => {
+        const baselineEntry = getBaselineDesired().find((webhook) =>
+          webhookIdentitiesMatch(webhook, identity),
         );
-      }
+        if (!baselineEntry) {
+          // Not part of the baseline (e.g. a webhook subscribed out-of-band) — restoring it is
+          // neither possible nor required to match the stored baseline.
+          return;
+        }
 
-      const toSubscribe = createSubscribeParams(
-        resolvedWebhook,
-        requiresAdobeAuth,
-        params,
-      );
-
-      await createWebhookSubscription(commerceWebhooksClient, toSubscribe);
-      logger.info(`Updated webhook: ${getWebhookName(identity)}`);
-      liveIdentities = [...liveIdentities, identity];
-
-      subscribedWebhooks = [
-        ...subscribedWebhooks.filter(
-          (subscribed) => !webhookIdentitiesMatch(subscribed, identity),
-        ),
-        resolvedWebhook,
-      ];
-    } else if (operation.kind === "remove") {
-      const identity = toIdentity(operation.before);
-
-      if (isWebhookInList(liveIdentities, identity)) {
-        await deleteWebhookSubscription(
+        const { requiresAdobeAuth, ...resolvedWebhook } = baselineEntry;
+        await createWebhookSubscription(
           commerceWebhooksClient,
-          identity,
-          identity,
+          createSubscribeParams(resolvedWebhook, requiresAdobeAuth, params),
         );
-        logger.info(`Unsubscribed webhook: ${getWebhookName(identity)}`);
-        liveIdentities = liveIdentities.filter(
-          (live) => !webhookIdentitiesMatch(live, identity),
-        );
-      } else {
-        logger.debug(
-          `Webhook not found, skipping unsubscribe: ${getWebhookName(identity)}`,
-        );
-      }
+      });
+    },
+  };
 
-      subscribedWebhooks = subscribedWebhooks.filter(
-        (subscribed) => !webhookIdentitiesMatch(subscribed, identity),
-      );
+  const state: WebhookApplyState = {
+    liveIdentities: liveWebhooks.map(toIdentity),
+    subscribedWebhooks: [...(context.baseline?.data.subscribedWebhooks ?? [])],
+  };
+
+  try {
+    await pruneStaleWebhooks(state, desired, appConfig.metadata.id, deps);
+
+    for (const operation of plan.operations) {
+      // biome-ignore lint/performance/noAwaitInLoops: operations must run sequentially so a failure aborts the remaining ones
+      await applyWebhookOperation(operation, state, deps);
     }
+  } catch (error) {
+    // Roll Commerce back to the baseline before surfacing the error; the failed upgrade does not
+    // advance the baseline, so a clean recovery leaves the two back in sync.
+    return recovery.recover(error);
   }
 
   return {
-    snapshotData: { subscribedWebhooks },
+    snapshotData: { subscribedWebhooks: state.subscribedWebhooks },
   };
 }
 
-/** Removes live webhooks owned by this app that are absent from the target. */
+/** Dispatches a single planned operation to its handler. */
+function applyWebhookOperation(
+  operation: WebhookDomainPlan["operations"][number],
+  state: WebhookApplyState,
+  deps: WebhookApplyDeps,
+): Promise<void> {
+  if (operation.kind === "add") {
+    return applyAddOperation(operation, state, deps);
+  }
+  if (operation.kind === "update") {
+    return applyUpdateOperation(operation, state, deps);
+  }
+  return applyRemoveOperation(operation, state, deps);
+}
+
+/** Subscribes a planned add (unless already live) and records its compensating unsubscribe. */
+async function applyAddOperation(
+  operation: Extract<WebhookDomainPlan["operations"][number], { kind: "add" }>,
+  state: WebhookApplyState,
+  deps: WebhookApplyDeps,
+): Promise<void> {
+  const { commerceWebhooksClient, logger, params } = deps;
+
+  // `after` is always fully resolved for `add` (see planWebhookSubscriptions).
+  const { requiresAdobeAuth, ...resolvedWebhook } =
+    operation.after as ResolvedWebhookPayload;
+  const identity = toIdentity(resolvedWebhook);
+
+  if (isWebhookInList(state.liveIdentities, identity)) {
+    logger.info(
+      `Webhook already subscribed, skipping: ${getWebhookName(identity)}`,
+    );
+  } else {
+    await createWebhookSubscription(
+      commerceWebhooksClient,
+      createSubscribeParams(resolvedWebhook, requiresAdobeAuth, params),
+    );
+    logger.info(`Subscribed webhook: ${getWebhookName(identity)}`);
+    state.liveIdentities = [...state.liveIdentities, identity];
+    deps.recordRemovalOfAdded(identity);
+  }
+
+  if (!isWebhookInList(state.subscribedWebhooks, identity)) {
+    state.subscribedWebhooks.push(resolvedWebhook);
+  }
+}
+
+/**
+ * Applies an identity-preserving config change. Commerce's subscribe endpoint is a guarded insert,
+ * not an upsert, so an update must unsubscribe the live identity before resubscribing it.
+ */
+async function applyUpdateOperation(
+  operation: Extract<
+    WebhookDomainPlan["operations"][number],
+    { kind: "update" }
+  >,
+  state: WebhookApplyState,
+  deps: WebhookApplyDeps,
+): Promise<void> {
+  const { commerceWebhooksClient, logger, params } = deps;
+  const identity = toIdentity(operation.before);
+
+  // `after` is always fully resolved for `update` (see planWebhookSubscriptions).
+  const { requiresAdobeAuth, ...resolvedWebhook } =
+    operation.after as ResolvedWebhookPayload;
+
+  if (isWebhookInList(state.liveIdentities, identity)) {
+    await deleteWebhookSubscription(commerceWebhooksClient, identity, identity);
+    state.liveIdentities = state.liveIdentities.filter(
+      (live) => !webhookIdentitiesMatch(live, identity),
+    );
+    deps.recordRestoreOfRemoved(identity);
+  }
+
+  await createWebhookSubscription(
+    commerceWebhooksClient,
+    createSubscribeParams(resolvedWebhook, requiresAdobeAuth, params),
+  );
+  logger.info(`Updated webhook: ${getWebhookName(identity)}`);
+  state.liveIdentities = [...state.liveIdentities, identity];
+  deps.recordRemovalOfAdded(identity);
+
+  state.subscribedWebhooks = [
+    ...state.subscribedWebhooks.filter(
+      (subscribed) => !webhookIdentitiesMatch(subscribed, identity),
+    ),
+    resolvedWebhook,
+  ];
+}
+
+/** Unsubscribes a planned remove (if live) and records its compensating re-subscribe. */
+async function applyRemoveOperation(
+  operation: Extract<
+    WebhookDomainPlan["operations"][number],
+    { kind: "remove" }
+  >,
+  state: WebhookApplyState,
+  deps: WebhookApplyDeps,
+): Promise<void> {
+  const { commerceWebhooksClient, logger } = deps;
+  const identity = toIdentity(operation.before);
+
+  if (isWebhookInList(state.liveIdentities, identity)) {
+    await deleteWebhookSubscription(commerceWebhooksClient, identity, identity);
+    logger.info(`Unsubscribed webhook: ${getWebhookName(identity)}`);
+    state.liveIdentities = state.liveIdentities.filter(
+      (live) => !webhookIdentitiesMatch(live, identity),
+    );
+    deps.recordRestoreOfRemoved(identity);
+  } else {
+    logger.debug(
+      `Webhook not found, skipping unsubscribe: ${getWebhookName(identity)}`,
+    );
+  }
+
+  state.subscribedWebhooks = state.subscribedWebhooks.filter(
+    (subscribed) => !webhookIdentitiesMatch(subscribed, identity),
+  );
+}
+
+/**
+ * Removes live webhooks owned by this app that are absent from the target, recording a restore for
+ * each successful removal so a later failure can put it back. Mutates `state.liveIdentities`.
+ */
 async function pruneStaleWebhooks(
-  liveWebhooks: CommerceWebhook[],
+  state: WebhookApplyState,
   desiredWebhooks: readonly WebhookIdentity[],
   appId: string,
-  context: WebhooksExecutionContext,
-): Promise<WebhookIdentity[]> {
-  const { commerceWebhooksClient, logger } = context;
-  let liveIdentities = liveWebhooks.map(toIdentity);
-  const staleWebhooks = liveWebhooks.filter(
-    (webhook) =>
-      isWebhookOwnedByApp(webhook, appId) &&
-      !isDesiredWebhook(webhook, desiredWebhooks),
+  deps: WebhookApplyDeps,
+): Promise<void> {
+  const { commerceWebhooksClient, logger } = deps;
+  const staleIdentities = state.liveIdentities.filter(
+    (identity) =>
+      isWebhookOwnedByApp(identity, appId) &&
+      !isDesiredWebhook(identity, desiredWebhooks),
   );
 
-  for (const stale of staleWebhooks) {
-    const identity = toIdentity(stale);
-
+  for (const identity of staleIdentities) {
     // biome-ignore lint/performance/noAwaitInLoops: removals must run sequentially so a failure aborts the remaining work
     await deleteWebhookSubscription(commerceWebhooksClient, identity, identity);
 
     logger.info(`Unsubscribed webhook: ${getWebhookName(identity)}`);
-    liveIdentities = liveIdentities.filter(
+    state.liveIdentities = state.liveIdentities.filter(
       (live) => !webhookIdentitiesMatch(live, identity),
     );
+    deps.recordRestoreOfRemoved(identity);
   }
-  return liveIdentities;
 }
 
 /** Attaches Developer Console credentials when the webhook requires Adobe authentication. */

--- a/packages/aio-commerce-lib-app/test/integration/management/events.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/management/events.test.ts
@@ -14,11 +14,22 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { isSucceededState } from "#management/common/workflow/types";
+import { applyCommerceEvents } from "#management/domains/events/commerce";
+import { createEventsStepContext } from "#management/domains/events/context";
+import { planCommerceEvents } from "#management/domains/events/plan";
+import {
+  COMMERCE_PROVIDER_TYPE,
+  getNamespacedEvent,
+  getProviderKey,
+} from "#management/domains/events/utils";
 import {
   createInitialInstallationState,
   runInstallation,
 } from "#management/installation/runner";
-import { configWithFullEventing } from "#test/fixtures/config";
+import {
+  configWithCommerceEventing,
+  configWithFullEventing,
+} from "#test/fixtures/config";
 import {
   createMockCommerceEventProvider,
   createMockIoEventMetadata,
@@ -36,6 +47,7 @@ import type {
   EventProviderCreateParams as CommerceEventProviderCreateParams,
   UpdateEventingConfigurationParams,
 } from "@adobe/aio-commerce-lib-events/commerce";
+import type { EventingSnapshotData } from "#management/domains/events/types";
 
 type IoEventProviderRequestBody = {
   label: string;
@@ -368,5 +380,217 @@ describe("eventing installation", () => {
         },
       },
     });
+  });
+});
+
+describe("eventing upgrade recovery integration", () => {
+  const UPGRADE_PATH = ["upgrade", "eventing", "commerce"];
+
+  test("rolls back an added subscription when Commerce rejects a sibling during an upgrade", async () => {
+    vi.stubEnv("__OW_NAMESPACE", "test-namespace");
+
+    const {
+      consumerOrgId: orgId,
+      projectId,
+      workspaceId,
+    } = installationContext.appData;
+
+    const baselineConfig = configWithCommerceEventing;
+    const [baselineProvider] = baselineConfig.eventing.commerce;
+    // The upgrade adds two events; Commerce accepts one and rejects the other.
+    const addedValidEvent = {
+      description: "Triggered when an order is accepted",
+      fields: [{ name: "order_id" }],
+      label: "Order Accepted",
+      name: "plugin.order_accepted",
+      runtimeActions: ["my-package/handle-order"],
+    };
+    const addedRejectedEvent = {
+      description: "An event Commerce does not support",
+      fields: [{ name: "order_id" }],
+      label: "Invented",
+      name: "plugin.invented_event",
+      runtimeActions: ["my-package/handle-order"],
+    };
+    const targetConfig = {
+      ...baselineConfig,
+      eventing: {
+        commerce: [
+          {
+            ...baselineProvider,
+            events: [
+              ...baselineProvider.events,
+              addedValidEvent,
+              addedRejectedEvent,
+            ],
+          },
+        ],
+      },
+    };
+
+    // Maps each event's parent (raw) name to the namespaced subscription name Commerce received.
+    const subscribedByParent: Record<string, string> = {};
+    const unsubscribed: string[] = [];
+
+    apiServer.use(
+      http.get(`${IO_EVENTS_BASE_URL}/${orgId}/providers`, () =>
+        HttpResponse.json({
+          _embedded: { providers: [] },
+          _links: { self: { href: "/providers" } },
+        }),
+      ),
+      http.get(
+        `${IO_EVENTS_BASE_URL}/${orgId}/${projectId}/${workspaceId}/registrations`,
+        () =>
+          HttpResponse.json({
+            _embedded: { registrations: [] },
+            _links: { self: { href: "/registrations" } },
+          }),
+      ),
+      http.post(
+        `${IO_EVENTS_BASE_URL}/${orgId}/${projectId}/${workspaceId}/providers`,
+        async ({ request }) => {
+          const body = (await request.json()) as IoEventProviderRequestBody;
+          return HttpResponse.json(
+            createMockIoEventProviderHalModel(
+              createMockIoEventProvider({
+                description: body.description,
+                id: "io-provider-commerce",
+                instance_id: body.instance_id,
+                label: body.label,
+                provider_metadata: body.provider_metadata,
+              }),
+            ),
+          );
+        },
+      ),
+      http.post(
+        `${IO_EVENTS_BASE_URL}/${orgId}/${projectId}/${workspaceId}/providers/:providerId/eventmetadata`,
+        async ({ request }) => {
+          const body = (await request.json()) as IoEventMetadataRequestBody;
+          return HttpResponse.json(
+            createMockIoEventMetadataHalModel(
+              createMockIoEventMetadata({
+                description: body.description,
+                event_code: body.event_code,
+                label: body.label,
+              }),
+            ),
+          );
+        },
+      ),
+      http.post(
+        `${IO_EVENTS_BASE_URL}/${orgId}/${projectId}/${workspaceId}/registrations`,
+        async ({ request }) => {
+          const body = (await request.json()) as IoEventRegistrationRequestBody;
+          return HttpResponse.json(
+            createMockIoEventRegistrationHalModel(
+              createMockIoEventRegistration({
+                client_id: body.client_id,
+                description: body.description,
+                id: "registration-1",
+                name: body.name,
+              }),
+            ),
+          );
+        },
+      ),
+      http.get(`${COMMERCE_BASE_URL}/eventing/eventProvider`, () =>
+        HttpResponse.json([{ workspace_configuration: "" }]),
+      ),
+      http.get(`${COMMERCE_BASE_URL}/eventing/getEventSubscriptions`, () =>
+        HttpResponse.json([]),
+      ),
+      http.put(`${COMMERCE_BASE_URL}/eventing/updateConfiguration`, () =>
+        HttpResponse.json(true),
+      ),
+      http.post(
+        `${COMMERCE_BASE_URL}/eventing/eventProvider`,
+        async ({ request }) => {
+          const { eventProvider } = (await request.json()) as {
+            eventProvider: CommerceEventProviderCreateParams;
+          };
+          return HttpResponse.json(
+            createMockCommerceEventProvider({
+              description: eventProvider.description,
+              id: "commerce-provider-1",
+              instance_id: eventProvider.instance_id,
+              label: eventProvider.label,
+              provider_id: eventProvider.provider_id,
+              workspace_configuration: "",
+            }),
+          );
+        },
+      ),
+      http.post(
+        `${COMMERCE_BASE_URL}/eventing/eventSubscribe`,
+        async ({ request }) => {
+          const body = (await request.json()) as {
+            event: { name: string; parent: string };
+          };
+          subscribedByParent[body.event.parent] = body.event.name;
+
+          if (body.event.parent === addedRejectedEvent.name) {
+            // Commerce rejects an event it does not support.
+            return HttpResponse.json(
+              { message: "Event is not in the list of supported events" },
+              { status: 400 },
+            );
+          }
+          return HttpResponse.json([]);
+        },
+      ),
+      http.post(
+        `${COMMERCE_BASE_URL}/eventing/eventUnsubscribe/:name`,
+        ({ params }) => {
+          unsubscribed.push(decodeURIComponent(params.name as string));
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    const lifecycleContext = createMockInstallationContext();
+    const context = {
+      ...lifecycleContext,
+      ...createEventsStepContext(lifecycleContext),
+    };
+    const baselineData: EventingSnapshotData = {
+      providers: [
+        {
+          events: baselineProvider.events,
+          key: getProviderKey(baselineProvider.provider),
+          provider: baselineProvider.provider,
+          type: COMMERCE_PROVIDER_TYPE,
+        },
+      ],
+    };
+    const baseline = { config: baselineConfig, data: baselineData };
+
+    const planResult = await planCommerceEvents(
+      { baseline, path: UPGRADE_PATH, targetConfig },
+      context,
+    );
+    expect.assert(planResult.kind === "planned");
+
+    // The apply fails (no snapshot advances the baseline) reporting the original rejection.
+    const applyResult = await applyCommerceEvents(planResult.plan, {
+      ...context,
+      attemptId: "attempt-1",
+      baseline,
+      targetConfig,
+    }).catch((error: unknown) => error);
+    expect(applyResult).toBeInstanceOf(Error);
+
+    // The accepted added event was subscribed, then rolled back on recovery, while the baseline
+    // event is never unsubscribed.
+    const acceptedName = subscribedByParent[addedValidEvent.name];
+    expect(acceptedName).toBeDefined();
+    expect(unsubscribed).toContain(acceptedName);
+    expect(unsubscribed).not.toContain(
+      getNamespacedEvent(
+        baselineConfig.metadata,
+        baselineProvider.events[0].name,
+      ),
+    );
   });
 });

--- a/packages/aio-commerce-lib-app/test/integration/management/webhooks.test.ts
+++ b/packages/aio-commerce-lib-app/test/integration/management/webhooks.test.ts
@@ -423,4 +423,102 @@ describe("webhooks upgrade planning integration", () => {
       expect.objectContaining({ fields: [{ name: "sku" }] }),
     ]);
   });
+
+  test("restores the removed webhook when Commerce rejects a plugin.my_invented_webhook replacement", async () => {
+    vi.stubEnv("__OW_NAMESPACE", "test-namespace");
+
+    const [subscribedWebhook] = configWithWebhooks.webhooks;
+    const baselineWebhook = {
+      batch_name: "test_app_webhooks_default",
+      hook_name: "test_app_webhooks_order_created",
+      method: subscribedWebhook.webhook.method,
+      url: "https://test-namespace.adobeioruntime.net/api/v1/web/my-package/handle-webhook",
+      webhook_method: subscribedWebhook.webhook.webhook_method,
+      webhook_type: subscribedWebhook.webhook.webhook_type,
+    };
+
+    // webhook_method is an identity field, so changing it plans a remove-then-add.
+    const targetConfig = {
+      ...configWithWebhooks,
+      webhooks: [
+        {
+          ...configWithWebhooks.webhooks[0],
+          webhook: {
+            ...configWithWebhooks.webhooks[0].webhook,
+            webhook_method: "plugin.my_invented_webhook",
+          },
+        },
+      ],
+    };
+
+    const subscribedMethods: string[] = [];
+    let unsubscribed = false;
+
+    apiServer.use(
+      http.get(`${COMMERCE_BASE_URL}/webhooks/list`, () =>
+        HttpResponse.json([baselineWebhook]),
+      ),
+      http.post(`${COMMERCE_BASE_URL}/webhooks/unsubscribe`, () => {
+        unsubscribed = true;
+        return HttpResponse.json({});
+      }),
+      http.post(
+        `${COMMERCE_BASE_URL}/webhooks/subscribe`,
+        async ({ request }) => {
+          const body = (await request.json()) as {
+            webhook: { webhook_method: string };
+          };
+          subscribedMethods.push(body.webhook.webhook_method);
+
+          if (body.webhook.webhook_method === "plugin.my_invented_webhook") {
+            // Commerce rejects a webhook_method it does not support.
+            return HttpResponse.json(
+              { message: "Invalid webhook_method" },
+              { status: 400 },
+            );
+          }
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const lifecycleContext = createMockInstallationContext();
+    const context = {
+      ...lifecycleContext,
+      ...createWebhooksStepContext(lifecycleContext),
+    };
+    const baseline = {
+      config: configWithWebhooks,
+      data: { subscribedWebhooks: [baselineWebhook] },
+    };
+
+    const planResult = await planWebhookSubscriptions(
+      { baseline, path: UPGRADE_PATH, targetConfig },
+      context,
+    );
+    expect.assert(planResult.kind === "planned");
+    expect(planResult.plan.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "add" }),
+        expect.objectContaining({ kind: "remove" }),
+      ]),
+    );
+
+    // The apply fails (no snapshot returned, so the baseline is never advanced).
+    const applyResult = await applyWebhookSubscriptions(planResult.plan, {
+      ...context,
+      attemptId: "attempt-1",
+      baseline,
+      targetConfig,
+    }).catch((error: unknown) => error);
+    expect(applyResult).toBeInstanceOf(Error);
+
+    // The old webhook was removed, the replacement rejected, and the old one re-subscribed on
+    // recovery — so Commerce is back at the baseline.
+    expect(unsubscribed).toBe(true);
+    expect(subscribedMethods).toContain("plugin.my_invented_webhook");
+    expect(subscribedMethods).toContain(
+      subscribedWebhook.webhook.webhook_method,
+    );
+  });
 });

--- a/packages/aio-commerce-lib-app/test/unit/management/common/workflow/utils.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/common/workflow/utils.test.ts
@@ -12,6 +12,7 @@
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { WorkflowStepError } from "#management/common/workflow/recovery";
 import {
   createFailedState,
   createSucceededState,
@@ -143,6 +144,21 @@ describe("createWorkflowError", () => {
       key: "STEP_EXECUTION_FAILED",
       message: "HTTP 400 Bad Request — API error detail",
       path: ["step"],
+    });
+  });
+
+  test("should lift the key and payload from a WorkflowStepError", async () => {
+    const err = new WorkflowStepError("recovery failed", {
+      key: "UPGRADE_RECOVERY_FAILED",
+      payload: { targetMayDivergeFromBaseline: true },
+    });
+
+    const result = await createWorkflowError(err, ["step"], "IGNORED_KEY");
+    expect(result).toEqual({
+      key: "UPGRADE_RECOVERY_FAILED",
+      message: "recovery failed",
+      path: ["step"],
+      payload: { targetMayDivergeFromBaseline: true },
     });
   });
 });

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/events/apply.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/events/apply.test.ts
@@ -14,6 +14,10 @@ import { HTTPError } from "ky";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
+  UPGRADE_RECOVERY_FAILED,
+  WorkflowStepError,
+} from "#management/common/workflow/recovery";
+import {
   applyCommerceEvents,
   commerceEventsStep,
 } from "#management/domains/events/commerce";
@@ -42,6 +46,7 @@ import {
   createMockExternalEventsConfig as externalConfig,
   createMockIoEventsListClient as ioEventsClient,
 } from "#test/fixtures/eventing";
+import { makeHttpError } from "#test/fixtures/http-error";
 
 import type {
   CommerceEventsConfig,
@@ -883,8 +888,12 @@ describe("applyCommerceEvents", () => {
       key: "k1",
       label: "P1",
     };
+    const deleteEventSubscription = vi.fn().mockResolvedValue(undefined);
+    const createEventSubscription = vi.fn().mockResolvedValue(undefined);
     const context = persistingProviderContext(provider, {
       commerceEventsClient: {
+        createEventSubscription,
+        deleteEventSubscription,
         updateEventSubscription: () =>
           Promise.reject(new Error("update failed")),
       },
@@ -912,7 +921,305 @@ describe("applyCommerceEvents", () => {
 
     await expect(
       applyCommerceEvents(plan, context as ApplyContext<EventsStepContext>),
-    ).rejects.toThrow();
+    ).rejects.toThrow("update failed");
+
+    // The in-place update never applied, so the baseline subscription is untouched — recovery
+    // must not delete-then-recreate a subscription it never actually changed.
+    expect(deleteEventSubscription).not.toHaveBeenCalled();
+    expect(createEventSubscription).not.toHaveBeenCalled();
+  });
+
+  test("restores a subscription's baseline version when Commerce rejects its recreate", async () => {
+    vi.spyOn(commerceEventsStep, "install").mockResolvedValue([]);
+    const provider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+    // Reject the target recreate (one field) but let the baseline restore (two fields) succeed.
+    const createEventSubscription = vi.fn((sub: { fields?: unknown[] }) =>
+      sub.fields?.length === 1
+        ? Promise.reject(new Error("Commerce rejected the subscription"))
+        : Promise.resolve(null),
+    );
+    const context = persistingProviderContext(provider, {
+      commerceEventsClient: { createEventSubscription },
+    });
+
+    const plan = await planCommerce(
+      commerceConfig([
+        {
+          events: [
+            {
+              ...event("a", ["pkg/a"]),
+              fields: [{ name: "field_a" }, { name: "field_b" }],
+            },
+          ],
+          provider,
+        },
+      ]),
+      commerceConfig([
+        {
+          events: [{ ...event("a", ["pkg/a"]), fields: [{ name: "field_a" }] }],
+          provider,
+        },
+      ]),
+    );
+
+    await expect(
+      applyCommerceEvents(plan, context as ApplyContext<EventsStepContext>),
+    ).rejects.toThrow("Failed to update Commerce event subscription");
+
+    const name = getNamespacedEvent(metadata, "a");
+    // The baseline version (both fields) was re-created during recovery.
+    expect(createEventSubscription).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fields: [{ name: "field_a" }, { name: "field_b" }],
+        name,
+      }),
+    );
+  });
+
+  test("reports both errors and flags baseline drift when the recovery re-subscribe also fails", async () => {
+    vi.spyOn(commerceEventsStep, "install").mockResolvedValue([]);
+    const provider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+    const context = persistingProviderContext(provider, {
+      commerceEventsClient: {
+        createEventSubscription: () =>
+          Promise.reject(new Error("create failed")),
+      },
+    });
+
+    const plan = await planCommerce(
+      commerceConfig([
+        {
+          events: [
+            {
+              ...event("a", ["pkg/a"]),
+              fields: [{ name: "field_a" }, { name: "field_b" }],
+            },
+          ],
+          provider,
+        },
+      ]),
+      commerceConfig([
+        {
+          events: [{ ...event("a", ["pkg/a"]), fields: [{ name: "field_a" }] }],
+          provider,
+        },
+      ]),
+    );
+
+    const error = await applyCommerceEvents(
+      plan,
+      context as ApplyContext<EventsStepContext>,
+    ).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(WorkflowStepError);
+    const workflowError = error as WorkflowStepError<{
+      targetMayDivergeFromBaseline: boolean;
+    }>;
+    expect(workflowError.key).toBe(UPGRADE_RECOVERY_FAILED);
+    expect(workflowError.payload?.targetMayDivergeFromBaseline).toBe(true);
+  });
+
+  test("rolls back this upgrade's added subscriptions when onboarding a new event is rejected", async () => {
+    // The create-or-get onboarding pass subscribes the added events; reject it as Commerce would
+    // for an unsupported event, after its accepted siblings were already created.
+    const install = vi
+      .spyOn(commerceEventsStep, "install")
+      .mockRejectedValue(
+        new Error(
+          'Event "observer.invalid" is not in the list of supported events',
+        ),
+      );
+    const deleteEventSubscription = vi.fn().mockResolvedValue(undefined);
+    const provider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+    const context = persistingProviderContext(provider, {
+      commerceEventsClient: { deleteEventSubscription },
+    });
+
+    // Baseline has "a"; this upgrade adds "b" and "c". Both adds must roll back, "a" must not.
+    const plan = await planCommerce(
+      commerceConfig([{ events: [event("a", ["pkg/a"])], provider }]),
+      commerceConfig([
+        {
+          events: [
+            event("a", ["pkg/a"]),
+            event("b", ["pkg/a"]),
+            event("c", ["pkg/a"]),
+          ],
+          provider,
+        },
+      ]),
+    );
+
+    await expect(
+      applyCommerceEvents(plan, context as ApplyContext<EventsStepContext>),
+    ).rejects.toThrow("is not in the list of supported events");
+
+    expect(install).toHaveBeenCalledTimes(1);
+    const deletedNames = deleteEventSubscription.mock.calls.map(
+      (call) => (call[0] as { name: string }).name,
+    );
+    expect(deletedNames).toEqual(
+      expect.arrayContaining([
+        getNamespacedEvent(metadata, "b"),
+        getNamespacedEvent(metadata, "c"),
+      ]),
+    );
+    expect(deletedNames).not.toContain(getNamespacedEvent(metadata, "a"));
+  });
+
+  test("tolerates Commerce's 400 for unsubscribing the rejected event's own never-created subscription", async () => {
+    // The compensation set is built from the plan's added events before any create runs, so it
+    // includes the rejected event itself. Commerce rejects unsubscribing an event it never
+    // registered with 400 (not 404) — reproduces the exact response seen in manual E2E testing.
+    const rejectedName = getNamespacedEvent(metadata, "b");
+    vi.spyOn(commerceEventsStep, "install").mockRejectedValue(
+      new Error('Event "observer.b" is not in the list of supported events'),
+    );
+    const deleteEventSubscription = vi.fn((params: { name: string }) =>
+      params.name === rejectedName
+        ? Promise.reject(
+            makeHttpError(
+              400,
+              "Bad Request",
+              JSON.stringify({
+                message: `The "${rejectedName}" event is not registered. You cannot unsubscribe from it.`,
+              }),
+            ),
+          )
+        : Promise.resolve(undefined),
+    );
+    const provider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+    const context = persistingProviderContext(provider, {
+      commerceEventsClient: { deleteEventSubscription },
+    });
+
+    // Baseline has "a"; this upgrade adds "b" (rejected) and "c" (accepted).
+    const plan = await planCommerce(
+      commerceConfig([{ events: [event("a", ["pkg/a"])], provider }]),
+      commerceConfig([
+        {
+          events: [
+            event("a", ["pkg/a"]),
+            event("b", ["pkg/a"]),
+            event("c", ["pkg/a"]),
+          ],
+          provider,
+        },
+      ]),
+    );
+
+    const error = await applyCommerceEvents(
+      plan,
+      context as ApplyContext<EventsStepContext>,
+    ).catch((thrown: unknown) => thrown);
+
+    // The 400 for "b" (never created) is tolerated, "c" (created) rolls back cleanly, so the
+    // original onboarding rejection surfaces rather than an UPGRADE_RECOVERY_FAILED.
+    expect((error as Error).message).toContain(
+      "is not in the list of supported events",
+    );
+    expect(deleteEventSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({ name: getNamespacedEvent(metadata, "c") }),
+    );
+  });
+
+  test("tolerates an already-absent subscription during rollback and surfaces the original error", async () => {
+    vi.spyOn(commerceEventsStep, "install").mockRejectedValue(
+      new Error("onboarding rejected"),
+    );
+    // The rejected event was never created, so its rollback delete comes back not-found.
+    const deleteEventSubscription = vi.fn().mockRejectedValue(httpError(404));
+    const provider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+    const context = persistingProviderContext(provider, {
+      commerceEventsClient: { deleteEventSubscription },
+    });
+
+    const plan = await planCommerce(
+      commerceConfig([{ events: [event("a", ["pkg/a"])], provider }]),
+      commerceConfig([
+        { events: [event("a", ["pkg/a"]), event("b", ["pkg/a"])], provider },
+      ]),
+    );
+
+    const error = await applyCommerceEvents(
+      plan,
+      context as ApplyContext<EventsStepContext>,
+    ).catch((thrown: unknown) => thrown);
+
+    // A not-found rollback delete is treated as already-gone, so recovery succeeds and the
+    // original onboarding error surfaces rather than an UPGRADE_RECOVERY_FAILED.
+    expect((error as Error).message).toContain("onboarding rejected");
+  });
+
+  test("rolls back a newly added provider's subscriptions when its onboarding is rejected", async () => {
+    const install = vi
+      .spyOn(commerceEventsStep, "install")
+      .mockRejectedValue(new Error("new provider onboarding rejected"));
+    const deleteEventSubscription = vi.fn().mockResolvedValue(undefined);
+    const existingProvider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+    const addedProvider: EventProvider = {
+      description: "P2",
+      key: "k2",
+      label: "P2",
+    };
+    const context = persistingProviderContext(existingProvider, {
+      commerceEventsClient: { deleteEventSubscription },
+    });
+
+    // Baseline has provider P1 (event "a"); the upgrade adds a wholly new provider P2 with "b"/"c".
+    const plan = await planCommerce(
+      commerceConfig([
+        { events: [event("a", ["pkg/a"])], provider: existingProvider },
+      ]),
+      commerceConfig([
+        { events: [event("a", ["pkg/a"])], provider: existingProvider },
+        {
+          events: [event("b", ["pkg/b"]), event("c", ["pkg/b"])],
+          provider: addedProvider,
+        },
+      ]),
+    );
+
+    await expect(
+      applyCommerceEvents(plan, context as ApplyContext<EventsStepContext>),
+    ).rejects.toThrow("new provider onboarding rejected");
+
+    expect(install).toHaveBeenCalledTimes(1);
+    const deletedNames = deleteEventSubscription.mock.calls.map(
+      (call) => (call[0] as { name: string }).name,
+    );
+    // Both of the new provider's subscriptions roll back; the existing provider's event does not.
+    expect(deletedNames).toEqual(
+      expect.arrayContaining([
+        getNamespacedEvent(metadata, "b"),
+        getNamespacedEvent(metadata, "c"),
+      ]),
+    );
+    expect(deletedNames).not.toContain(getNamespacedEvent(metadata, "a"));
   });
 });
 

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/webhooks/apply.test.ts
@@ -12,6 +12,10 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import {
+  UPGRADE_RECOVERY_FAILED,
+  WorkflowStepError,
+} from "#management/common/workflow/recovery";
 import { applyWebhookSubscriptions } from "#management/domains/webhooks/apply";
 import { DEFAULT_INSTALLATION_PARAMS } from "#test/fixtures/installation";
 import {
@@ -21,6 +25,7 @@ import {
   createMockWebhooksContext,
 } from "#test/fixtures/webhooks";
 
+import type { UpgradeRecoveryFailedPayload } from "#management/common/workflow/recovery";
 import type { WebhooksExecutionContext } from "#management/domains/webhooks/context";
 
 const DEFAULT_PARAMS = DEFAULT_INSTALLATION_PARAMS;
@@ -520,5 +525,170 @@ describe("applyWebhookSubscriptions", () => {
     await expect(applyWebhookSubscriptions(plan, context)).rejects.toThrow();
     expect(subscribeWebhook).not.toHaveBeenCalled();
     expect(unsubscribeWebhook).toHaveBeenCalledTimes(1);
+  });
+
+  const INVENTED_METHOD = "plugin.my_invented_webhook";
+
+  /** A webhook-identity change: the old identity is removed, the new one (rejected below) is added. */
+  const identityChangePlan = {
+    operations: [
+      {
+        before: retainedWebhook,
+        id: "op-remove",
+        kind: "remove" as const,
+        label: "Unsubscribe old",
+      },
+      {
+        after: createMockResolvedWebhook({
+          batch_name: "test_app_webhooks_invented",
+          hook_name: "test_app_webhooks_invented",
+          webhook_method: INVENTED_METHOD,
+          webhook_type: "after",
+        }),
+        id: "op-add",
+        kind: "add" as const,
+        label: "Subscribe new",
+      },
+    ],
+    path: UPGRADE_PATH,
+  };
+
+  test("restores the removed webhook when Commerce rejects its replacement, surfacing the original error", async () => {
+    // The removed webhook's replacement is rejected by Commerce (a webhook_method it does not
+    // support), so recovery must re-subscribe the removed baseline webhook.
+    const subscribeWebhook = vi.fn((payload: { webhook_method: string }) => {
+      if (payload.webhook_method === INVENTED_METHOD) {
+        return Promise.reject(
+          new Error("Commerce rejected the webhook_method"),
+        );
+      }
+      return Promise.resolve(null);
+    });
+    const unsubscribeWebhook = vi.fn().mockResolvedValue(null);
+    const getWebhookList = vi.fn().mockResolvedValue([retainedWebhook]);
+
+    const context = {
+      ...makeContext(
+        subscribeWebhook,
+        getWebhookList,
+        DEFAULT_PARAMS,
+        unsubscribeWebhook,
+      ),
+      attemptId: "attempt-1",
+      baseline: {
+        config: createMockWebhooksConfig(),
+        data: { subscribedWebhooks: [retainedWebhook] },
+      },
+      targetConfig: createMockWebhooksConfig(),
+    };
+
+    await expect(
+      applyWebhookSubscriptions(identityChangePlan, context),
+    ).rejects.toThrow("Commerce rejected the webhook_method");
+
+    // The old webhook was unsubscribed, then re-subscribed on recovery.
+    expect(unsubscribeWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook_method: DEFAULT_RESOLVED_IDENTITY.webhook_method,
+      }),
+    );
+    expect(subscribeWebhook).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        webhook_method: DEFAULT_RESOLVED_IDENTITY.webhook_method,
+      }),
+    );
+  });
+
+  test("reports both errors and flags baseline drift when recovery itself fails", async () => {
+    // Commerce rejects the replacement, and then also rejects the re-subscribe of the old webhook,
+    // so recovery cannot restore the baseline.
+    const subscribeWebhook = vi.fn((payload: { webhook_method: string }) => {
+      if (payload.webhook_method === INVENTED_METHOD) {
+        return Promise.reject(new Error("original rejection"));
+      }
+      return Promise.reject(new Error("recovery rejection"));
+    });
+    const unsubscribeWebhook = vi.fn().mockResolvedValue(null);
+    const getWebhookList = vi.fn().mockResolvedValue([retainedWebhook]);
+
+    const context = {
+      ...makeContext(
+        subscribeWebhook,
+        getWebhookList,
+        DEFAULT_PARAMS,
+        unsubscribeWebhook,
+      ),
+      attemptId: "attempt-1",
+      baseline: {
+        config: createMockWebhooksConfig(),
+        data: { subscribedWebhooks: [retainedWebhook] },
+      },
+      targetConfig: createMockWebhooksConfig(),
+    };
+
+    const error = await applyWebhookSubscriptions(
+      identityChangePlan,
+      context,
+    ).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(WorkflowStepError);
+    const workflowError =
+      error as WorkflowStepError<UpgradeRecoveryFailedPayload>;
+    expect(workflowError.key).toBe(UPGRADE_RECOVERY_FAILED);
+    expect(workflowError.payload).toMatchObject({
+      originalError: expect.stringContaining("original rejection"),
+      recovery: "failed",
+      recoveryError: expect.stringContaining("recovery rejection"),
+      targetMayDivergeFromBaseline: true,
+    });
+  });
+
+  test("unsubscribes an already-added webhook when a later add fails, returning to the baseline", async () => {
+    // Two adds, the second rejected: recovery must undo the first (already-subscribed) add so the
+    // target matches the baseline, not "baseline + the surviving add".
+    const firstAdd = createMockResolvedWebhook({
+      batch_name: "test_app_webhooks_first",
+      hook_name: "test_app_webhooks_first",
+      webhook_method: "observer.first_added",
+      webhook_type: "after",
+    });
+    const secondAdd = createMockResolvedWebhook({
+      batch_name: "test_app_webhooks_second",
+      hook_name: "test_app_webhooks_second",
+      webhook_method: INVENTED_METHOD,
+      webhook_type: "after",
+    });
+
+    const subscribeWebhook = vi.fn((payload: { webhook_method: string }) => {
+      if (payload.webhook_method === INVENTED_METHOD) {
+        return Promise.reject(
+          new Error("Commerce rejected the webhook_method"),
+        );
+      }
+      return Promise.resolve(null);
+    });
+    const unsubscribeWebhook = vi.fn().mockResolvedValue(null);
+    const context = makeApplyContext(
+      subscribeWebhook,
+      vi.fn().mockResolvedValue([]),
+      unsubscribeWebhook,
+    );
+
+    const plan = {
+      operations: [
+        { after: firstAdd, id: "op-1", kind: "add" as const, label: "Add 1" },
+        { after: secondAdd, id: "op-2", kind: "add" as const, label: "Add 2" },
+      ],
+      path: UPGRADE_PATH,
+    };
+
+    await expect(applyWebhookSubscriptions(plan, context)).rejects.toThrow(
+      "Commerce rejected the webhook_method",
+    );
+
+    // The first add was rolled back.
+    expect(unsubscribeWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ webhook_method: "observer.first_added" }),
+    );
   });
 });


### PR DESCRIPTION
## Description

During an upgrade, an identity change on a webhook or event subscription is applied as remove-then-add. If the target rejects the replacement, the previous entity was already gone — leaving the app broken and the stored baseline out of sync with reality.

This adds a `RecoveryScope` abstraction (`management/common/workflow/recovery.ts`) that both the webhooks and events domains use: each domain records a compensation immediately after committing a change to the target, and on failure replays those compensations in reverse to roll the target back to the stored baseline before surfacing the original error. If recovery itself also fails, the failure carries both the original and recovery errors and flags that the target may no longer match the baseline (`UPGRADE_RECOVERY_FAILED`).

Extended past the ticket's literal replacement scope to also cover **multi-add atomicity** for events: adding several new event subscriptions in one upgrade is no longer partial — if the target rejects one, the ones already created in that attempt are rolled back too (webhooks already had this by virtue of its single-loop structure; events didn't).

## Related Issue

[CEXT-6659](https://jira.corp.adobe.com/browse/CEXT-6659)

## Motivation and Context

Some values pass SDK schema validation but are rejected by the target system (e.g. an invented `webhook_method`, or an event name Commerce doesn't support) — the schema can't enumerate every valid Commerce operation name. Without recovery, a rejected replacement left the app in a broken, inconsistent state relative to its own stored baseline.

## How Has This Been Tested?

- Unit tests: rejection → restore, recovery-also-fails (both errors recorded + baseline-divergence flag), 404/400 tolerance during rollback, multi-add rollback (including a wholly-new-provider case), in-place-update-failure no longer destroys a healthy subscription.
- Integration tests: real plan/apply against `msw`-mocked Commerce + I/O Events, for both webhooks (identity-change rejection → restore) and events (multi-add rejection → rollback).
- Live E2E against a real Commerce/Adobe I/O Events tenant: webhook identity-change rejection (restore + original error), multi-webhook all-or-nothing, config-only update path, and happy-path replacement — all confirmed. Also caught and fixed a real bug during live testing (rollback attempting to unsubscribe the rejected event's own never-created subscription; Commerce returns 400, not 404, for that case).
- Full package suite: 1288/1288 passing. Typecheck, biome, build, and `publint` all clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
