### PR TITLE
CEXT-6727 Event upgrade fails with 404 (no event metadata) when a duplicate event provider exists in the org

### DIFF
--- a/.changeset/three-singers-listen.md
+++ b/.changeset/three-singers-listen.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-commerce-lib-app": patch
+---
+
+Resolve the correct event provider during an upgrade when a duplicate provider exists in the org. Provider resolution now prefers the current workspace-scoped provider over a stale legacy (workspace-less) one, and prefers a provider that carries metadata over an empty duplicate — so an upgrade no longer fails with a 404 "no such event metadata" by targeting the wrong provider.

--- a/.changeset/three-singers-listen.md
+++ b/.changeset/three-singers-listen.md
@@ -2,4 +2,4 @@
 "@adobe/aio-commerce-lib-app": patch
 ---
 
-Resolve the correct event provider during an upgrade when a duplicate provider exists in the org. Provider resolution now prefers the current workspace-scoped provider over a stale legacy (workspace-less) one, and prefers a provider that carries metadata over an empty duplicate — so an upgrade no longer fails with a 404 "no such event metadata" by targeting the wrong provider.
+Fix upgrades failing with a 404 "no such event metadata" error when a duplicate event provider exists in the org.

--- a/packages/aio-commerce-lib-app/source/management/domains/events/apply.ts
+++ b/packages/aio-commerce-lib-app/source/management/domains/events/apply.ts
@@ -250,7 +250,11 @@ async function reconcileProviderSubResources(
   );
 }
 
