### PR TITLE
Add commerce-app-api-mesh skill

### DIFF
--- a/.changeset/commerce-app-api-mesh-skill.md
+++ b/.changeset/commerce-app-api-mesh-skill.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-plugin-app-management": minor
+---
+
+Add `commerce-app-api-mesh` skill for scaffolding and updating an API Mesh configuration in front of a Commerce app, covering sources, type extension, resolvers, and deployment verification.

--- a/plugins/commerce/app-management/.tessl-plugin/plugin.json
+++ b/plugins/commerce/app-management/.tessl-plugin/plugin.json
@@ -9,6 +9,7 @@
     "skills/commerce-app-webhooks",
     "skills/commerce-app-business-config",
     "skills/commerce-app-storage",
-    "skills/commerce-app-admin-ui"
+    "skills/commerce-app-admin-ui",
+    "skills/commerce-app-api-mesh"
   ]
 }

--- a/plugins/commerce/app-management/README.md
+++ b/plugins/commerce/app-management/README.md
@@ -15,6 +15,7 @@ commerce-app-init
   └─→ commerce-app-business-config
   └─→ commerce-app-admin-ui
   └─→ commerce-app-storage
+        └─→ commerce-app-api-mesh
 ```
 
 A developer creating an app that needs events and webhooks would run `commerce-app-init` first, then chain to `commerce-app-eventing` and `commerce-app-webhooks` in any order.
@@ -29,6 +30,7 @@ A developer creating an app that needs events and webhooks would run `commerce-a
 | [commerce-app-business-config](./skills/commerce-app-business-config/) | Manage custom business configuration       | Available |
 | [commerce-app-storage](./skills/commerce-app-storage/)                 | Integrate App Builder Database Storage     | Available |
 | [commerce-app-admin-ui](./skills/commerce-app-admin-ui/)               | Extend the Commerce Admin UI               | Available |
+| [commerce-app-api-mesh](./skills/commerce-app-api-mesh/)               | Wire API Mesh in front of a Commerce app   | Available |
 
 ## Installation
 
@@ -54,4 +56,5 @@ npx skills add adobe/skills --skill commerce-app-webhooks
 npx skills add adobe/skills --skill commerce-app-business-config
 npx skills add adobe/skills --skill commerce-app-storage
 npx skills add adobe/skills --skill commerce-app-admin-ui
+npx skills add adobe/skills --skill commerce-app-api-mesh
 ```

--- a/plugins/commerce/app-management/README.md
+++ b/plugins/commerce/app-management/README.md
@@ -15,7 +15,7 @@ commerce-app-init
   └─→ commerce-app-business-config
   └─→ commerce-app-admin-ui
   └─→ commerce-app-storage
-        └─→ commerce-app-api-mesh
+  └─→ commerce-app-api-mesh
 ```
 
 A developer creating an app that needs events and webhooks would run `commerce-app-init` first, then chain to `commerce-app-eventing` and `commerce-app-webhooks` in any order.

--- a/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
@@ -87,10 +87,14 @@ Always pair `sourceSelectionSet` with `result` when extracting a scalar from an 
 
 ## Step 4 — Deploy and verify
 
+The first `aio api-mesh:*` call in a session opens an interactive browser login (`Waiting for browser login...`). An agent without browser access can't complete this itself — hand the printed login URI to the human and wait.
+
 ```sh
 aio api-mesh:create mesh.json -c   # first time
 aio api-mesh:update mesh.json -c   # subsequent edits
 ```
+
+`-c`/`--autoConfirmAction` skips the interactive `Are you sure you want to update the mesh: <id>?` prompt. That prompt is the only checkpoint before mutating a mesh other people or systems may already depend on — reserve `-c` for a workspace-scoped mesh you just created yourself (e.g. in CI, or a throwaway dev workspace). When updating an existing, shared, or already-deployed mesh, omit `-c` and have a human confirm the prompt, or at minimum get explicit human sign-off on the diff before running the command — treat this like any other live-infrastructure change, not a routine CLI call.
 
 Provisioning is asynchronous — poll rather than assume completion:
 

--- a/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
@@ -20,6 +20,8 @@ metadata:
 
 Composes Commerce's own GraphQL API and this app's runtime actions into a single mesh schema. Two moves this skill covers: exposing a runtime action as a mesh source, and extending an existing Commerce type with a field resolved by delegating to that source.
 
+This skill assumes general API Mesh knowledge (`mesh.json` anatomy, handler types, transforms, hooks, secrets, CORS, generic declarative/programmatic resolvers). If any of that is unfamiliar, load it from Adobe's own material first — see [References](#references) — rather than guessing at syntax. None of that material covers extending an existing Commerce type via `additionalResolvers` (`targetTypeName`/`sourceTypeName`/`requiredSelectionSet`/`sourceSelectionSet`) or wrapping an aio-commerce-sdk runtime action as a mesh source — that's what follows.
+
 ## Prerequisites
 
 - `aio plugins install @adobe/aio-cli-plugin-api-mesh` is installed.
@@ -110,3 +112,8 @@ Verify in two tiers: first the source's root field directly, then the field in i
 ## Chaining
 
 - **The source doesn't exist yet as a runtime action** — invoke `commerce-app-storage`, `commerce-app-webhooks`, or `commerce-app-eventing` to scaffold and deploy it first.
+
+## References
+
+- [API Mesh prompting guide](https://developer.adobe.com/graphql-mesh-gateway/mesh/basic/prompting) — Adobe's own guidance for prompting an agent to write mesh configs; general workflow and expectations
+- [api-mesh-starter-kit llm.txt](https://raw.githubusercontent.com/adobe-commerce/api-mesh-starter-kit/refs/heads/main/llm.txt) — reference knowledge base covering `mesh.json` anatomy, all three handler types, transforms, hooks, secrets, context state, CORS, and the CLI command set

--- a/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: commerce-app-api-mesh
+description: >
+  Scaffold or update an Adobe API Mesh configuration (mesh.json) in front of
+  a Commerce app: add GraphQL/OpenAPI sources, extend an existing Commerce
+  GraphQL type with a new field, and wire a cross-source resolver for it.
+  Use when the user mentions API Mesh, mesh.json, extending a Commerce
+  GraphQL type (e.g. adding a field to Order/CustomerOrder/Product), or
+  stitching a runtime action's data into the storefront's GraphQL schema.
+license: Apache-2.0
+compatibility: >
+  Requires the api-mesh CLI plugin (aio plugins install
+  @adobe/aio-cli-plugin-api-mesh). If wrapping a runtime action as a source,
+  that action must already be built and deployed.
+metadata:
+  author: adobe
+---
+
+# Wire API Mesh in Front of a Commerce App
+
+Composes Commerce's own GraphQL API and this app's runtime actions into a single mesh schema. Two moves this skill covers: exposing a runtime action as a mesh source, and extending an existing Commerce type with a field resolved by delegating to that source.
+
+## Prerequisites
+
+- `aio plugins install @adobe/aio-cli-plugin-api-mesh` is installed.
+- If exposing a runtime action as a source, it's already built and deployed with a real, reachable HTTPS endpoint — a source pointing at an undeployed action fails opaquely.
+- Check whether a mesh already exists for this workspace: `aio api-mesh:get`. "No mesh found" → you'll `create`; otherwise you're editing an existing `mesh.json` and will `update`.
+
+## Step 1 — Confirm schema shapes via introspection
+
+Before writing `additionalTypeDefs` or `additionalResolvers`, introspect the Commerce (or other) GraphQL source you're extending. Don't assume a type/field name from memory or a similar-sounding convention — near-miss names produce a mesh that builds successfully but whose resolver never fires.
+
+```bash
+curl -s -X POST "<graphql-endpoint>" -H "Content-Type: application/json" \
+  -d '{"query":"{ __type(name: \"<TargetType>\") { fields { name } } }"}'
+```
+
+## Step 2 — Scaffold sources
+
+```json
+{
+  "name": "Commerce",
+  "handler": {
+    "graphql": {
+      "endpoint": "<commerce-graphql-endpoint>",
+      "operationHeaders": { "Authorization": "{context.headers.authorization}" }
+    }
+  }
+}
+```
+
+Include `operationHeaders` by default on any source whose schema has customer-, cart-, or session-scoped fields — API Mesh does **not** forward the caller's `Authorization` header automatically. Omitting it makes every authenticated query fail with the backend's own generic "not authorized" error, indistinguishable from an invalid token.
+
+To wrap a runtime action, write a small static OpenAPI document describing just its endpoint and reference it by relative path:
+
+```json
+{
+  "name": "<SourceName>",
+  "handler": { "openapi": { "source": "./mesh/<source>.json" } }
+}
+```
+
+The declared response schema must match what the action actually returns — the mesh parses according to what you declare, it doesn't reshape data.
+
+## Step 3 — Extend a type and wire the resolver
+
+```json
+"additionalTypeDefs": "extend type <TargetType> { <newField>: String }",
+"additionalResolvers": [
+  {
+    "targetTypeName": "<TargetType>",
+    "targetFieldName": "<newField>",
+    "sourceName": "<SourceName>",
+    "sourceTypeName": "Query",
+    "sourceFieldName": "<sourceField>",
+    "requiredSelectionSet": "{ <keyField> }",
+    "sourceArgs": { "<arg>": "{root.<keyField>}" },
+    "sourceSelectionSet": "{ <resultField> }",
+    "result": "<resultField>"
+  }
+]
+```
+
+Always pair `sourceSelectionSet` with `result` when extracting a scalar from an object-returning source field — never use `result` alone. The `result`-only path builds its selection set by hand instead of via the GraphQL parser, and breaks with `"No type was found for field node ... __typename"` specifically when the target field resolves inside a list (e.g. a parent's `items[].<newField>`). A direct root-query call to the same source field succeeds even when this bug is present, so that test alone isn't sufficient proof the resolver works.
+
+## Step 4 — Deploy and verify
+
+```sh
+aio api-mesh:create mesh.json -c   # first time
+aio api-mesh:update mesh.json -c   # subsequent edits
+```
+
+Provisioning is asynchronous — poll rather than assume completion:
+
+```sh
+until aio api-mesh:status 2>&1 | grep -qi success; do sleep 20; done
+```
+
+Verify in two tiers: first the source's root field directly, then the field in its real nested/authenticated shape (a list-nested query with a real caller credential, not a flat root-field call). Tier 1 passing does not prove tier 2 works — the bug above is invisible in tier 1.
+
+## Common Issues
+
+- **`"not authorized"` on an authenticated query, even with a valid token** — the source's `graphql` handler is missing `operationHeaders`. Check `mesh.json`, not the token.
+- **`"No type was found for field node ... __typename"` on a nested/list field, but the source works fine at root** — the resolver uses `result` without `sourceSelectionSet`. Add it.
+
+## Quality Bar
+
+- `aio api-mesh:status` reports success, and the new field resolves correctly in its real nested/authenticated shape, not just at the source's root field.
+
+## Chaining
+
+- **The source doesn't exist yet as a runtime action** — invoke `commerce-app-storage`, `commerce-app-webhooks`, or `commerce-app-eventing` to scaffold and deploy it first.

--- a/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
+++ b/plugins/commerce/app-management/skills/commerce-app-api-mesh/SKILL.md
@@ -62,6 +62,45 @@ To wrap a runtime action, write a small static OpenAPI document describing just 
 }
 ```
 
+The OpenAPI document itself needs enough shape for the mesh to generate a Query field from it — not just the pointer above. Minimal example for a single-endpoint runtime action:
+
+```json
+{
+  "openapi": "3.0.0",
+  "info": { "title": "<SourceName>", "version": "1.0.0" },
+  "servers": [{ "url": "<runtime-action-base-url>" }],
+  "paths": {
+    "/<action-path>": {
+      "get": {
+        "operationId": "<sourceField>",
+        "parameters": [
+          {
+            "name": "<arg>",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "<resultField>": { "type": "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`operationId` becomes the Query field name — it must match `sourceFieldName` in Step 3's resolver exactly, or the resolver builds successfully but never fires.
+
 The declared response schema must match what the action actually returns — the mesh parses according to what you declare, it doesn't reshape data.
 
 ## Step 3 — Extend a type and wire the resolver
@@ -87,6 +126,8 @@ Always pair `sourceSelectionSet` with `result` when extracting a scalar from an 
 
 ## Step 4 — Deploy and verify
 
+If you already know a browser-based app will call this mesh, decide `responseConfig.CORS` now, before your first deploy — the browser-verification tier below exists to catch a missed CORS config, but deciding upfront avoids a second deploy cycle.
+
 The first `aio api-mesh:*` call in a session opens an interactive browser login (`Waiting for browser login...`). An agent without browser access can't complete this itself — hand the printed login URI to the human and wait.
 
 ```sh
@@ -104,6 +145,8 @@ until aio api-mesh:status 2>&1 | grep -qi success; do sleep 20; done
 
 Verify in two tiers: first the source's root field directly, then the field in its real nested/authenticated shape (a list-nested query with a real caller credential, not a flat root-field call). Tier 1 passing does not prove tier 2 works — the bug above is invisible in tier 1.
 
+If the consuming app will call this mesh directly from a browser (not just server-to-server), add a third tier: a real request from that app's actual origin. The two tiers above only prove server-side reachability — a mesh with no `responseConfig.CORS` entry for that origin passes both while still failing every browser call through it, not just the new field (see the CORS section of the api-mesh-starter-kit reference below).
+
 ## Common Issues
 
 - **`"not authorized"` on an authenticated query, even with a valid token** — the source's `graphql` handler is missing `operationHeaders`. Check `mesh.json`, not the token.
@@ -112,6 +155,7 @@ Verify in two tiers: first the source's root field directly, then the field in i
 ## Quality Bar
 
 - `aio api-mesh:status` reports success, and the new field resolves correctly in its real nested/authenticated shape, not just at the source's root field.
+- If a browser-based app will call this mesh, that app can complete a real request against it — not just `aio api-mesh:status` and `curl`.
 
 ## Chaining
 


### PR DESCRIPTION
## Description

Adds the `commerce-app-api-mesh` skill to the `commerce-app-management` plugin, covering how to scaffold or update an API Mesh configuration (`mesh.json`) in front of a Commerce app: adding GraphQL/OpenAPI sources, extending an existing Commerce GraphQL type, and wiring a cross-source resolver for it.

Registers the new skill in `.tessl-plugin/plugin.json`, adds it to the plugin `README.md` (chain diagram, skill table, install list), and includes a changeset for the plugin.

## Related Issue

N/A

## Motivation and Context

There was no guided workflow for wiring API Mesh in front of a Commerce app. This skill fills that gap with the common failure modes (missing `operationHeaders`, `result` without `sourceSelectionSet`) and a verification flow.

## How Has This Been Tested?

Ran `pnpm lint` and `pnpm typecheck` across the monorepo; both pass. No code paths are affected, only documentation/skill content.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read the **DEVELOPMENT** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)