-/** Finds the deployed I/O Events provider by its current or legacy instance id. */
+/**
+ * Finds the deployed I/O Events provider for a target, preferring the current workspace-scoped
+ * instance id over the legacy (workspace-less) one, and a metadata-bearing provider over an empty
+ * duplicate that shares its instance id.
+ */
 function resolveDeployedProvider(
   target: EventingProviderSnapshot,
   targetMetadata: ApplicationMetadata,
@@ -258,18 +262,29 @@ function resolveDeployedProvider(
   workspaceId: string,
   existingData: ExistingIoEventsData,
 ): IoEventProviderWithMetadata | null {
-  const candidates = new Set([
+  // The legacy id is not unique within an org, so a current-scheme match must always win over it.
+  const orderedCandidates = [
     generateInstanceId(targetMetadata, target.provider, workspaceId),
-    generateInstanceIdDeprecated(targetMetadata, target.provider),
     generateInstanceId(baselineMetadata, target.provider, workspaceId),
+    generateInstanceIdDeprecated(targetMetadata, target.provider),
     generateInstanceIdDeprecated(baselineMetadata, target.provider),
-  ]);
+  ];
 
-  return (
-    existingData.providersWithMetadata.find((candidate) =>
-      candidates.has(candidate.instance_id),
-    ) ?? null
-  );
+  for (const candidate of orderedCandidates) {
+    const matches = existingData.providersWithMetadata.filter(
+      (provider) => provider.instance_id === candidate,
+    );
+    if (matches.length === 0) {
+      continue;
+    }
+
+    // A stale duplicate can share the instance id but carry no metadata; prefer the populated one.
+    return (
+      matches.find((provider) => provider.metadata.length > 0) ?? matches[0]
+    );
+  }
+
+  return null;
 }
 
 /** The fully-qualified I/O Events code set for a group of events under a provider type. */

--- a/packages/aio-commerce-lib-app/test/unit/management/domains/events/apply.test.ts
+++ b/packages/aio-commerce-lib-app/test/unit/management/domains/events/apply.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   COMMERCE_PROVIDER_TYPE,
   EXTERNAL_PROVIDER_TYPE,
+  generateInstanceIdDeprecated,
   getIoEventCode,
   getNamespacedEvent,
   getRegistrationName,
@@ -38,6 +39,7 @@ import {
   createMockDeployedIoProvider,
   createMockDeployedRegistration,
   createMockEventingInstallationContext,
+  createMockIoEventProvider,
   createMockAppEvent as event,
   createMockExternalEventsConfig as externalConfig,
   createMockIoEventsListClient as ioEventsClient,
@@ -234,6 +236,70 @@ describe("applyCommerceEvents", () => {
     };
     expect(putParams.registrationId).toBe("reg-1");
     expect(putParams.eventsOfInterest).toHaveLength(2);
+  });
+
+  test("resolves the current-scheme provider over a stale deprecated-scheme duplicate", async () => {
+    vi.spyOn(commerceEventsStep, "install").mockResolvedValue([]);
+    const provider: EventProvider = {
+      description: "P1",
+      key: "k1",
+      label: "P1",
+    };
+
+    // Correct provider: current workspace-scoped instance id.
+    const correctProvider = createMockDeployedIoProvider({
+      id: "correct-provider",
+      provider,
+    });
+    // Stale duplicate: deprecated (workspace-less) instance id, which is not unique within an org
+    // and can be returned first by the org-wide provider list. It must not win.
+    const staleProvider = {
+      ...createMockIoEventProvider({
+        id: "stale-provider",
+        instance_id: generateInstanceIdDeprecated(
+          metadata,
+          provider as unknown as Parameters<
+            typeof generateInstanceIdDeprecated
+          >[1],
+        ),
+        label: provider.label,
+        provider_metadata: COMMERCE_PROVIDER_TYPE,
+      }),
+      _embedded: { eventmetadata: [] },
+    };
+
+    const registrationName = getRegistrationName(correctProvider, "pkg/a");
+    const updateRegistration = vi.fn().mockResolvedValue(undefined);
+
+    const context = createMockEventingInstallationContext({
+      ioEventsClient: ioEventsClient({
+        // Stale one listed first — an unordered first-match lookup would have picked it.
+        providers: [staleProvider, correctProvider],
+        registrations: [
+          createMockDeployedRegistration(registrationName, "reg-1"),
+        ],
+        updateRegistration,
+      }) as never,
+      params: { AIO_COMMERCE_AUTH_IMS_CLIENT_ID: "test-client-id" },
+    });
+
+    // Adding "b" changes the registration's event set → PUT, whose payload reveals the resolved provider.
+    const plan = await planCommerce(
+      commerceConfig([{ events: [event("a", ["pkg/a"])], provider }]),
+      commerceConfig([
+        { events: [event("a", ["pkg/a"]), event("b", ["pkg/a"])], provider },
+      ]),
+    );
+
+    await applyCommerceEvents(plan, context as ApplyContext<EventsStepContext>);
+
+    expect(updateRegistration).toHaveBeenCalledTimes(1);
+    const putParams = updateRegistration.mock.calls[0][0] as {
+      eventsOfInterest: { providerId: string }[];
+    };
+    for (const eventOfInterest of putParams.eventsOfInterest) {
+      expect(eventOfInterest.providerId).toBe("correct-provider");
+    }
   });
 
   test("deletes metadata and subscription for an event dropped from a persisting provider", async () => {


### PR DESCRIPTION
## Description

Fixes event provider resolution during an upgrade when more than one provider record for the same app exists in the org. `resolveDeployedProvider` now resolves candidates in a defined order — the current workspace-scoped instance id (`appId-providerKey-workspaceId`) first, and the legacy workspace-less id only as a fallback — and, among records sharing an id, prefers the one that actually carries event metadata over an empty duplicate.

## Related Issue

[CEXT-6727](https://jira.corp.adobe.com/browse/CEXT-6727)

## Motivation and Context

The deprecated instance-id scheme (`appId-providerKey`, no workspace) is not unique within an org. When a duplicate provider existed from the same app installed in another workspace, provider churn, or a legacy provider the old unordered lookup could match the deprecated candidate and pick a stale provider from a different workspace. The registration update then targeted the wrong provider, and the upgrade failed with a 404 ("no such event metadata"). Ordering the candidates and preferring the metadata-bearing record makes resolution deterministic and always favors the workspace's own current provider.

This only affects resolution of duplicates of the *same* provider; distinct providers within an app are resolved independently by key and are unchanged.

## How Has This Been Tested?

- Added a unit test that reproduces the bug: a stale deprecated-scheme provider listed ahead of the correct current-scheme provider. The test fails on the old code (wrong provider selected) and passes with the fix, asserting the registration update targets the correct provider id.
- `pnpm typecheck` and the events `apply` suite pass; Biome clean.
- The original 404 was first observed and root-caused live on a workspace containing a duplicate provider.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read the **DEVELOPMENT** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
